### PR TITLE
added regex filtering

### DIFF
--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexRule.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexRule.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.filtering.regex;
+
+
+/**
+ * A generic regular expression rule. Borrowed from Apache Nutch 1.9.
+ *
+ */
+
+public abstract class RegexRule {
+
+    private final boolean sign;
+
+    /**
+     * Constructs a new regular expression rule.
+     *
+     * @param sign specifies if this rule must filter-in or filter-out.
+     *        A <code>true</code> value means that any url matching this rule
+     *        must be accepted, a <code>false</code> value means that any url
+     *        matching this rule must be rejected.
+     * @param regex is the regular expression used for matching (see
+     *        {@link #match(String)} method).
+     */
+    protected RegexRule(boolean sign, String regex) {
+        this.sign = sign;
+    }
+
+    /**
+     * Return if this rule is used for filtering-in or out.
+     *
+     * @return <code>true</code> if any url matching this rule must be accepted,
+     *         otherwise <code>false</code>.
+     */
+    protected boolean accept() { return sign; }
+
+    /**
+     * Checks if a url matches this rule.
+     * @param url is the url to check.
+     * @return <code>true</code> if the specified url matches this rule,
+     *         otherwise <code>false</code>.
+     */
+    protected abstract boolean match(String url);
+
+}

--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLFilter.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.filtering.regex;
+
+// JDK imports
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+// Adapted from Apache Nutch 1.9
+
+/**
+ * Filters URLs based on a file of regular expressions using the
+ * {@link java.util.regex Java Regex implementation}.
+ */
+public class RegexURLFilter extends RegexURLFilterBase {
+
+    public RegexURLFilter() {
+        super();
+    }
+
+    // Inherited Javadoc
+    protected RegexRule createRule(boolean sign, String regex) {
+        return new Rule(sign, regex);
+    }
+
+    private class Rule extends RegexRule {
+
+        private Pattern pattern;
+
+        Rule(boolean sign, String regex) {
+            super(sign, regex);
+            pattern = Pattern.compile(regex);
+        }
+
+        protected boolean match(String url) {
+            return pattern.matcher(url).find();
+        }
+    }
+
+}

--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLFilterBase.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLFilterBase.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.filtering.regex;
+
+// JDK imports
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.InputStreamReader;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ArrayList;
+
+// Commons Logging imports
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.node.TextNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.storm.crawler.filtering.URLFilter;
+
+/**
+ * An abstract class for implementing Regex URL filtering. Adapted from Apache Nutch 1.9
+ *
+ */
+
+public abstract class RegexURLFilterBase implements URLFilter {
+
+    /** logger */
+    private final static Logger LOG = LoggerFactory.getLogger(RegexURLFilterBase.class);
+
+    /** A list of applicable rules */
+    private List<RegexRule> rules;
+
+
+    public void configure(JsonNode paramNode) {
+
+        JsonNode filenameNode = paramNode.get("regexFilterFile");
+        String rulesFileName;
+        if (filenameNode != null) {
+            rulesFileName = filenameNode.getTextValue();
+        } else {
+            rulesFileName = "default-regex-filters.txt";
+        }
+        this.rules = readRules(rulesFileName);
+    }
+
+    private List<RegexRule> readRules(String rulesFile) {
+        List<RegexRule> rules = new ArrayList<RegexRule>();
+
+        try {
+
+            InputStream regexStream = getClass().getClassLoader().getResourceAsStream(rulesFile);
+            Reader reader = new InputStreamReader(regexStream, "UTF-8");
+            BufferedReader in = new BufferedReader(reader);
+            String line;
+
+            while ((line = in.readLine()) != null) {
+                if (line.length() == 0) {
+                    continue;
+                }
+                char first = line.charAt(0);
+                boolean sign = false;
+                switch (first) {
+                    case '+':
+                        sign = true;
+                        break;
+                    case '-':
+                        sign = false;
+                        break;
+                    case ' ':
+                    case '\n':
+                    case '#':           // skip blank & comment lines
+                        continue;
+                    default:
+                        throw new IOException("Invalid first character: " + line);
+                }
+
+                String regex = line.substring(1);
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Adding rule [" + regex + "]");
+                }
+                RegexRule rule = createRule(sign, regex);
+                rules.add(rule);
+
+            }
+        } catch (IOException e) {
+            LOG.error("There was an error reading the default-regex-filters file");
+            e.printStackTrace();
+        }
+        return rules;
+    }
+
+    /**
+     * Creates a new {@link RegexRule}.
+     * @param sign of the regular expression.
+     *        A <code>true</code> value means that any URL matching this rule
+     *        must be included, whereas a <code>false</code>
+     *        value means that any URL matching this rule must be excluded.
+     * @param regex is the regular expression associated to this rule.
+     */
+    protected abstract RegexRule createRule(boolean sign, String regex);
+
+
+  /* -------------------------- *
+   * <implementation:URLFilter> *
+   * -------------------------- */
+
+    // Inherited Javadoc
+    public String filter(String url) {
+        for (RegexRule rule : rules) {
+            if (rule.match(url)) {
+                return rule.accept() ? url : null;
+            }
+        };
+        return null;
+    }
+
+}

--- a/src/main/resources/default-regex-filters.txt
+++ b/src/main/resources/default-regex-filters.txt
@@ -1,0 +1,12 @@
+# skip file: ftp: and mailto: urls
+-^(file|ftp|mailto):
+
+# skip image and other suffixes we can't yet parse
+# for a more extensive coverage use the urlfilter-suffix plugin
+-\.(gif|GIF|jpg|JPG|png|PNG|ico|ICO|css|CSS|sit|SIT|eps|EPS|wmf|WMF|zip|ZIP|ppt|PPT|mpg|MPG|xls|XLS|gz|GZ|rpm|RPM|tgz|TGZ|mov|MOV|exe|EXE|jpeg|JPEG|bmp|BMP|js|JS)(\?|&)*
+
+# skip URLs with slash-delimited segment that repeats 3+ times, to break loops
+-.*(/[^/]+)/[^/]+\1/[^/]+\1/
+
+# accept anything else
++.

--- a/src/main/resources/urlfilters.json
+++ b/src/main/resources/urlfilters.json
@@ -6,6 +6,14 @@
       "params": {
         "removeAnchorPart": "true"
       }
+    },
+    {
+      "class": "com.digitalpebble.storm.crawler.filtering.regex.RegexURLFilter",
+      "name": "RegexURLFilter",
+      "params": {
+        "regexFilterFile": "default-regex-filters.txt"
+      }
     }
+
   ]
 }


### PR DESCRIPTION
Added a regex URL filter. Adapted almost line-for-line from Nutch 1.9.

Only quirk is that the user must specify a file (in urlfilters.json) from which to load regex rules, rather than including the rules themselves in the JSON config. This is because regular expressions typically contain characters that must be escaped within JSON, so it would be a big headache for users to include their regex rules directly within the `params` node.
