### PR TITLE
Added a URL normalizing regex filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target
 .settings
 .project
 
+# Ignore IntelliJ IDEA artifacts
+*.iml
+.idea

--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLNormalizer.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLNormalizer.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.filtering.regex;
+
+import com.digitalpebble.storm.crawler.filtering.URLFilter;
+import org.codehaus.jackson.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.*;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * The RegexURLNormalizer is a URL filter that normalizes URLs by
+ * matching a regular expression and inserting a replacement string.
+ *
+ * Adapted from Apache Nutch 1.9.
+ */
+
+public class RegexURLNormalizer implements URLFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RegexURLNormalizer.class);
+
+    /**
+     * Class which holds a compiled pattern and its corresponding substition
+     * string.
+     */
+    private static class Rule {
+        public Pattern pattern;
+
+        public String substitution;
+    }
+
+    private List<Rule> rules;
+
+    private static final List<Rule> EMPTY_RULES = Collections.emptyList();
+
+    public void configure(JsonNode paramNode) {
+
+        JsonNode filenameNode = paramNode.get("regexNormalizerFile");
+        String rulesFileName;
+        if (filenameNode != null) {
+            rulesFileName = filenameNode.getTextValue();
+        } else {
+            rulesFileName = "default-regex-normalizers.xml";
+        }
+        this.rules = readRules(rulesFileName);
+
+    }
+
+    /**
+     * This function does the replacements by iterating through all the regex
+     * patterns. It accepts a string url as input and returns the altered string.
+     * If the normalized url is an empty string, the function will return null.
+     */
+    public String filter(String urlString) {
+
+        Iterator<Rule> i = rules.iterator();
+        while (i.hasNext()) {
+            Rule r = (Rule) i.next();
+
+            Matcher matcher = r.pattern.matcher(urlString);
+
+            urlString = matcher.replaceAll(r.substitution);
+        }
+
+        if (urlString.equals(""))
+            urlString = null;
+
+        return urlString;
+    }
+
+    /** Reads the configuration file and populates a List of Rules. */
+    private List<Rule> readRules(String rulesFile) {
+        try {
+            InputStream regexStream = getClass().getClassLoader().getResourceAsStream(rulesFile);
+            Reader reader = new InputStreamReader(regexStream, "UTF-8");
+
+            return readConfiguration(reader);
+        } catch (Exception e) {
+            LOG.error("Error loading rules from file: " + e);
+            return EMPTY_RULES;
+        }
+    }
+
+    private List<Rule> readConfiguration(Reader reader) {
+        List<Rule> rules = new ArrayList<Rule>();
+        try {
+
+            // borrowed heavily from code in Configuration.java
+            Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                    .parse(new InputSource(reader));
+            Element root = doc.getDocumentElement();
+            if ((!"regex-normalize".equals(root.getTagName()))
+                    && (LOG.isErrorEnabled())) {
+                LOG.error("bad conf file: top-level element not <regex-normalize>");
+            }
+            NodeList regexes = root.getChildNodes();
+            for (int i = 0; i < regexes.getLength(); i++) {
+                Node regexNode = regexes.item(i);
+                if (!(regexNode instanceof Element))
+                    continue;
+                Element regex = (Element) regexNode;
+                if ((!"regex".equals(regex.getTagName())) && (LOG.isWarnEnabled())) {
+                    LOG.warn("bad conf file: element not <regex>");
+                }
+                NodeList fields = regex.getChildNodes();
+                String patternValue = null;
+                String subValue = null;
+                for (int j = 0; j < fields.getLength(); j++) {
+                    Node fieldNode = fields.item(j);
+                    if (!(fieldNode instanceof Element))
+                        continue;
+                    Element field = (Element) fieldNode;
+                    if ("pattern".equals(field.getTagName()) && field.hasChildNodes())
+                        patternValue = ((Text) field.getFirstChild()).getData();
+                    if ("substitution".equals(field.getTagName())
+                            && field.hasChildNodes())
+                        subValue = ((Text) field.getFirstChild()).getData();
+                    if (!field.hasChildNodes())
+                        subValue = "";
+                }
+                if (patternValue != null && subValue != null) {
+                    Rule rule = new Rule();
+                    try {
+                        rule.pattern = Pattern.compile(patternValue);
+                    } catch (PatternSyntaxException e) {
+                        if (LOG.isErrorEnabled()) {
+                            LOG.error("skipped rule: " + patternValue + " -> " + subValue + " : invalid regular expression pattern: " + e);
+                        }
+                        continue;
+                    }
+                    rule.substitution = subValue;
+                    rules.add(rule);
+                }
+            }
+        } catch (Exception e) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("error parsing conf file: " + e);
+            }
+            return EMPTY_RULES;
+        }
+        if (rules.size() == 0) return EMPTY_RULES;
+        return rules;
+    }
+
+}

--- a/src/main/resources/default-regex-normalizers.xml
+++ b/src/main/resources/default-regex-normalizers.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<!-- This is the configuration file for the RegexUrlNormalize Class.
+     This is intended so that users can specify substitutions to be
+     done on URLs. The regex engine that is used is Perl5 compatible.
+     The rules are applied to URLs in the order they occur in this file.  -->
+
+<!-- WATCH OUT: an xml parser reads this file an ampersands must be
+     expanded to &amp; -->
+
+<!-- The following rules show how to strip out session IDs, default pages, 
+     interpage anchors, etc. Order does matter!  -->
+<regex-normalize>
+
+<!-- removes session ids from urls (such as jsessionid and PHPSESSID) -->
+<!--<regex>-->
+  <!--<pattern>(?i)(;?\b_?(l|j|bv_)?(sid|phpsessid|sessionid)=.*?)(\?|&amp;|#|$)</pattern>-->
+  <!--<substitution>$4</substitution>-->
+<!--</regex>-->
+
+<!-- changes default pages into standard for /index.html, etc. into /
+<regex>
+  <pattern>/((?i)index|default)\.((?i)js[pf]{1}?[afx]?|cgi|cfm|asp[x]?|[psx]?htm[l]?|php[3456]?)(\?|&amp;|#|$)</pattern>
+  <substitution>/$3</substitution>
+</regex> -->
+
+<!-- removes interpage href anchors such as site.com#location -->
+<!--<regex>-->
+  <!--<pattern>#.*?(\?|&amp;|$)</pattern>-->
+  <!--<substitution>$1</substitution>-->
+<!--</regex>-->
+
+<!-- cleans ?&amp;var=value into ?var=value -->
+<!--<regex>-->
+  <!--<pattern>\?&amp;</pattern>-->
+  <!--<substitution>\?</substitution>-->
+<!--</regex>-->
+
+<!-- cleans multiple sequential ampersands into a single ampersand -->
+<!--<regex>-->
+  <!--<pattern>&amp;{2,}</pattern>-->
+  <!--<substitution>&amp;</substitution>-->
+<!--</regex>-->
+
+<!-- removes trailing ? -->
+<!--<regex>-->
+  <!--<pattern>[\?&amp;\.]$</pattern>-->
+  <!--<substitution></substitution>-->
+<!--</regex>-->
+
+<!-- Removes query strings -->
+<!--<regex>-->
+    <!--<pattern>\?.*$</pattern>-->
+    <!--<substitution></substitution>-->
+<!--</regex>-->
+
+<!-- removes duplicate slashes -->
+<!--<regex>-->
+  <!--<pattern>(?&lt;!:)/{2,}</pattern>-->
+  <!--<substitution>/</substitution>-->
+<!--</regex>-->
+
+</regex-normalize>

--- a/src/main/resources/urlfilters.json
+++ b/src/main/resources/urlfilters.json
@@ -8,6 +8,13 @@
       }
     },
     {
+      "class": "com.digitalpebble.storm.crawler.filtering.regex.RegexURLNormalizer",
+      "name": "RegexURLNormalizer",
+      "params": {
+        "regexNormalizerFile": "default-regex-normalizers.xml"
+      }
+    },
+    {
       "class": "com.digitalpebble.storm.crawler.filtering.regex.RegexURLFilter",
       "name": "RegexURLFilter",
       "params": {


### PR DESCRIPTION
This PR adds a new URLFilter, the RegexURLNormalizer. This is a normalizing filter; its purpose is to match and replace substrings of URLs.

The filter is configured through an XML document, specified by the regexNormalizerFile param in `urlfilters.json`. The PR also includes a `default-regex-normalizers.xml` config file. All of the example normalizers are commented out, so the behavior of storm-crawler won't change until the user modifies this file.

The PR also adds entries to .gitignore to exclude IntelliJ IDEA artifacts.
