### PR TITLE
Upgrade Jackson to Jackson2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,9 +234,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.9.12</version>
+		       <groupId>com.fasterxml.jackson.core</groupId>
+		       <artifactId>jackson-databind</artifactId>
+		       <version>2.4.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/URLFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/URLFilter.java
@@ -17,7 +17,7 @@
 
 package com.digitalpebble.storm.crawler.filtering;
 
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Unlike Nutch, URLFilters can normalise the URLs as well as filtering them.

--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/URLFilters.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/URLFilters.java
@@ -23,11 +23,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /** Wrapper for the URLFilters defined in a JSON configuration **/
 public class URLFilters implements URLFilter {
@@ -39,7 +38,7 @@ public class URLFilters implements URLFilter {
 
     /**
      * loads the filters from a JSON configuration file
-     * 
+     *
      * @throws IOException
      * @throws JsonMappingException
      * @throws JsonParseException
@@ -94,13 +93,13 @@ public class URLFilters implements URLFilter {
         }
 
         // conf node contains a list of objects
-        Iterator<JsonNode> filterIter = jsonNode.getElements();
+        Iterator<JsonNode> filterIter = jsonNode.elements();
         while (filterIter.hasNext()) {
             JsonNode afilterNode = filterIter.next();
             JsonNode classNode = afilterNode.get("class");
             if (classNode == null)
                 continue;
-            String className = classNode.getTextValue().trim();
+            String className = classNode.textValue().trim();
             // check that it is available and implements the interface URLFilter
             try {
                 Class<?> filterClass = Class.forName(className);

--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/basic/BasicURLFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/basic/BasicURLFilter.java
@@ -19,10 +19,8 @@ package com.digitalpebble.storm.crawler.filtering.basic;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-
-import org.codehaus.jackson.JsonNode;
-
 import com.digitalpebble.storm.crawler.filtering.URLFilter;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class BasicURLFilter implements URLFilter {
 
@@ -46,7 +44,7 @@ public class BasicURLFilter implements URLFilter {
     public void configure(JsonNode paramNode) {
         JsonNode node = paramNode.get("removeAnchorPart");
         if (node != null)
-            removeAnchorPart = node.getBooleanValue();
+            removeAnchorPart = node.booleanValue();
     }
 
 }

--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLFilterBase.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLFilterBase.java
@@ -23,17 +23,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.InputStreamReader;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
 
 // Commons Logging imports
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.TextNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.storm.crawler.filtering.URLFilter;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * An abstract class for implementing Regex URL filtering. Adapted from Apache Nutch 1.9
@@ -54,7 +52,7 @@ public abstract class RegexURLFilterBase implements URLFilter {
         JsonNode filenameNode = paramNode.get("regexFilterFile");
         String rulesFileName;
         if (filenameNode != null) {
-            rulesFileName = filenameNode.getTextValue();
+            rulesFileName = filenameNode.textValue();
         } else {
             rulesFileName = "default-regex-filters.txt";
         }

--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLNormalizer.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLNormalizer.java
@@ -18,13 +18,15 @@
 package com.digitalpebble.storm.crawler.filtering.regex;
 
 import com.digitalpebble.storm.crawler.filtering.URLFilter;
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.*;
 import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -66,7 +68,7 @@ public class RegexURLNormalizer implements URLFilter {
         JsonNode filenameNode = paramNode.get("regexNormalizerFile");
         String rulesFileName;
         if (filenameNode != null) {
-            rulesFileName = filenameNode.getTextValue();
+            rulesFileName = filenameNode.textValue();
         } else {
             rulesFileName = "default-regex-normalizers.xml";
         }

--- a/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilter.java
@@ -19,8 +19,9 @@ package com.digitalpebble.storm.crawler.parse;
 
 import java.util.HashMap;
 
-import org.codehaus.jackson.JsonNode;
 import org.w3c.dom.DocumentFragment;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Implementations of ParseFilter are called by the ParserBolt to extract custom

--- a/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilters.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilters.java
@@ -24,12 +24,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.DocumentFragment;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /** Wrapper for the ParseFilters defined in a JSON configuration **/
 public class ParseFilters implements ParseFilter {
@@ -91,13 +90,13 @@ public class ParseFilters implements ParseFilter {
         }
 
         // conf node contains a list of objects
-        Iterator<JsonNode> filterIter = jsonNode.getElements();
+        Iterator<JsonNode> filterIter = jsonNode.elements();
         while (filterIter.hasNext()) {
             JsonNode afilterNode = filterIter.next();
             String filterName = "<unnamed>";
             JsonNode nameNode = afilterNode.get("name");
             if (nameNode != null) {
-                filterName = nameNode.getTextValue();
+                filterName = nameNode.textValue();
             }
             JsonNode classNode = afilterNode.get("class");
             if (classNode == null) {
@@ -105,7 +104,7 @@ public class ParseFilters implements ParseFilter {
                         filterName);
                 continue;
             }
-            String className = classNode.getTextValue().trim();
+            String className = classNode.textValue().trim();
             filterName += '[' + className + ']';
             // check that it is available and implements the interface
             // ParseFilter

--- a/src/main/java/com/digitalpebble/storm/crawler/parse/filter/DebugParseFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/parse/filter/DebugParseFilter.java
@@ -24,10 +24,10 @@ import java.util.HashMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.xml.serialize.XMLSerializer;
-import org.codehaus.jackson.JsonNode;
 import org.w3c.dom.DocumentFragment;
 
 import com.digitalpebble.storm.crawler.parse.ParseFilter;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /** Dumps the DOM representation of a document into a file **/
 public class DebugParseFilter implements ParseFilter {

--- a/src/main/java/com/digitalpebble/storm/crawler/parse/filter/XPathFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/parse/filter/XPathFilter.java
@@ -36,7 +36,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.xml.serialize.Method;
 import org.apache.xml.serialize.OutputFormat;
 import org.apache.xml.serialize.XMLSerializer;
-import org.codehaus.jackson.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -47,6 +46,7 @@ import org.w3c.dom.NodeList;
 
 import com.digitalpebble.storm.crawler.parse.ParseFilter;
 import com.digitalpebble.storm.crawler.util.KeyValues;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Simple ParseFilter to illustrate and test the interface. Reads a XPATH
@@ -177,7 +177,7 @@ public class XPathFilter implements ParseFilter {
     @Override
     public void configure(JsonNode paramNode) {
         java.util.Iterator<Entry<String, JsonNode>> iter = paramNode
-                .getFields();
+                .fields();
         while (iter.hasNext()) {
             Entry<String, JsonNode> entry = iter.next();
             String key = entry.getKey();

--- a/src/main/java/com/digitalpebble/storm/metrics/DebugMetricsConsumer.java
+++ b/src/main/java/com/digitalpebble/storm/metrics/DebugMetricsConsumer.java
@@ -30,8 +30,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectWriter;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
@@ -42,6 +40,8 @@ import backtype.storm.metric.api.IMetricsConsumer;
 import backtype.storm.task.IErrorReporter;
 import backtype.storm.task.TopologyContext;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
@@ -49,7 +49,7 @@ import com.google.common.collect.ImmutableSortedMap;
 /**
  * Displays metrics at JSON format in a servlet running on
  * http://localhost:7070/metrics
- * 
+ *
  * @author Enno Shioji (enno.shioji@peerindex.com)
  */
 public class DebugMetricsConsumer implements IMetricsConsumer {

--- a/src/main/java/com/digitalpebble/storm/metrics/LibratoMetricsConsumer.java
+++ b/src/main/java/com/digitalpebble/storm/metrics/LibratoMetricsConsumer.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +36,7 @@ import backtype.storm.metric.api.IMetricsConsumer;
 import backtype.storm.task.IErrorReporter;
 import backtype.storm.task.TopologyContext;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.librato.metrics.HttpPoster;
 import com.librato.metrics.HttpPoster.Response;
 import com.librato.metrics.LibratoBatch;


### PR DESCRIPTION
I added the jackson 2.4 databind jar to the pom file of stormcrawler. I changed the JsonNode of multiple interfaces (URLFilter,ParseFilter) and there implementing classes. Also I upgraded some of the metric classes. I removed the old jackson 1.9.7 jar so this is a complete upgrade of jackson 1.9.7 to jackson 2.4.0.
I tested this by running mvn clean package to create the jar,  then I ran the storm jar. Hence I followed
the instructions on the main page https://github.com/nfalaki/storm-crawler.
