### PR TITLE
Pull out conf loading to a util function

### DIFF
--- a/src/main/java/com/digitalpebble/storm/crawler/ConfigurableTopology.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/ConfigurableTopology.java
@@ -17,22 +17,17 @@
 
 package com.digitalpebble.storm.crawler;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-
-import org.yaml.snakeyaml.Yaml;
 
 import backtype.storm.Config;
 import backtype.storm.LocalCluster;
 import backtype.storm.StormSubmitter;
 import backtype.storm.topology.TopologyBuilder;
+
+import com.digitalpebble.storm.crawler.util.ConfUtils;
 
 public abstract class ConfigurableTopology {
 
@@ -84,19 +79,7 @@ public abstract class ConfigurableTopology {
                 }
                 iter.remove();
                 String resource = iter.next();
-                Yaml yaml = new Yaml();
-                Map ret = null;
-                try {
-                    ret = (Map) yaml.load(new InputStreamReader(
-                            new FileInputStream(resource)));
-                } catch (FileNotFoundException e) {
-                    System.err
-                            .println("Conf file does not exist : " + resource);
-                    System.exit(-1);
-                }
-                if (ret == null)
-                    ret = new HashMap();
-                conf.putAll(ret);
+                conf = ConfUtils.loadConf(resource);
                 iter.remove();
             } else if (param.equals("-local")) {
                 isLocal = true;
@@ -104,7 +87,7 @@ public abstract class ConfigurableTopology {
             }
         }
 
-        return (String[]) newArgs.toArray(new String[newArgs.size()]);
+        return newArgs.toArray(new String[newArgs.size()]);
     }
 
 }

--- a/src/main/java/com/digitalpebble/storm/crawler/util/ConfUtils.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/util/ConfUtils.java
@@ -17,9 +17,16 @@
 
 package com.digitalpebble.storm.crawler.util;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
 import java.util.Map;
 
+import backtype.storm.Config;
 import backtype.storm.utils.Utils;
+
+import org.yaml.snakeyaml.Yaml;
 
 /** TODO replace by calls to backtype.storm.utils.Utils **/
 
@@ -59,4 +66,20 @@ public class ConfUtils {
         return (String) Utils.get(conf, key, defaultValue);
     }
 
+    public static Config loadConf(String resource) {
+        Config conf = new Config();
+        Yaml yaml = new Yaml();
+        Map ret = null;
+        try {
+            ret = (Map) yaml.load(new InputStreamReader(new FileInputStream(resource)));
+        } catch (FileNotFoundException e) {
+            System.err.println("Conf file does not exist : " + resource);
+            System.exit(-1);
+        }
+        if (ret == null) {
+            ret = new HashMap();
+        }
+        conf.putAll(ret);
+        return conf;
+    }
 }


### PR DESCRIPTION
Sometimes it is useful to give a class a non topolgy related
main method that can be used for admin/batch functionality.

These cases will want to use the same config as a topology, so
make loading it general.
