### PR TITLE
Improved robots.txt handling

### DIFF
--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/RobotsURLFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/RobotsURLFilter.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.filtering;
+
+import com.digitalpebble.storm.crawler.protocol.MemoryRobotsCache;
+import com.digitalpebble.storm.crawler.protocol.RobotsCache;
+import com.fasterxml.jackson.databind.JsonNode;
+import crawlercommons.robots.BaseRobotRules;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * This {@link com.digitalpebble.storm.crawler.filtering.URLFilter} filters outlinks
+ * using the robots rules for the domain. If the rules for the domain aren't found
+ * in the cache, the outlink will pass the filter.
+ */
+public class RobotsURLFilter implements URLFilter {
+
+    private RobotsCache cache;
+
+    public String filter(String URL) {
+        try {
+            URL url = new URL(URL);
+            String key = getCacheKey(url);
+            BaseRobotRules rules = cache.get(key);
+            // If we have a cache miss, return the URL
+            if (rules == null)
+                return URL;
+            if (rules.isAllowed(URL))
+                return URL;
+            else
+                return null;
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    public void configure(JsonNode paramNode) {
+        //TODO Specify the cache in the config
+        this.cache = MemoryRobotsCache.getInstance();
+    }
+
+    /**
+     * Compose unique key to store and access robot rules in cache for given URL
+     */
+    private static String getCacheKey(URL url) {
+        // TODO This method is a direct port from HttpRobotsRulesParser. We should consolidate
+
+        String protocol = url.getProtocol().toLowerCase(); // normalize to lower
+        // case
+        String host = url.getHost().toLowerCase(); // normalize to lower case
+        int port = url.getPort();
+        if (port == -1) {
+            port = url.getDefaultPort();
+        }
+        /*
+         * Robot rules apply only to host, protocol, and port where robots.txt
+         * is hosted (cf. NUTCH-1752). Consequently
+         */
+        String cacheKey = protocol + ":" + host + ":" + port;
+        return cacheKey;
+    }
+}

--- a/src/main/java/com/digitalpebble/storm/crawler/filtering/RobotsURLFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/filtering/RobotsURLFilter.java
@@ -37,7 +37,7 @@ public class RobotsURLFilter implements URLFilter {
     public String filter(String URL) {
         try {
             URL url = new URL(URL);
-            String key = getCacheKey(url);
+            String key = cache.getCacheKey(url);
             BaseRobotRules rules = cache.get(key);
             // If we have a cache miss, return the URL
             if (rules == null)
@@ -56,24 +56,4 @@ public class RobotsURLFilter implements URLFilter {
         this.cache = MemoryRobotsCache.getInstance();
     }
 
-    /**
-     * Compose unique key to store and access robot rules in cache for given URL
-     */
-    private static String getCacheKey(URL url) {
-        // TODO This method is a direct port from HttpRobotsRulesParser. We should consolidate
-
-        String protocol = url.getProtocol().toLowerCase(); // normalize to lower
-        // case
-        String host = url.getHost().toLowerCase(); // normalize to lower case
-        int port = url.getPort();
-        if (port == -1) {
-            port = url.getDefaultPort();
-        }
-        /*
-         * Robot rules apply only to host, protocol, and port where robots.txt
-         * is hosted (cf. NUTCH-1752). Consequently
-         */
-        String cacheKey = protocol + ":" + host + ":" + port;
-        return cacheKey;
-    }
 }

--- a/src/main/java/com/digitalpebble/storm/crawler/protocol/MemoryRobotsCache.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/protocol/MemoryRobotsCache.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.protocol;
+
+import org.apache.storm.guava.cache.CacheBuilder;
+import org.apache.storm.guava.cache.CacheLoader;
+import org.apache.storm.guava.cache.LoadingCache;
+import crawlercommons.robots.BaseRobotRules;
+
+/**
+ * Provides an in-memory, singleton, thread-safe cache for robots rules.
+ */
+public class MemoryRobotsCache implements RobotsCache {
+
+    private static final long MAX_SIZE = 1000;
+
+    private static final MemoryRobotsCache INSTANCE = new MemoryRobotsCache();
+
+    private static LoadingCache<String, BaseRobotRules> CACHE;
+
+    public static MemoryRobotsCache getInstance() {
+        return INSTANCE;
+    }
+
+    private MemoryRobotsCache() {
+        CACHE = CacheBuilder.newBuilder().maximumSize(MAX_SIZE).build( new CacheLoader<String, BaseRobotRules>() {
+            @Override
+            public BaseRobotRules load(String s) throws Exception {
+                return null;
+            }
+        });
+    }
+
+    public BaseRobotRules get(String key) {
+        return CACHE.getIfPresent(key);
+    }
+
+    public void put(String key, BaseRobotRules rules) {
+        CACHE.put(key, rules);
+    }
+
+}

--- a/src/main/java/com/digitalpebble/storm/crawler/protocol/RobotRulesParser.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/protocol/RobotRulesParser.java
@@ -46,7 +46,7 @@ public abstract class RobotRulesParser {
     public static final Logger LOG = LoggerFactory
             .getLogger(RobotRulesParser.class);
 
-    protected static final Hashtable<String, BaseRobotRules> CACHE = new Hashtable<String, BaseRobotRules>();
+    protected RobotsCache cache;
 
     /**
      * A {@link BaseRobotRules} object appropriate for use when the

--- a/src/main/java/com/digitalpebble/storm/crawler/protocol/RobotsCache.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/protocol/RobotsCache.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.protocol;
+
+import crawlercommons.robots.BaseRobotRules;
+
+/**
+ * This interface defines the methods that must be implemented by a cache for Robots rules.
+ */
+public interface RobotsCache {
+
+    /**
+     *
+     * @param key Cache key
+     * @return Returns the robots rules for the key, or null if there's a cache miss.
+     */
+    public BaseRobotRules get(String key);
+
+    /**
+     *
+     * @param key Cache key
+     * @param rules Robots rules to associate with the key
+     */
+    public void put(String key, BaseRobotRules rules);
+}

--- a/src/main/java/com/digitalpebble/storm/crawler/protocol/RobotsCache.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/protocol/RobotsCache.java
@@ -19,6 +19,8 @@ package com.digitalpebble.storm.crawler.protocol;
 
 import crawlercommons.robots.BaseRobotRules;
 
+import java.net.URL;
+
 /**
  * This interface defines the methods that must be implemented by a cache for Robots rules.
  */
@@ -37,4 +39,6 @@ public interface RobotsCache {
      * @param rules Robots rules to associate with the key
      */
     public void put(String key, BaseRobotRules rules);
+
+    public String getCacheKey(URL url);
 }

--- a/src/main/java/com/digitalpebble/storm/crawler/protocol/http/HttpRobotRulesParser.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/protocol/http/HttpRobotRulesParser.java
@@ -63,25 +63,6 @@ public class HttpRobotRulesParser extends RobotRulesParser {
         setConf(conf);
     }
 
-    /**
-     * Compose unique key to store and access robot rules in cache for given URL
-     */
-    protected static String getCacheKey(URL url) {
-        String protocol = url.getProtocol().toLowerCase(); // normalize to lower
-        // case
-        String host = url.getHost().toLowerCase(); // normalize to lower case
-        int port = url.getPort();
-        if (port == -1) {
-            port = url.getDefaultPort();
-        }
-        /*
-         * Robot rules apply only to host, protocol, and port where robots.txt
-         * is hosted (cf. NUTCH-1752). Consequently
-         */
-        String cacheKey = protocol + ":" + host + ":" + port;
-        return cacheKey;
-    }
-
     public void setConf(Config conf) {
         super.setConf(conf);
         allowForbidden = ConfUtils.getBoolean(conf, "http.robots.403.allow",
@@ -101,7 +82,7 @@ public class HttpRobotRulesParser extends RobotRulesParser {
      */
     public BaseRobotRules getRobotRulesSet(Protocol http, URL url) {
 
-        String cacheKey = getCacheKey(url);
+        String cacheKey = cache.getCacheKey(url);
         BaseRobotRules robotRules = cache.get(cacheKey);
 
         boolean cacheRule = true;
@@ -168,7 +149,8 @@ public class HttpRobotRulesParser extends RobotRulesParser {
                 if (redir != null
                         && !redir.getHost().equalsIgnoreCase(url.getHost())) {
                     // cache also for the redirected host
-                    cache.put(getCacheKey(redir), robotRules);
+                    String redirKey = cache.getCacheKey(redir);
+                    cache.put(redirKey, robotRules);
                 }
             }
         }

--- a/src/main/resources/urlfilters.json
+++ b/src/main/resources/urlfilters.json
@@ -20,6 +20,11 @@
       "params": {
         "regexFilterFile": "default-regex-filters.txt"
       }
+    },
+    {
+      "class": "com.digitalpebble.storm.crawler.filtering.RobotsURLFilter",
+      "name": "RobotsURLFilter",
+      "params": {}
     }
 
   ]


### PR DESCRIPTION
This PR adds a new mechanism for robots.txt caching and filtering.

Among the changes are:

- A new thread-safe, in-memory singleton cache for robots rules
- A RobotsURLFilter
- Moves the getCacheKey() method to the cache implementation because it's used in several locations
- The ParserBolt ensures that the robots rules are loaded into the shared cache, which means conditionally refetching and parsing the domain's robots.txt file