### PR TITLE
Pass in the Storm config when configuring ParseFilters

### DIFF
--- a/src/main/java/com/digitalpebble/storm/crawler/bolt/ParserBolt.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/bolt/ParserBolt.java
@@ -109,7 +109,7 @@ public class ParserBolt extends BaseRichBolt {
 
         if (parseconfigfile != null)
             try {
-                parseFilters = new ParseFilters(parseconfigfile);
+                parseFilters = new ParseFilters(conf, parseconfigfile);
             } catch (IOException e) {
                 LOG.error("Exception caught while loading the ParseFilters");
                 throw new RuntimeException(

--- a/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilter.java
@@ -18,27 +18,52 @@
 package com.digitalpebble.storm.crawler.parse;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.w3c.dom.DocumentFragment;
 
+import com.digitalpebble.storm.crawler.bolt.ParserBolt;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
- * Implementations of ParseFilter are called by the ParserBolt to extract custom
- * data from webpages
- **/
+ * Implementations of ParseFilter are responsible for extracting custom data
+ * from the crawled content. They are managed by the {@link ParserBolt}
+ */
 public interface ParseFilter {
 
+    /**
+     * Called when parsing a specific page
+     *
+     * @param URL
+     *            the URL of the page being parsed
+     * @param content
+     *            the content being parsed
+     * @param doc
+     *            the DOM tree resulting of the parsing of the content or null
+     *            if {@link #needsDOM()} returns <code>false</code>
+     * @param metadata
+     *            the metadata to be updated with the resulting of the parsing
+     */
     public void filter(String URL, byte[] content, DocumentFragment doc,
             HashMap<String, String[]> metadata);
 
-    /** Configuration of the filter with a JSONNode object **/
-    public void configure(JsonNode paramNode);
+    /**
+     * Called when this filter is being initialized
+     *
+     * @param stormConf
+     *            The Storm configuration used for the ParserBolt
+     * @param filterParams
+     *            the filter specific configuration. Never null
+     */
+    public void configure(Map stormConf, JsonNode filterParams);
 
     /**
-     * Returns true if the ParseFilter needs a DOM representation of the
-     * document, false otherwise.
-     **/
+     * Specifies whether this filter requires a DOM representation of the
+     * document
+     *
+     * @return <code>true</code>if this needs a DOM representation of the
+     *         document, <code>false</code> otherwise.
+     */
     public boolean needsDOM();
 
 }

--- a/src/main/java/com/digitalpebble/storm/crawler/parse/filter/DebugParseFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/parse/filter/DebugParseFilter.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.xml.serialize.XMLSerializer;
@@ -32,7 +33,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 /** Dumps the DOM representation of a document into a file **/
 public class DebugParseFilter implements ParseFilter {
 
-    OutputStream os;
+    private OutputStream os;
 
     @Override
     public void filter(String URL, byte[] content, DocumentFragment doc,
@@ -48,7 +49,7 @@ public class DebugParseFilter implements ParseFilter {
     }
 
     @Override
-    public void configure(JsonNode paramNode) {
+    public void configure(Map stormConf, JsonNode filterParams) {
         try {
             File outFile = File.createTempFile("DOMDump", ".txt");
             os = FileUtils.openOutputStream(outFile);

--- a/src/main/java/com/digitalpebble/storm/crawler/parse/filter/XPathFilter.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/parse/filter/XPathFilter.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.xml.namespace.QName;
@@ -175,8 +176,8 @@ public class XPathFilter implements ParseFilter {
     }
 
     @Override
-    public void configure(JsonNode paramNode) {
-        java.util.Iterator<Entry<String, JsonNode>> iter = paramNode
+    public void configure(Map stormConf, JsonNode filterParams) {
+        java.util.Iterator<Entry<String, JsonNode>> iter = filterParams
                 .fields();
         while (iter.hasNext()) {
             Entry<String, JsonNode> entry = iter.next();


### PR DESCRIPTION
A ParseFilter may want to access the Storm config during its config phase. To
that end the interface is changed to receive both the Storm config as well as
the Filter's parameters.

Also I changed ParseFilters to always call configure on the ParseFilter even
if there are no params defined. I think the original difference was too subtle
and therefore error prone. To make it easy on the ParseFiler, the paramsNode
is set to a NullNode.

Fixes #56