### PR TITLE
Fix XPathFilter to properly process XPathExpressions with element names

### DIFF
--- a/src/main/java/com/digitalpebble/storm/crawler/bolt/ParserBolt.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/bolt/ParserBolt.java
@@ -38,6 +38,7 @@ import org.apache.tika.sax.BodyContentHandler;
 import org.apache.tika.sax.Link;
 import org.apache.tika.sax.LinkContentHandler;
 import org.apache.tika.sax.TeeContentHandler;
+import org.apache.tika.sax.XHTMLContentHandler;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.DocumentFragment;
 import org.xml.sax.ContentHandler;
@@ -87,13 +88,14 @@ public class ParserBolt extends BaseRichBolt {
     private boolean upperCaseElementNames = true;
     private Class HTMLMapperClass = IdentityHtmlMapper.class;
 
+    @Override
     public void prepare(Map conf, TopologyContext context,
             OutputCollector collector) {
 
         String urlconfigfile = ConfUtils.getString(conf,
                 "urlfilters.config.file", "urlfilters.json");
 
-        if (urlconfigfile != null)
+        if (urlconfigfile != null) {
             try {
                 urlFilters = new URLFilters(urlconfigfile);
             } catch (IOException e) {
@@ -101,13 +103,14 @@ public class ParserBolt extends BaseRichBolt {
                 throw new RuntimeException(
                         "Exception caught while loading the URLFilters", e);
             }
+        }
 
         String parseconfigfile = ConfUtils.getString(conf,
                 "parsefilters.config.file", "parsefilters.json");
 
         parseFilters = ParseFilters.emptyParseFilter;
 
-        if (parseconfigfile != null)
+        if (parseconfigfile != null) {
             try {
                 parseFilters = new ParseFilters(parseconfigfile);
             } catch (IOException e) {
@@ -115,6 +118,7 @@ public class ParserBolt extends BaseRichBolt {
                 throw new RuntimeException(
                         "Exception caught while loading the ParseFilters", e);
             }
+        }
 
         this.parentURLFilter = new URLFilterUtil(conf);
 
@@ -157,6 +161,7 @@ public class ParserBolt extends BaseRichBolt {
 
     }
 
+    @Override
     public void execute(Tuple tuple) {
         eventMeters.scope("tuple_in").mark();
 
@@ -201,6 +206,7 @@ public class ParserBolt extends BaseRichBolt {
             root = doc.createDocumentFragment();
             DOMBuilder domhandler = new DOMBuilder(doc, root);
             domhandler.setUpperCaseElementNames(upperCaseElementNames);
+            domhandler.setDefaultNamespaceURI(XHTMLContentHandler.XHTML);
             teeHandler = new TeeContentHandler(linkHandler, textHandler,
                     domhandler);
         }
@@ -265,8 +271,9 @@ public class ParserBolt extends BaseRichBolt {
         List<Link> links = linkHandler.getLinks();
         Set<String> slinks = new HashSet<String>(links.size());
         for (Link l : links) {
-            if (StringUtils.isBlank(l.getUri()))
+            if (StringUtils.isBlank(l.getUri())) {
                 continue;
+            }
             String urlOL = null;
 
             // build an absolute URL
@@ -309,6 +316,7 @@ public class ParserBolt extends BaseRichBolt {
         eventMeters.scope("tuple_success").mark();
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         // output of this module is the list of fields to index
         // with at least the URL, text content

--- a/src/main/java/com/digitalpebble/storm/crawler/parse/DOMBuilder.java
+++ b/src/main/java/com/digitalpebble/storm/crawler/parse/DOMBuilder.java
@@ -59,9 +59,15 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
     protected Stack<Element> m_elemStack = new Stack<Element>();
 
     /**
+     * Element recorded with this namespace will be converted to Node without a
+     * namespace
+     */
+    private String defaultNamespaceURI = null;
+
+    /**
      * DOMBuilder instance constructor... it will add the DOM nodes to the
      * document fragment.
-     * 
+     *
      * @param doc
      *            Root document
      * @param node
@@ -75,7 +81,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
     /**
      * DOMBuilder instance constructor... it will add the DOM nodes to the
      * document fragment.
-     * 
+     *
      * @param doc
      *            Root document
      * @param docFrag
@@ -89,7 +95,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
     /**
      * DOMBuilder instance constructor... it will add the DOM nodes to the
      * document.
-     * 
+     *
      * @param doc
      *            Root document
      */
@@ -100,7 +106,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
     /**
      * Get the root node of the DOM being created. This is either a Document or
      * a DocumentFragment.
-     * 
+     *
      * @return The root document or document fragment if not null
      */
     Node getRootNode() {
@@ -109,7 +115,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Get the node currently being processed.
-     * 
+     *
      * @return the current node being processed
      */
     Node getCurrentNode() {
@@ -118,7 +124,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Return null since there is no Writer for this class.
-     * 
+     *
      * @return null
      */
     java.io.Writer getWriter() {
@@ -127,7 +133,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Append a node to the current container.
-     * 
+     *
      * @param newNode
      *            New node to append
      */
@@ -161,21 +167,22 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
                 }
             }
 
-            if (ok)
+            if (ok) {
                 m_doc.appendChild(newNode);
+            }
         }
     }
 
     /**
      * Receive an object for locating the origin of SAX document events.
-     * 
+     *
      * <p>
      * SAX parsers are strongly encouraged (though not absolutely required) to
      * supply a locator: if it does so, it must supply the locator to the
      * application by invoking this method before invoking any of the other
      * methods in the ContentHandler interface.
      * </p>
-     * 
+     *
      * <p>
      * The locator allows the application to determine the end position of any
      * document-related event, even if the parser is not reporting an error.
@@ -184,18 +191,19 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * application's business rules). The information returned by the locator is
      * probably not sufficient for use with a search engine.
      * </p>
-     * 
+     *
      * <p>
      * Note that the locator will return correct information only during the
      * invocation of the events in this interface. The application should not
      * attempt to use it at any other time.
      * </p>
-     * 
+     *
      * @param locator
      *            An object that can return the location of any SAX document
      *            event.
      * @see org.xml.sax.Locator
      */
+    @Override
     public void setDocumentLocator(Locator locator) {
 
         // No action for the moment.
@@ -203,13 +211,14 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Receive notification of the beginning of a document.
-     * 
+     *
      * <p>
      * The SAX parser will invoke this method only once, before any other
      * methods in this interface or in DTDHandler (except for
      * setDocumentLocator).
      * </p>
      */
+    @Override
     public void startDocument() throws org.xml.sax.SAXException {
 
         // No action for the moment.
@@ -217,7 +226,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Receive notification of the end of a document.
-     * 
+     *
      * <p>
      * The SAX parser will invoke this method only once, and it will be the last
      * method invoked during the parse. The parser shall not invoke this method
@@ -225,6 +234,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * or reached the end of input.
      * </p>
      */
+    @Override
     public void endDocument() throws org.xml.sax.SAXException {
 
         // No action for the moment.
@@ -232,7 +242,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Receive notification of the beginning of an element.
-     * 
+     *
      * <p>
      * The Parser will invoke this method at the beginning of every element in
      * the XML document; there will be a corresponding endElement() event for
@@ -240,15 +250,15 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * element's content will be reported, in order, before the corresponding
      * endElement() event.
      * </p>
-     * 
+     *
      * <p>
      * If the element name has a namespace prefix, the prefix will still be
      * attached. Note that the attribute list provided will contain only
      * attributes with explicit values (specified or defaulted): #IMPLIED
      * attributes will be omitted.
      * </p>
-     * 
-     * 
+     *
+     *
      * @param ns
      *            The namespace of the node
      * @param localName
@@ -260,20 +270,24 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * @see #endElement
      * @see org.xml.sax.Attributes
      */
+    @Override
     public void startElement(String ns, String localName, String name,
             Attributes atts) throws org.xml.sax.SAXException {
 
         Element elem;
 
-        if (upperCaseElementNames)
+        if (upperCaseElementNames) {
             name = name.toUpperCase();
+        }
 
         // Note that the namespace-aware call must be used to correctly
         // construct a Level 2 DOM, even for non-namespaced nodes.
-        if ((null == ns) || (ns.length() == 0))
+        if ((null == ns) || (ns.length() == 0)
+                || ns.equals(defaultNamespaceURI)) {
             elem = m_doc.createElementNS(null, name);
-        else
+        } else {
             elem = m_doc.createElementNS(ns, name);
+        }
 
         append(elem);
 
@@ -283,13 +297,16 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
             if (0 != nAtts) {
                 for (int i = 0; i < nAtts; i++) {
                     // First handle a possible ID attribute
-                    if (atts.getType(i).equalsIgnoreCase("ID"))
+                    if (atts.getType(i).equalsIgnoreCase("ID")) {
                         setIDAttribute(atts.getValue(i), elem);
+                    }
 
                     String attrNS = atts.getURI(i);
 
                     if ("".equals(attrNS))
+                     {
                         attrNS = null; // DOM represents no-namespace as null
+                    }
 
                     // System.out.println("attrNS: "+attrNS+", localName: "+atts.getQName(i)
                     // +", qname: "+atts.getQName(i)+", value: "+atts.getValue(i));
@@ -298,8 +315,9 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
                     // In SAX, xmlns: attributes have an empty namespace, while
                     // in DOM they should have the xmlns namespace
-                    if (attrQName.startsWith("xmlns:"))
+                    if (attrQName.startsWith("xmlns:")) {
                         attrNS = "http://www.w3.org/2000/xmlns/";
+                    }
 
                     // ALWAYS use the DOM Level 2 call!
                     elem.setAttributeNS(attrNS, attrQName, atts.getValue(i));
@@ -321,23 +339,23 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
     }
 
     /**
-     * 
-     * 
-     * 
+     *
+     *
+     *
      * Receive notification of the end of an element.
-     * 
+     *
      * <p>
      * The SAX parser will invoke this method at the end of every element in the
      * XML document; there will be a corresponding startElement() event for
      * every endElement() event (even when the element is empty).
      * </p>
-     * 
+     *
      * <p>
      * If the element name has a namespace prefix, the prefix will still be
      * attached to the name.
      * </p>
-     * 
-     * 
+     *
+     *
      * @param ns
      *            the namespace of the element
      * @param localName
@@ -345,6 +363,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * @param name
      *            The element name
      */
+    @Override
     public void endElement(String ns, String localName, String name)
             throws org.xml.sax.SAXException {
         m_elemStack.pop();
@@ -354,7 +373,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Set an ID string to node association in the ID table.
-     * 
+     *
      * @param id
      *            The ID string.
      * @param elem
@@ -367,7 +386,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Receive notification of character data.
-     * 
+     *
      * <p>
      * The Parser will call this method to report each chunk of character data.
      * SAX parsers may return all contiguous character data in a single chunk,
@@ -375,18 +394,18 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * in any single event must come from the same external entity, so that the
      * Locator provides useful information.
      * </p>
-     * 
+     *
      * <p>
      * The application must not attempt to read from the array outside of the
      * specified range.
      * </p>
-     * 
+     *
      * <p>
      * Note that some parsers will report whitespace using the
      * ignorableWhitespace() method rather than this one (validating parsers
      * must do so).
      * </p>
-     * 
+     *
      * @param ch
      *            The characters from the XML document.
      * @param start
@@ -396,11 +415,14 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * @see #ignorableWhitespace
      * @see org.xml.sax.Locator
      */
+    @Override
     public void characters(char ch[], int start, int length)
             throws org.xml.sax.SAXException {
         if (isOutsideDocElem()
                 && XMLCharacterRecognizer.isWhiteSpace(ch, start, length))
+         {
             return; // avoid DOM006 Hierarchy request error
+        }
 
         if (m_inCData) {
             cdata(ch, start, length);
@@ -423,7 +445,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * If available, when the disable-output-escaping attribute is used, output
      * raw text without escaping. A PI will be inserted in front of the node
      * with the name "lotusxsl-next-is-raw" and a value of "formatter-to-dom".
-     * 
+     *
      * @param ch
      *            Array containing the characters
      * @param start
@@ -435,7 +457,9 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
             throws org.xml.sax.SAXException {
         if (isOutsideDocElem()
                 && XMLCharacterRecognizer.isWhiteSpace(ch, start, length))
+         {
             return; // avoid DOM006 Hierarchy request error
+        }
 
         String s = new String(ch, start, length);
 
@@ -446,12 +470,12 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Report the beginning of an entity.
-     * 
+     *
      * The start and end of the document entity are not reported. The start and
      * end of the external DTD subset are reported using the pseudo-name
      * "[dtd]". All other events must be properly nested within start/end entity
      * events.
-     * 
+     *
      * @param name
      *            The name of the entity. If it is a parameter entity, the name
      *            will begin with '%'.
@@ -459,6 +483,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * @see org.xml.sax.ext.DeclHandler#internalEntityDecl
      * @see org.xml.sax.ext.DeclHandler#externalEntityDecl
      */
+    @Override
     public void startEntity(String name) throws org.xml.sax.SAXException {
 
         // Almost certainly the wrong behavior...
@@ -467,17 +492,18 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Report the end of an entity.
-     * 
+     *
      * @param name
      *            The name of the entity that is ending.
      * @see #startEntity
      */
+    @Override
     public void endEntity(String name) throws org.xml.sax.SAXException {
     }
 
     /**
      * Receive notivication of a entityReference.
-     * 
+     *
      * @param name
      *            name of the entity reference
      */
@@ -487,26 +513,26 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Receive notification of ignorable whitespace in element content.
-     * 
+     *
      * <p>
      * Validating Parsers must use this method to report each chunk of ignorable
      * whitespace (see the W3C XML 1.0 recommendation, section 2.10):
      * non-validating parsers may also use this method if they are capable of
      * parsing and using content models.
      * </p>
-     * 
+     *
      * <p>
      * SAX parsers may return all contiguous whitespace in a single chunk, or
      * they may split it into several chunks; however, all of the characters in
      * any single event must come from the same external entity, so that the
      * Locator provides useful information.
      * </p>
-     * 
+     *
      * <p>
      * The application must not attempt to read from the array outside of the
      * specified range.
      * </p>
-     * 
+     *
      * @param ch
      *            The characters from the XML document.
      * @param start
@@ -515,10 +541,13 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      *            The number of characters to read from the array.
      * @see #characters
      */
+    @Override
     public void ignorableWhitespace(char ch[], int start, int length)
             throws org.xml.sax.SAXException {
         if (isOutsideDocElem())
+         {
             return; // avoid DOM006 Hierarchy request error
+        }
 
         String s = new String(ch, start, length);
 
@@ -527,7 +556,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Tell if the current node is outside the document element.
-     * 
+     *
      * @return true if the current node is outside the document element.
      */
     private boolean isOutsideDocElem() {
@@ -538,23 +567,24 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Receive notification of a processing instruction.
-     * 
+     *
      * <p>
      * The Parser will invoke this method once for each processing instruction
      * found: note that processing instructions may occur before or after the
      * main document element.
      * </p>
-     * 
+     *
      * <p>
      * A SAX parser should never report an XML declaration (XML 1.0, section
      * 2.8) or a text declaration (XML 1.0, section 4.3.1) using this method.
      * </p>
-     * 
+     *
      * @param target
      *            The processing instruction target.
      * @param data
      *            The processing instruction data, or null if none was supplied.
      */
+    @Override
     public void processingInstruction(String target, String data)
             throws org.xml.sax.SAXException {
         append(m_doc.createProcessingInstruction(target, data));
@@ -562,10 +592,10 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Report an XML comment anywhere in the document.
-     * 
+     *
      * This callback will be used for comments inside or outside the document
      * element, including comments in the external DTD subset (if read).
-     * 
+     *
      * @param ch
      *            An array holding the characters in the comment.
      * @param start
@@ -573,12 +603,14 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * @param length
      *            The number of characters to use from the array.
      */
+    @Override
     public void comment(char ch[], int start, int length)
             throws org.xml.sax.SAXException {
         // tagsoup sometimes submits invalid values here
         if (ch == null || start < 0 || length >= (ch.length - start)
-                || length < 0)
+                || length < 0) {
             return;
+        }
         append(m_doc.createComment(new String(ch, start, length)));
     }
 
@@ -587,9 +619,10 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Report the start of a CDATA section.
-     * 
+     *
      * @see #endCDATA
      */
+    @Override
     public void startCDATA() throws org.xml.sax.SAXException {
         m_inCData = true;
         append(m_doc.createCDATASection(""));
@@ -597,16 +630,17 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Report the end of a CDATA section.
-     * 
+     *
      * @see #startCDATA
      */
+    @Override
     public void endCDATA() throws org.xml.sax.SAXException {
         m_inCData = false;
     }
 
     /**
      * Receive notification of cdata.
-     * 
+     *
      * <p>
      * The Parser will call this method to report each chunk of character data.
      * SAX parsers may return all contiguous character data in a single chunk,
@@ -614,18 +648,18 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * in any single event must come from the same external entity, so that the
      * Locator provides useful information.
      * </p>
-     * 
+     *
      * <p>
      * The application must not attempt to read from the array outside of the
      * specified range.
      * </p>
-     * 
+     *
      * <p>
      * Note that some parsers will report whitespace using the
      * ignorableWhitespace() method rather than this one (validating parsers
      * must do so).
      * </p>
-     * 
+     *
      * @param ch
      *            The characters from the XML document.
      * @param start
@@ -635,28 +669,30 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * @see #ignorableWhitespace
      * @see org.xml.sax.Locator
      */
-    public void cdata(char ch[], int start, int length)
-            throws org.xml.sax.SAXException {
+    public void cdata(char ch[], int start, int length) {
         if (isOutsideDocElem()
                 && XMLCharacterRecognizer.isWhiteSpace(ch, start, length))
+         {
             return; // avoid DOM006 Hierarchy request error
+        }
 
         String s = new String(ch, start, length);
 
         // XXX ab@apache.org: modified from the original, to accomodate TagSoup.
         Node n = m_currentNode.getLastChild();
-        if (n instanceof CDATASection)
+        if (n instanceof CDATASection) {
             ((CDATASection) n).appendData(s);
-        else if (n instanceof Comment)
+        } else if (n instanceof Comment) {
             ((Comment) n).appendData(s);
+        }
     }
 
     /**
      * Report the start of DTD declarations, if any.
-     * 
+     *
      * Any declarations are assumed to be in the internal subset unless
      * otherwise indicated.
-     * 
+     *
      * @param name
      *            The document type name.
      * @param publicId
@@ -668,6 +704,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * @see #endDTD
      * @see #startEntity
      */
+    @Override
     public void startDTD(String name, String publicId, String systemId)
             throws org.xml.sax.SAXException {
 
@@ -676,9 +713,10 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Report the end of DTD declarations.
-     * 
+     *
      * @see #startDTD
      */
+    @Override
     public void endDTD() throws org.xml.sax.SAXException {
 
         // Do nothing for now.
@@ -686,14 +724,14 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * Begin the scope of a prefix-URI Namespace mapping.
-     * 
+     *
      * <p>
      * The information from this event is not necessary for normal Namespace
      * processing: the SAX XML reader will automatically replace prefixes for
      * element and attribute names when the
      * http://xml.org/sax/features/namespaces feature is true (the default).
      * </p>
-     * 
+     *
      * <p>
      * There are cases, however, when applications need to use prefixes in
      * character data or in attribute values, where they cannot safely be
@@ -701,7 +739,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * information to the application to expand prefixes in those contexts
      * itself, if necessary.
      * </p>
-     * 
+     *
      * <p>
      * Note that start/endPrefixMapping events are not guaranteed to be properly
      * nested relative to each-other: all startPrefixMapping events will occur
@@ -709,7 +747,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * events will occur after the corresponding endElement event, but their
      * order is not guaranteed.
      * </p>
-     * 
+     *
      * @param prefix
      *            The Namespace prefix being declared.
      * @param uri
@@ -717,6 +755,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * @see #endPrefixMapping
      * @see #startElement
      */
+    @Override
     public void startPrefixMapping(String prefix, String uri)
             throws org.xml.sax.SAXException {
 
@@ -736,24 +775,25 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     /**
      * End the scope of a prefix-URI mapping.
-     * 
+     *
      * <p>
      * See startPrefixMapping for details. This event will always occur after
      * the corresponding endElement event, but the order of endPrefixMapping
      * events is not otherwise guaranteed.
      * </p>
-     * 
+     *
      * @param prefix
      *            The prefix that was being mapping.
      * @see #startPrefixMapping
      * @see #endElement
      */
+    @Override
     public void endPrefixMapping(String prefix) throws org.xml.sax.SAXException {
     }
 
     /**
      * Receive notification of a skipped entity.
-     * 
+     *
      * <p>
      * The Parser will invoke this method once for each entity skipped.
      * Non-validating processors may skip entities if they have not seen the
@@ -763,11 +803,12 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
      * http://xml.org/sax/features/external-general-entities and the
      * http://xml.org/sax/features/external-parameter-entities properties.
      * </p>
-     * 
+     *
      * @param name
      *            The name of the skipped entity. If it is a parameter entity,
      *            the name will begin with '%'.
      */
+    @Override
     public void skippedEntity(String name) throws org.xml.sax.SAXException {
     }
 
@@ -777,5 +818,13 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
 
     public void setUpperCaseElementNames(boolean upperCaseElementNames) {
         this.upperCaseElementNames = upperCaseElementNames;
+    }
+
+    public String getDefaultNamespaceURI() {
+        return defaultNamespaceURI;
+    }
+
+    public void setDefaultNamespaceURI(String defaultNamespaceURI) {
+        this.defaultNamespaceURI = defaultNamespaceURI;
     }
 }

--- a/src/test/java/com/digitalpebble/storm/crawler/parse/filter/XPathFilterTest.java
+++ b/src/test/java/com/digitalpebble/storm/crawler/parse/filter/XPathFilterTest.java
@@ -29,13 +29,13 @@ import com.digitalpebble.storm.crawler.bolt.ParserBolt;
 import com.digitalpebble.storm.crawler.util.KeyValues;
 
 public class XPathFilterTest extends ParsingTester {
-    
+
     @Before
     public void setupParserBolt() {
         bolt = new ParserBolt();
         setupParserBolt(bolt);
     }
-    
+
     @Test
     public void testBasicExtraction() throws IOException {
 
@@ -49,9 +49,7 @@ public class XPathFilterTest extends ParsingTester {
                 .get(2);
         Assert.assertNotNull(metadata);
         String concept = KeyValues.getValue("concept", metadata);
-        // TODO should not be null : modify after underlying issue has been
-        // fixed
-        Assert.assertNull(concept);
+        Assert.assertNotNull(concept);
 
         concept = KeyValues.getValue("concept2", metadata);
         Assert.assertNotNull(concept);


### PR DESCRIPTION
When parsing the content, Tika creates a properly formatted XHTML document:
all elements are created within the namespace XHTML.

However in XPath 1.0, there's no concept of default namespace so
XPath expressions such as //BODY doesn't match anything. To make this
work we should use //ns1:BODY and define a NamespaceContext which associates
ns1 with "http://www.w3.org/1999/xhtml"

To keep the XPathExpressions simpler, I modified the DOMBuilder which
is our SaxHandler used to convert the SAX Events into a DOM tree to
ignore a "default name space" and the ParserBolt initializes it with
the XHTML namespace. This way //BODY matches.

Fixes #31