### PR TITLE
Update to the ParserBolt

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/Constants.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/Constants.java
@@ -25,6 +25,9 @@ public class Constants {
     public static final String PARTITION_MODE_DOMAIN = "byDomain";
     public static final String PARTITION_MODE_IP = "byIP";
 
+    public static final String STATUS_ERROR_MESSAGE = "error.message";
+    public static final String STATUS_ERROR_SOURCE = "error.source";
+
     // used to determine how many URLs from the same domain should be allowed
     // before we block the URLs
     public static final String maxLiveURLsPerQueueParamName = "BlockingURLSpout.maxLiveURLsPerQueue";

--- a/core/src/main/java/com/digitalpebble/storm/crawler/filtering/URLFilters.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/filtering/URLFilters.java
@@ -37,14 +37,20 @@ import com.fasterxml.jackson.databind.node.NullNode;
  */
 public class URLFilters implements URLFilter {
 
+    public static final URLFilters emptyURLFilters = new URLFilters();
+
     private static final org.slf4j.Logger LOG = LoggerFactory
             .getLogger(URLFilters.class);
 
     private URLFilter[] filters;
 
+    private URLFilters() {
+        filters = new URLFilters[0];
+    }
+
     /**
      * Loads the filters from a JSON configuration file
-     * 
+     *
      * @throws IOException
      */
     public URLFilters(Map stormConf, String configFile) throws IOException {


### PR DESCRIPTION
- Add a boolean to skip the emit of outlinks
- wrap the parseFilters within a try/catch

Note that one subtle change I made is that if we fail to build a URL object
out of the url String, we simply skip the outlinks emitting. The comment
hints toward this not be possible so I don't think that's an issue