### PR TITLE
Removed write limit from Tika handler to get full text

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/ParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/ParserBolt.java
@@ -177,7 +177,7 @@ public class ParserBolt extends BaseRichBolt {
         org.apache.tika.metadata.Metadata md = new org.apache.tika.metadata.Metadata();
 
         LinkContentHandler linkHandler = new LinkContentHandler();
-        ContentHandler textHandler = new BodyContentHandler();
+        ContentHandler textHandler = new BodyContentHandler(-1);
         TeeContentHandler teeHandler = new TeeContentHandler(linkHandler,
                 textHandler);
         ParseContext parseContext = new ParseContext();


### PR DESCRIPTION
Tika shouldn't limit content size. It's already done using http.content.limit property.