### PR TITLE
Rewrite BasicURLNormalizer so URLs don't get double encoded

### DIFF
--- a/core/src/test/java/com/digitalpebble/storm/crawler/filtering/BasicURLNormalizerTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/filtering/BasicURLNormalizerTest.java
@@ -179,6 +179,34 @@ public class BasicURLNormalizerTest {
         assertEquals("Failed to filter query string", expectedResult, normalizedUrl);
     }
 
+    @Test
+    public void testProperURLEncodingWithoutQueryParameter()
+            throws MalformedURLException {
+        URLFilter urlFilter = createFilter(queryParamsToFilter);
+        String urlWithEscapedCharacters = "http://www.dillards.com/product/ASICS-Womens-GT2000-3-LiteShow%E2%84%A2-Running-Shoes_301_-1_301_504736989";
+        URL testSourceUrl = new URL(urlWithEscapedCharacters);
+        String testUrl = urlWithEscapedCharacters;
+        String expectedResult = urlWithEscapedCharacters;
+        String normalizedUrl = urlFilter.filter(testSourceUrl, new Metadata(),
+                testUrl);
+        assertEquals("Failed to filter query string", expectedResult,
+                normalizedUrl);
+    }
+
+    @Test
+    public void testProperURLEncodingWithQueryParameters()
+            throws MalformedURLException {
+        URLFilter urlFilter = createFilter(queryParamsToFilter);
+        String urlWithEscapedCharacters = "http://www.dillards.com/product/ASICS-Womens-GT2000-3-LiteShow%E2%84%A2-Running-Shoes_301_-1_301_504736989?how=are&you=doing";
+        URL testSourceUrl = new URL(urlWithEscapedCharacters);
+        String testUrl = urlWithEscapedCharacters;
+        String expectedResult = urlWithEscapedCharacters;
+        String normalizedUrl = urlFilter.filter(testSourceUrl, new Metadata(),
+                testUrl);
+        assertEquals("Failed to filter query string", expectedResult,
+                normalizedUrl);
+    }
+
     private JsonNode getArrayNode(List<String> queryElementsToRemove) {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.valueToTree(queryElementsToRemove);


### PR DESCRIPTION
URL encoding is so tricky! And there are basically no good library
that handles it properly, mostly because of the lack of proper support
via the URL and URI classes.

In any event, I rewrote filterQueryElements so that it no longer
double encode the URLs. This is done by simply only modifying the
query string and leaving the other elements unchanged.

I added some 2 unit tests to validate my code.

Fixes #118