### PR TITLE
[Fetcher] Specify arbitraty max thread nums per queue ID

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/FetcherBolt.java
@@ -138,7 +138,7 @@ public class FetcherBolt extends BaseRichBolt {
                 LOG.warn("Cannot parse url: {}", url, e);
                 return null;
             }
-            final String proto = u.getProtocol().toLowerCase(Locale.ROOT);
+
             String key = null;
             // reuse any key that might have been given
             // be it the hostname, domain or IP
@@ -146,7 +146,7 @@ public class FetcherBolt extends BaseRichBolt {
                 key = t.getStringByField("key");
             }
             if (StringUtils.isNotBlank(key)) {
-                queueID = proto + "://" + key.toLowerCase(Locale.ROOT);
+                queueID = key.toLowerCase(Locale.ROOT);
                 return new FetchItem(url, u, t, queueID);
             }
 
@@ -177,7 +177,7 @@ public class FetcherBolt extends BaseRichBolt {
                     key = u.toExternalForm();
                 }
             }
-            queueID = proto + "://" + key.toLowerCase(Locale.ROOT);
+            queueID = key.toLowerCase(Locale.ROOT);
             return new FetchItem(url, u, t, queueID);
         }
 

--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/FetcherBolt.java
@@ -273,7 +273,7 @@ public class FetcherBolt extends BaseRichBolt {
 
         AtomicInteger inQueues = new AtomicInteger(0);
 
-        final int maxThreads;
+        final int defaultMaxThread;
         final long crawlDelay;
         final long minCrawlDelay;
 
@@ -287,7 +287,7 @@ public class FetcherBolt extends BaseRichBolt {
 
         public FetchItemQueues(Config conf) {
             this.conf = conf;
-            this.maxThreads = ConfUtils.getInt(conf,
+            this.defaultMaxThread = ConfUtils.getInt(conf,
                     "fetcher.threads.per.queue", 1);
             queueMode = ConfUtils.getString(conf, "fetcher.queue.mode",
                     QUEUE_MODE_HOST);
@@ -333,8 +333,11 @@ public class FetcherBolt extends BaseRichBolt {
         public synchronized FetchItemQueue getFetchItemQueue(String id) {
             FetchItemQueue fiq = queues.get(id);
             if (fiq == null) {
+                // custom maxThread value?
+                final int customThreadVal = ConfUtils.getInt(conf,
+                        "fetcher.maxThreads." + id, defaultMaxThread);
                 // initialize queue
-                fiq = new FetchItemQueue(conf, maxThreads, crawlDelay,
+                fiq = new FetchItemQueue(conf, customThreadVal, crawlDelay,
                         minCrawlDelay);
                 queues.put(id, fiq);
 


### PR DESCRIPTION
We want to have a default number of max threads to use per queue but also specify arbitrary values per queue ID e.g. `fetcher.maxThreads.INSERT_HOSTNAME_HERE: 10`

This patch also simplifies the queueIDs by not prefixing them with the protocol.