### PR TITLE
Catch exceptions in ParseFilters.filter() method

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilters.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilters.java
@@ -50,7 +50,7 @@ public class ParseFilters implements ParseFilter {
 
     /**
      * loads the filters from a JSON configuration file
-     * 
+     *
      * @throws IOException
      */
     public ParseFilters(Map stormConf, String configFile) throws IOException {
@@ -156,7 +156,11 @@ public class ParseFilters implements ParseFilter {
             Metadata metadata, List<Outlink> outlinks) {
         for (ParseFilter filter : filters) {
             long start = System.currentTimeMillis();
-            filter.filter(URL, content, doc, metadata, outlinks);
+            try {
+                filter.filter(URL, content, doc, metadata, outlinks);
+            } catch (Exception e) {
+                LOG.error("ParseFilter {} failed due to {}", filter.getClass(), e);
+            }
             long end = System.currentTimeMillis();
             LOG.debug("ParseFilter {} took {} msec", filter.getClass()
                     .getName(), (end - start));


### PR DESCRIPTION
I recently ran into an issue where a single failing ParseFilter would break the entire filtering chain. This is undesirable because it causes a URL to be sent down the Status stream with `Status.ERROR`, due to nothing but a potentially malformed ParseFilter.

@DigitalPebble/committers-crawler can you see any reason why it might be a bad idea to catch and report, but otherwise ignore, exceptions in the `ParseFilters.filter()` method?