### PR TITLE
Allowing the parse output to output more than one document

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/SiteMapParserBolt.java
@@ -44,8 +44,10 @@ import com.digitalpebble.storm.crawler.Constants;
 import com.digitalpebble.storm.crawler.Metadata;
 import com.digitalpebble.storm.crawler.filtering.URLFilters;
 import com.digitalpebble.storm.crawler.parse.Outlink;
+import com.digitalpebble.storm.crawler.parse.ParseData;
 import com.digitalpebble.storm.crawler.parse.ParseFilter;
 import com.digitalpebble.storm.crawler.parse.ParseFilters;
+import com.digitalpebble.storm.crawler.parse.ParseResult;
 import com.digitalpebble.storm.crawler.persistence.Status;
 import com.digitalpebble.storm.crawler.protocol.HttpHeaders;
 import com.digitalpebble.storm.crawler.util.ConfUtils;
@@ -115,7 +117,12 @@ public class SiteMapParserBolt extends BaseRichBolt {
 
         // apply the parse filters if any to the current document
         try {
-            parseFilters.filter(url, content, null, metadata, outlinks);
+            ParseResult parse = new ParseResult();
+            parse.setOutlinks(outlinks);
+            ParseData parseData = parse.get(url);
+            parseData.setMetadata(metadata);
+
+            parseFilters.filter(url, content, null, parse);
         } catch (RuntimeException e) {
             String errorMessage = "Exception while running parse filters on "
                     + url + ": " + e;

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseData.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseData.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.parse;
+
+import com.digitalpebble.storm.crawler.Metadata;
+
+public class ParseData {
+    private byte[] content;
+    private String text;
+    private Metadata metadata;
+
+    public ParseData() {
+        this.metadata = new Metadata();
+    }
+
+    public ParseData(String text, Metadata metadata) {
+        this.text = text;
+        this.metadata = metadata;
+        this.content = new byte[0];
+    }
+
+    public ParseData(Metadata md) {
+        this.metadata = md;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
+    }
+
+    public byte[] getContent() {
+        return content;
+    }
+
+    public void setContent(byte[] content) {
+        this.content = content;
+    }
+
+    public void put(String key, String value) {
+        metadata.addValue(key, value);
+    }
+
+    public String get(String key) {
+        return metadata.getFirstValue(key);
+    }
+
+    public String[] getValues(String key) {
+        return metadata.getValues(key);
+    }
+}

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilter.java
@@ -5,9 +5,9 @@
  * DigitalPebble licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,12 +17,10 @@
 
 package com.digitalpebble.storm.crawler.parse;
 
-import java.util.List;
 import java.util.Map;
 
 import org.w3c.dom.DocumentFragment;
 
-import com.digitalpebble.storm.crawler.Metadata;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
@@ -41,13 +39,11 @@ public interface ParseFilter {
      * @param doc
      *            the DOM tree resulting of the parsing of the content or null
      *            if {@link #needsDOM()} returns <code>false</code>
-     * @param metadata
+     * @param parse
      *            the metadata to be updated with the resulting of the parsing
-     * @param outlinks
-     *            outlinks extracted by the parser
      */
     public void filter(String URL, byte[] content, DocumentFragment doc,
-            Metadata metadata, List<Outlink> outlinks);
+            ParseResult parse);
 
     /**
      * Called when this filter is being initialized

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilters.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilters.java
@@ -153,10 +153,11 @@ public class ParseFilters implements ParseFilter {
 
     @Override
     public void filter(String URL, byte[] content, DocumentFragment doc,
-            Metadata metadata, List<Outlink> outlinks) {
+            ParseResult parse) {
+
         for (ParseFilter filter : filters) {
             long start = System.currentTimeMillis();
-            filter.filter(URL, content, doc, metadata, outlinks);
+            filter.filter(URL, content, doc, parse);
             long end = System.currentTimeMillis();
             LOG.debug("ParseFilter {} took {} msec", filter.getClass()
                     .getName(), (end - start));

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseResult.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseResult.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.parse;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.digitalpebble.storm.crawler.Metadata;
+
+public class ParseResult implements Iterable<Map.Entry<String, ParseData>> {
+
+    private List<Outlink> outlinks;
+    private Map<String, ParseData> parseMap;
+
+    public ParseResult() {
+        parseMap = new HashMap<>();
+        outlinks = new ArrayList<>();
+    }
+
+    public ParseResult(Map<String, ParseData> map) {
+        if (map == null) {
+            throw new NullPointerException();
+        }
+
+        parseMap = map;
+        outlinks = new ArrayList<>();
+    }
+
+    public boolean isEmpty() {
+        return parseMap.isEmpty();
+    }
+
+    public int size() {
+        return parseMap.size();
+    }
+
+    public List<Outlink> getOutlinks() {
+        return outlinks;
+    }
+
+    public void setOutlinks(List<Outlink> outlinks) {
+        this.outlinks = outlinks;
+    }
+
+    /**
+     * @return An existent instance of Parse for the given URL or an empty one
+     *         if none can be found, useful to avoid unnecessary checks in the
+     *         parse plugins
+     */
+    public ParseData get(String URL) {
+        if (parseMap.get(URL) == null) {
+            ParseData parse = new ParseData();
+            parseMap.put(URL, parse);
+
+            return parse;
+        }
+
+        return parseMap.get(URL);
+    }
+
+    public String[] getValues(String URL, String key) {
+        ParseData parseInfo = parseMap.get(URL);
+
+        if (parseInfo == null) {
+            return null;
+        }
+
+        return parseInfo.getValues(key);
+    }
+
+    public void put(String URL, String key, String value) {
+        if (parseMap.containsKey(URL)) {
+            parseMap.get(URL).getMetadata().addValue(key, value);
+        } else {
+            ParseData parse = new ParseData();
+            parse.put(key, value);
+            parseMap.put(URL, parse);
+        }
+    }
+
+    public void put(String URL, Metadata metadata) {
+        if (parseMap.containsKey(URL)) {
+            parseMap.get(URL).getMetadata().putAll(metadata);
+        } else {
+            ParseData parseData = new ParseData();
+            parseData.getMetadata().putAll(metadata);
+            parseMap.put(URL, parseData);
+        }
+    }
+
+    public Map<String, ParseData> getParseMap() {
+        return parseMap;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, ParseData>> iterator() {
+        return parseMap.entrySet().iterator();
+    }
+
+    @Override
+    public String toString() {
+        return parseMap.toString();
+    }
+
+}

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/filter/DebugParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/filter/DebugParseFilter.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
+import com.digitalpebble.storm.crawler.parse.ParseResult;
 import org.apache.commons.io.FileUtils;
 import org.apache.xml.serialize.XMLSerializer;
 import org.w3c.dom.DocumentFragment;
@@ -41,7 +42,7 @@ public class DebugParseFilter implements ParseFilter {
 
     @Override
     public void filter(String URL, byte[] content, DocumentFragment doc,
-            Metadata metadata, List<Outlink> outlinks) {
+            ParseResult parse) {
 
         try {
             XMLSerializer serializer = new XMLSerializer(os, null);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/filter/XPathFilter.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/filter/XPathFilter.java
@@ -32,6 +32,8 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import com.digitalpebble.storm.crawler.parse.ParseData;
+import com.digitalpebble.storm.crawler.parse.ParseResult;
 import org.apache.commons.lang.StringUtils;
 import org.apache.xml.serialize.Method;
 import org.apache.xml.serialize.OutputFormat;
@@ -160,10 +162,12 @@ public class XPathFilter implements ParseFilter {
 
     @Override
     public void filter(String URL, byte[] content, DocumentFragment doc,
-            Metadata metadata, List<Outlink> outlinks) {
+            ParseResult parse) {
+
+        ParseData parseData = parse.get(URL);
+        Metadata metadata = parseData.getMetadata();
 
         // applies the XPATH expression in the order in which they are produced
-
         java.util.Iterator<LabelledExpression> iter = expressions.iterator();
         while (iter.hasNext()) {
             LabelledExpression le = iter.next();
@@ -176,7 +180,6 @@ public class XPathFilter implements ParseFilter {
                 LOG.error("Error evaluating {}: {}", le.key, e);
             }
         }
-
     }
 
     @Override

--- a/core/src/test/java/com/digitalpebble/storm/crawler/parse/filter/SubDocumentsFilterTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/parse/filter/SubDocumentsFilterTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.parse.filter;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.digitalpebble.storm.crawler.Metadata;
+import com.digitalpebble.storm.crawler.bolt.JSoupParserBolt;
+
+public class SubDocumentsFilterTest extends ParsingTester {
+
+    @Before
+    public void setupParserBolt() {
+        bolt = new JSoupParserBolt();
+        setupParserBolt(bolt);
+    }
+
+    @Test
+    public void testSitemapSubdocuments() throws IOException {
+        prepareParserBolt("test.subdocfilter.json");
+
+        Metadata metadata = new Metadata();
+
+        parse("http://www.digitalpebble.com/sitemap.xml",
+                "digitalpebble.sitemap.xml", metadata);
+
+        Assert.assertEquals(6, output.getEmitted().size());
+    }
+}

--- a/core/src/test/java/com/digitalpebble/storm/crawler/parse/filter/SubDocumentsParseFilter.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/parse/filter/SubDocumentsParseFilter.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.parse.filter;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.DocumentFragment;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.digitalpebble.storm.crawler.parse.ParseData;
+import com.digitalpebble.storm.crawler.parse.ParseFilter;
+import com.digitalpebble.storm.crawler.parse.ParseResult;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class SubDocumentsParseFilter implements ParseFilter {
+    private static final org.slf4j.Logger LOG = LoggerFactory
+            .getLogger(SubDocumentsParseFilter.class);
+
+    @Override
+    public void filter(String URL, byte[] content, DocumentFragment doc,
+            ParseResult parse) {
+
+        InputStream stream = new ByteArrayInputStream(content);
+
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory
+                    .newInstance();
+            Document document = factory.newDocumentBuilder().parse(stream);
+            Element root = document.getDocumentElement();
+
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            XPathExpression expression = xPath.compile("//url");
+
+            NodeList nodes = (NodeList) expression.evaluate(root,
+                    XPathConstants.NODESET);
+
+            for (int i = 0; i < nodes.getLength(); i++) {
+                Node node = nodes.item(i);
+
+                expression = xPath.compile("loc");
+                Node child = (Node) expression.evaluate(node,
+                        XPathConstants.NODE);
+
+                // create a subdocument for each url found in the sitemap
+                ParseData parseData = parse.get(child.getTextContent());
+
+                NodeList childs = node.getChildNodes();
+                for (int j = 0; j < childs.getLength(); j++) {
+                    Node n = childs.item(j);
+                    parseData.put(n.getNodeName(), n.getTextContent());
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error processing sitemap from {}: {}", URL, e);
+        }
+    }
+
+    @Override
+    public void configure(Map stormConf, JsonNode filterParams) {
+        // nothing to do here for now
+    }
+
+    @Override
+    public boolean needsDOM() {
+        return false;
+    }
+}

--- a/core/src/test/resources/test.subdocfilter.json
+++ b/core/src/test/resources/test.subdocfilter.json
@@ -1,0 +1,8 @@
+{
+  "com.digitalpebble.storm.crawler.parse.ParseFilters": [
+    {
+      "class": "com.digitalpebble.storm.crawler.parse.filter.SubDocumentsParseFilter",
+      "name": "Subdocs"
+    }
+  ]
+}

--- a/external/src/main/java/com/digitalpebble/storm/crawler/tika/ParserBolt.java
+++ b/external/src/main/java/com/digitalpebble/storm/crawler/tika/ParserBolt.java
@@ -55,8 +55,10 @@ import com.digitalpebble.storm.crawler.Constants;
 import com.digitalpebble.storm.crawler.Metadata;
 import com.digitalpebble.storm.crawler.filtering.URLFilters;
 import com.digitalpebble.storm.crawler.parse.Outlink;
+import com.digitalpebble.storm.crawler.parse.ParseData;
 import com.digitalpebble.storm.crawler.parse.ParseFilter;
 import com.digitalpebble.storm.crawler.parse.ParseFilters;
+import com.digitalpebble.storm.crawler.parse.ParseResult;
 import com.digitalpebble.storm.crawler.persistence.Status;
 import com.digitalpebble.storm.crawler.util.ConfUtils;
 import com.digitalpebble.storm.crawler.util.MetadataTransfer;
@@ -245,9 +247,18 @@ public class ParserBolt extends BaseRichBolt {
         List<Outlink> outlinks = toOutlinks(url, linkHandler.getLinks(),
                 metadata);
 
+        ParseResult parse = new ParseResult();
+        parse.setOutlinks(outlinks);
+
+        // parse data of the parent URL
+        ParseData parseData = parse.get(url);
+        parseData.setMetadata(metadata);
+        parseData.setText(text);
+        parseData.setContent(content);
+
         // apply the parse filters if any
         try {
-            parseFilters.filter(url, content, root, metadata, outlinks);
+            parseFilters.filter(url, content, root, parse);
         } catch (RuntimeException e) {
             String errorMessage = "Exception while running parse filters on "
                     + url + ": " + e;
@@ -277,7 +288,16 @@ public class ParserBolt extends BaseRichBolt {
             }
         }
 
-        collector.emit(tuple, new Values(url, content, metadata, text.trim()));
+        // emit each document/subdocument in the ParseResult object
+        // there should be at least one ParseData item for the "parent" URL
+
+        for (Map.Entry<String, ParseData> doc : parse) {
+            ParseData parseDoc = doc.getValue();
+
+            collector.emit(new Values(doc.getKey(), parseDoc.getContent(),
+                    parseDoc.getMetadata(), parseDoc.getText()));
+        }
+
         collector.ack(tuple);
         eventCounter.scope("tuple_success").incrBy(1);
     }


### PR DESCRIPTION
This address the https://github.com/DigitalPebble/storm-crawler/issues/117 issue at some extent this also encapsulate in a `ParseResult` the parsing data/metadata of a URL. Each URL has only one `ParseResult` which at the same time has at least 1 `ParseData` instance to hold the data of the "parent" URL in case subdocuments are extracted in any `ParseFilter` the URLs and ParseData of each subdocument is added to the parent ParseResult. So the `ParserBolt` emits each `ParseData` container in the `ParseResult` as a tuple. So at the very least 1 `ParseData`, or any number if subdocuments are extracted, also this implies that there is no difference between the extracted information about the parent URL or any subdocument each `ParseData` gets emitted as a tuple.

I made some simple graph to try to explain this :) I hope it makes things a little more clearer than my explanation.
![storm-parsing](https://cloud.githubusercontent.com/assets/1291846/7991821/f664ea14-0ac8-11e5-8525-2e1d11a1e932.png)
