### PR TITLE
maven-java-formatter-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,14 @@
                         <target>1.7</target>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>com.googlecode.maven-java-formatter-plugin</groupId>
+                    <artifactId>maven-java-formatter-plugin</artifactId>
+                    <version>0.4</version>
+                    <configuration>
+                        <configFile>${project.basedir}/../eclipse-formatting-profile.xml</configFile>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
The command `mvn java-formatter:format` will apply the formatting to the code using the Eclipse formatting provided.

The latter can be imported directly in Eclipse and there seems to be plugins for other editors, however the point here is that the formatting will be done regardless of which editor is used.