### PR TITLE
Enforce robots meta instructions

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/JSoupParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/JSoupParserBolt.java
@@ -162,6 +162,12 @@ public class JSoupParserBolt extends BaseRichBolt {
                 // relative urls.
                 // e.g.: /foo will resolve to http://shopstyle.com/foo
                 String targetURL = link.attr("abs:href");
+
+                // nofollow
+                if ("nofollow".equalsIgnoreCase(link.attr("rel"))) {
+                    continue;
+                }
+
                 String anchor = link.text();
                 if (StringUtils.isNotBlank(targetURL)) {
                     List<String> anchors = slinks.get(targetURL);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/indexing/AbstractIndexerBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/indexing/AbstractIndexerBolt.java
@@ -35,6 +35,7 @@ import clojure.lang.PersistentVector;
 
 import com.digitalpebble.storm.crawler.Metadata;
 import com.digitalpebble.storm.crawler.util.ConfUtils;
+import com.digitalpebble.storm.crawler.util.RobotsTags;
 
 /** Abstract class to simplify writing IndexerBolts **/
 @SuppressWarnings("serial")
@@ -116,9 +117,15 @@ public abstract class AbstractIndexerBolt extends BaseRichBolt {
 
     /**
      * Determine whether a document should be indexed based on the presence of a
-     * given key/value. Returns true if the document should be kept.
+     * given key/value or the RobotsTags.ROBOTS_NO_INDEX directive.
+     * 
+     * @return true if the document should be kept.
      **/
     protected boolean filterDocument(Metadata meta) {
+        String noindexVal = meta.getFirstValue(RobotsTags.ROBOTS_NO_INDEX);
+        if ("true".equalsIgnoreCase(noindexVal))
+            return false;
+
         if (filterKeyValue == null)
             return true;
         String[] values = meta.getValues(filterKeyValue[0]);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/RobotsTags.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/RobotsTags.java
@@ -40,6 +40,12 @@ public class RobotsTags {
 
     public final static String ROBOTS_NO_FOLLOW = "robots.noFollow";
 
+    /**
+     * Whether to interpret the noFollow directive strictly (remove links) or
+     * not (remove anchor and do not track original URL). True by default.
+     **/
+    public final static String ROBOTS_NO_FOLLOW_STRICT = "robots.noFollow.strict";
+
     public final static String ROBOTS_NO_CACHE = "robots.noCache";
 
     private boolean noIndex = false;

--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/RobotsTags.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/RobotsTags.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.util;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.DocumentFragment;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.digitalpebble.storm.crawler.Metadata;
+
+/**
+ * Normalises the robots instructions provided by the HTML meta tags or the HTTP
+ * X-Robots-Tag headers.
+ **/
+public class RobotsTags {
+
+    public final static String ROBOTS_NO_INDEX = "robots.noIndex";
+
+    public final static String ROBOTS_NO_FOLLOW = "robots.noFollow";
+
+    public final static String ROBOTS_NO_CACHE = "robots.noCache";
+
+    private boolean noIndex = false;
+
+    private boolean noFollow = false;
+
+    private boolean noCache = false;
+
+    private static XPathExpression expression;
+    static {
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        try {
+            expression = xpath.compile("//META");
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Get the values from the fetch metadata **/
+    public RobotsTags(Metadata metadata) {
+        // HTTP headers
+        // X-Robots-Tag: noindex
+        String[] values = metadata.getValues("X-Robots-Tag");
+        if (values == null)
+            return;
+        if (values.length == 1) {
+            // just in case they put all the values on a single line
+            values = values[0].split(" *, *");
+        }
+        parseValues(values);
+    }
+
+    public RobotsTags() {
+    }
+
+    // set the values based on the meta tags
+    // HTML tags
+    // <meta name="robots" content="noarchive, nofollow"/>
+    // called by the parser bolts
+    public void extractMetaTags(DocumentFragment doc)
+            throws XPathExpressionException {
+        NodeList nodes = (NodeList) expression.evaluate(doc,
+                XPathConstants.NODESET);
+        if (nodes == null)
+            return;
+        int numNodes = nodes.getLength();
+        for (int i = 0; i < numNodes; i++) {
+            Node n = (Node) nodes.item(i);
+            // iterate on the attributes
+            // and check that it has name=robots and content
+            // whatever the case is
+            boolean isRobots = false;
+            String content = null;
+            NamedNodeMap attrs = n.getAttributes();
+            for (int att = 0; att < attrs.getLength(); att++) {
+                Node keyval = attrs.item(att);
+                if ("name".equalsIgnoreCase(keyval.getNodeName())
+                        && "robots".equalsIgnoreCase(keyval.getNodeValue())) {
+                    isRobots = true;
+                    continue;
+                }
+                if ("content".equalsIgnoreCase(keyval.getNodeName())) {
+                    content = keyval.getNodeValue();
+                    continue;
+                }
+            }
+
+            if (isRobots && content != null) {
+                // got a value - split it
+                String[] vals = content.split(" *, *");
+                parseValues(vals);
+            }
+        }
+    }
+
+    private void parseValues(String[] values) {
+        for (String v : values) {
+            v = v.trim();
+            if ("noindex".equalsIgnoreCase(v)) {
+                noIndex = true;
+            } else if ("nofollow".equalsIgnoreCase(v)) {
+                noFollow = true;
+            } else if ("noarchive".equalsIgnoreCase(v)) {
+                noCache = true;
+            } else if ("none".equalsIgnoreCase(v)) {
+                noIndex = true;
+                noFollow = true;
+                noCache = true;
+            }
+        }
+    }
+
+    /** Adds a normalised representation of the directives in the metadata **/
+    public void normaliseToMetadata(Metadata metadata) {
+        metadata.setValue(ROBOTS_NO_INDEX, Boolean.toString(noIndex));
+        metadata.setValue(ROBOTS_NO_CACHE, Boolean.toString(noCache));
+        metadata.setValue(ROBOTS_NO_FOLLOW, Boolean.toString(noFollow));
+    }
+
+    public boolean isNoIndex() {
+        return noIndex;
+    }
+
+    public boolean isNoFollow() {
+        return noFollow;
+    }
+
+    public boolean isNoCache() {
+        return noCache;
+    }
+
+}

--- a/core/src/test/java/com/digitalpebble/storm/crawler/bolt/JSoupParserBoltTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/bolt/JSoupParserBoltTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.bolt;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import backtype.storm.task.OutputCollector;
+
+import com.digitalpebble.storm.crawler.Constants;
+import com.digitalpebble.storm.crawler.TestUtil;
+import com.digitalpebble.storm.crawler.parse.filter.ParsingTester;
+
+public class JSoupParserBoltTest extends ParsingTester {
+
+    @Before
+    public void setupParserBolt() {
+        bolt = new JSoupParserBolt();
+        setupParserBolt(bolt);
+    }
+
+    @Test
+    public void testNoFollowOutlinks() throws IOException {
+
+        bolt.prepare(new HashMap(), TestUtil.getMockedTopologyContext(),
+                new OutputCollector(output));
+
+        parse("http://www.digitalpebble.com", "digitalpebble.com.html");
+
+        List<List<Object>> statusTuples = output
+                .getEmitted(Constants.StatusStreamName);
+
+        // there should be only 4 here
+        Assert.assertEquals(4, statusTuples.size());
+    }
+
+}

--- a/core/src/test/java/com/digitalpebble/storm/crawler/parse/filter/ParsingTester.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/parse/filter/ParsingTester.java
@@ -60,6 +60,15 @@ public class ParsingTester {
                 new OutputCollector(output));
     }
 
+    protected void parse(String url, byte[] content, Metadata metadata)
+            throws IOException {
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getBinaryByField("content")).thenReturn(content);
+        when(tuple.getStringByField("url")).thenReturn(url);
+        when(tuple.getValueByField("metadata")).thenReturn(metadata);
+        bolt.execute(tuple);
+    }
+
     protected void parse(String url, String filename) throws IOException {
         parse(url, filename, new Metadata());
     }

--- a/core/src/test/java/com/digitalpebble/storm/crawler/util/RobotsTagsTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/util/RobotsTagsTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.storm.crawler.util;
+
+import java.net.MalformedURLException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.digitalpebble.storm.crawler.Metadata;
+
+public class RobotsTagsTest {
+    @Test
+    public void testHTTPHeaders() throws MalformedURLException {
+        Metadata md = new Metadata();
+        RobotsTags tags = new RobotsTags(md);
+        Assert.assertEquals(false, tags.isNoCache());
+        Assert.assertEquals(false, tags.isNoFollow());
+        Assert.assertEquals(false, tags.isNoIndex());
+
+        md = new Metadata();
+        md.setValue("X-Robots-Tag", "none");
+        tags = new RobotsTags(md);
+        Assert.assertEquals(true, tags.isNoCache());
+        Assert.assertEquals(true, tags.isNoFollow());
+        Assert.assertEquals(true, tags.isNoIndex());
+
+        md = new Metadata();
+        md.setValues("X-Robots-Tag", new String[] { "noindex", "nofollow" });
+        tags = new RobotsTags(md);
+        Assert.assertEquals(false, tags.isNoCache());
+        Assert.assertEquals(true, tags.isNoFollow());
+        Assert.assertEquals(true, tags.isNoIndex());
+
+        // expect the content to be incorrect
+        md = new Metadata();
+        md.setValue("X-Robots-Tag", "noindex, nofollow");
+        tags = new RobotsTags(md);
+        Assert.assertEquals(false, tags.isNoCache());
+        Assert.assertEquals(true, tags.isNoFollow());
+        Assert.assertEquals(true, tags.isNoIndex());
+    }
+
+}

--- a/core/src/test/resources/digitalpebble.com.html
+++ b/core/src/test/resources/digitalpebble.com.html
@@ -13,6 +13,8 @@
   <!-- #EndEditable -->
 </head>
 
+<a rel="nofollow" href="inexistent.html"/>
+
 <body style="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);"
 alink="#000000" link="#000000" vlink="#000000">
 
@@ -89,7 +91,7 @@ alink="#000000" link="#000000" vlink="#000000">
         documents life cycle, from web-wide crawling and collection, content
         analysis, filtering and categorization to indexing. We are
         specialised in large scale processing using <a
-        href="http://hadoop.apache.org/">Hadoop</a> or <a href="http://storm.incubator.apache.org/">Storm</a> and have expertise in cloud platforms such as Amazon AWS, which has allowed
+        href="http://hadoop.apache.org/">Hadoop</a> or <a href="http://storm.apache.org/">Storm</a> and have expertise in cloud platforms such as Amazon AWS, which has allowed
         us to successfully deploy solutions scaling up to billions of documents for our <a href="references.html">clients</a>. </p>
         
         <p class="aligned">Not only to we have an extensive knowledge of open source solutions, we are also active contributors and 


### PR DESCRIPTION
Implements #147 

* Added RobotsTags to represent the instructions provided in the HTTP headers or META tags.
* JSoupParserBolt bypasses the extraction of outlinks and AbstractIndexerBolt filters out document according to these values.
* JSoupParserBolt filters out links with `rel="nofollow"`
* Added RobotsTagsTest and JSoupParserBoltTest.

Will add the same behaviour to the Tika parser after merging #145 

@DigitalPebble/committers-crawler please review