### PR TITLE
ContentFilter to restrict text of document to XPath match

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/filter/ContentFilter.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/filter/ContentFilter.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.parse.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.DocumentFragment;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.digitalpebble.storm.crawler.parse.ParseData;
+import com.digitalpebble.storm.crawler.parse.ParseFilter;
+import com.digitalpebble.storm.crawler.parse.ParseResult;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Restricts the text of the main document based on the text value of an Xpath
+ * expression (e.g. <div id='maincontent'>). This is useful when dealing with a
+ * known format to get rid of the boilerplate HTML code.
+ * **/
+public class ContentFilter implements ParseFilter {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(ContentFilter.class);
+
+    private XPath xpath = XPathFactory.newInstance().newXPath();
+    private List<XPathExpression> expressions;
+
+    @Override
+    public void filter(String URL, byte[] content, DocumentFragment doc,
+            ParseResult parse) {
+
+        ParseData pd = parse.get(URL);
+
+        // TODO determine how to restrict the expressions e.g. regexp on URL
+        // or value in metadata
+
+        // iterates on the expressions - stops at the first that matches
+        for (XPathExpression expression : expressions) {
+            try {
+                NodeList evalResults = (NodeList) expression.evaluate(doc,
+                        XPathConstants.NODESET);
+                if (evalResults.getLength() == 0) {
+                    continue;
+                }
+                StringBuffer newText = new StringBuffer();
+                for (int i = 0; i < evalResults.getLength(); i++) {
+                    Node node = evalResults.item(i);
+                    newText.append(node.getTextContent()).append("\n");
+                }
+
+                // give the doc its new text value
+                LOG.debug(
+                        "Restricted text for doc {}. Text size was {} and is now {}",
+                        URL, pd.getText().length(), newText.length());
+
+                pd.setText(newText.toString());
+
+                return;
+            } catch (XPathExpressionException e) {
+                LOG.error("Caught XPath expression", e);
+            }
+        }
+
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public void configure(Map stormConf, JsonNode filterParams) {
+        expressions = new ArrayList<XPathExpression>();
+        java.util.Iterator<Entry<String, JsonNode>> iter = filterParams
+                .fields();
+        while (iter.hasNext()) {
+            Entry<String, JsonNode> entry = iter.next();
+            String key = entry.getKey();
+            String xpathvalue = entry.getValue().asText();
+            try {
+                expressions.add(xpath.compile(xpathvalue));
+            } catch (XPathExpressionException e) {
+                throw new RuntimeException("Can't compile expression : "
+                        + xpathvalue, e);
+            }
+        }
+    }
+
+    @Override
+    public boolean needsDOM() {
+        return true;
+    }
+
+}

--- a/core/src/main/resources/parsefilters.json
+++ b/core/src/main/resources/parsefilters.json
@@ -7,6 +7,13 @@
         "canonical": "//*[@rel=\"canonical\"]/@href",
         "description": "//*[@name=\"description\"]/@content"
       }
+    },
+    {
+      "class": "com.digitalpebble.storm.crawler.parse.filter.ContentFilter",
+      "name": "ContentFilter",
+      "params": {
+        "pattern": "//DIV[@id=\"maincontent\"]"
+       }
     }
   ]
 }


### PR DESCRIPTION
Partly implements #146

This is a very simple initial version which takes a number of XPath expressions and rewrite the text content of the document based on the text covered by the first Xpath expression which matches.

We can refine it later so that the expressions are applied based on a URL pattern or key value pair in the metadata.  