### PR TITLE
Adding support for [SOLR] Write Spout, StatusUpdaterBolt and Indexer

### DIFF
--- a/external/solr/external-conf.yaml
+++ b/external/solr/external-conf.yaml
@@ -1,0 +1,24 @@
+# Solr indexer bolt
+solr.indexer.url: "http://localhost:8983/solr/collection1"
+solr.indexer.threads: 1
+solr.indexer.queue.size: 100
+solr.indexer.commit.size: 1
+
+# Solr spout and persistence bolt
+solr.status.url: "http://localhost:8983/solr/status"
+solr.status.threads: 1
+solr.status.queue.size: 100
+solr.status.commit.size: 1
+
+# Solr MetricsConsumer
+solr.metrics.url: "http://localhost:8983/solr/metrics"
+solr.metrics.threads: 1
+solr.metrics.queue.size: 100
+solr.metrics.commit.size: 1
+
+# For SolrCloud, this settings instead of solr.indexer.url
+#
+#   solr.indexer.zkhost: "http://localhost:9983/"
+#   solr.indexer.collection: collection1
+#
+# the same applies for the spout/persistence bolt and the metricsconsumer

--- a/external/solr/pom.xml
+++ b/external/solr/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.digitalpebble</groupId>
+        <artifactId>storm-crawler</artifactId>
+        <version>0.6-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>storm-crawler-solr</artifactId>
+    <packaging>jar</packaging>
+
+    <name>storm-crawler-solr</name>
+    <url>https://github.com/DigitalPebble/storm-crawler/external/solr</url>
+    <description>Solr resources for StormCrawler</description>
+
+    <properties>
+        <!-- dependency versions -->
+        <solr.version>5.1.0</solr.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                    </plugin>
+
+                    <!-- no test jar for storm-crawler-external -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>2.5</version>
+                        <executions>
+                            <execution>
+                                <id>attach-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.storm</groupId>
+            <artifactId>storm-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.digitalpebble</groupId>
+            <artifactId>storm-crawler-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-solrj</artifactId>
+            <version>${solr.version}</version>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/SolrConnection.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/SolrConnection.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.solr;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+
+import com.digitalpebble.storm.crawler.util.ConfUtils;
+
+@SuppressWarnings("serial")
+public class SolrConnection {
+
+    private SolrClient client;
+    private UpdateRequest request;
+
+    private SolrConnection(SolrClient sc, UpdateRequest r) {
+        client = sc;
+        request = r;
+    }
+
+    public SolrClient getClient() {
+        return client;
+    }
+
+    public UpdateRequest getRequest() {
+        return request;
+    }
+
+    public static SolrClient getClient(Map stormConf, String boltType) {
+        String zkHost = ConfUtils.getString(stormConf, "solr." + boltType
+                + ".zkhost", null);
+
+        String solrUrl = ConfUtils.getString(stormConf, "solr." + boltType
+                + ".url", "localhost");
+        String collection = ConfUtils.getString(stormConf, "solr." + boltType
+                + ".collection", null);
+        int threads = ConfUtils.getInt(stormConf, "solr." + boltType
+                + ".threads", 1);
+        int queueSize = ConfUtils.getInt(stormConf, "solr." + boltType
+                + ".queue.size", 250);
+
+        SolrClient client;
+
+        if (zkHost != null && zkHost.isEmpty() == false) {
+            client = new CloudSolrClient(zkHost);
+            ((CloudSolrClient) client).setDefaultCollection(collection);
+        } else {
+            // TODO This shouldn't be necessary once SOLR-7729 is fixed in solrj
+            if (collection != null) {
+                if (solrUrl.endsWith("/")) {
+                    solrUrl = solrUrl + collection;
+                } else {
+                    solrUrl = solrUrl + "/" + collection;
+                }
+            }
+
+            client = new ConcurrentUpdateSolrClient(solrUrl, queueSize, threads);
+        }
+
+        return client;
+    }
+
+    public static UpdateRequest getRequest(Map stormConf, String boltType) {
+        int commitWithin = ConfUtils.getInt(stormConf, "solr." + boltType
+                + ".commit.within", -1);
+
+        UpdateRequest request = new UpdateRequest();
+
+        if (commitWithin != -1) {
+            request.setCommitWithin(commitWithin);
+        }
+
+        return request;
+    }
+
+    public static SolrConnection getConnection(Map stormConf, String boltType) {
+        SolrClient client = getClient(stormConf, boltType);
+        UpdateRequest request = getRequest(stormConf, boltType);
+
+        return new SolrConnection(client, request);
+    }
+
+    public void close() throws IOException, SolrServerException {
+        if (client != null) {
+            client.commit();
+            client.close();
+        }
+    }
+}

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/SolrCrawlTopology.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/SolrCrawlTopology.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.solr;
+
+import backtype.storm.topology.TopologyBuilder;
+import backtype.storm.tuple.Fields;
+
+import com.digitalpebble.storm.crawler.ConfigurableTopology;
+import com.digitalpebble.storm.crawler.Constants;
+import com.digitalpebble.storm.crawler.bolt.FetcherBolt;
+import com.digitalpebble.storm.crawler.bolt.JSoupParserBolt;
+import com.digitalpebble.storm.crawler.bolt.SiteMapParserBolt;
+import com.digitalpebble.storm.crawler.bolt.StatusStreamBolt;
+import com.digitalpebble.storm.crawler.bolt.URLPartitionerBolt;
+import com.digitalpebble.storm.crawler.solr.bolt.IndexerBolt;
+import com.digitalpebble.storm.crawler.solr.metrics.MetricsConsumer;
+import com.digitalpebble.storm.crawler.solr.persistence.SolrSpout;
+import com.digitalpebble.storm.crawler.solr.persistence.StatusUpdaterBolt;
+
+/**
+ * Dummy topology to play with the spouts and bolts on Solr
+ */
+public class SolrCrawlTopology extends ConfigurableTopology {
+
+    public static void main(String[] args) throws Exception {
+        ConfigurableTopology.start(new SolrCrawlTopology(), args);
+    }
+
+    @Override
+    protected int run(String[] args) {
+        TopologyBuilder builder = new TopologyBuilder();
+
+        builder.setSpout("spout", new SolrSpout());
+
+        builder.setBolt("partitioner", new URLPartitionerBolt())
+                .shuffleGrouping("spout");
+
+        builder.setBolt("fetch", new FetcherBolt()).fieldsGrouping(
+                "partitioner", new Fields("key"));
+
+        builder.setBolt("sitemap", new SiteMapParserBolt())
+                .localOrShuffleGrouping("fetch");
+
+        builder.setBolt("parse", new JSoupParserBolt()).localOrShuffleGrouping(
+                "sitemap");
+
+        // consider that the process has been succesful regardless of what
+        // happens with the indexing
+        builder.setBolt("switch", new StatusStreamBolt())
+                .localOrShuffleGrouping("parse");
+
+        builder.setBolt("indexer", new IndexerBolt()).localOrShuffleGrouping(
+                "parse");
+
+        builder.setBolt("status", new StatusUpdaterBolt())
+                .localOrShuffleGrouping("switch", Constants.StatusStreamName)
+                .localOrShuffleGrouping("fetch", Constants.StatusStreamName)
+                .localOrShuffleGrouping("sitemap", Constants.StatusStreamName)
+                .localOrShuffleGrouping("parse", Constants.StatusStreamName);
+
+        conf.registerMetricsConsumer(MetricsConsumer.class);
+
+        return submit("crawl", conf, builder);
+    }
+}

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/bolt/IndexerBolt.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/bolt/IndexerBolt.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.solr.bolt;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.apache.solr.common.SolrInputDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.storm.crawler.Metadata;
+import com.digitalpebble.storm.crawler.indexing.AbstractIndexerBolt;
+import com.digitalpebble.storm.crawler.solr.SolrConnection;
+import com.digitalpebble.storm.crawler.util.ConfUtils;
+
+import backtype.storm.metric.api.MultiCountMetric;
+import backtype.storm.task.OutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.tuple.Tuple;
+
+public class IndexerBolt extends AbstractIndexerBolt {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(IndexerBolt.class);
+
+    private static final String BOLT_TYPE = "indexer";
+
+    private static final String SolrIndexCollection = "solr.indexer.collection";
+    private static final String SolrBatchSizeParam = "solr.indexer.commit.size";
+
+    private OutputCollector _collector;
+
+    private String collection;
+    private int batchSize;
+    private int counter = 0;
+
+    private MultiCountMetric eventCounter;
+
+    private SolrConnection connection;
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    public void prepare(Map conf, TopologyContext context,
+            OutputCollector collector) {
+        super.prepare(conf, context, collector);
+
+        _collector = collector;
+
+        collection = ConfUtils.getString(conf, IndexerBolt.SolrIndexCollection,
+                "collection1");
+        batchSize = ConfUtils.getInt(conf, IndexerBolt.SolrBatchSizeParam, 250);
+
+        try {
+            connection = SolrConnection.getConnection(conf, BOLT_TYPE);
+        } catch (Exception e) {
+            LOG.error("Can't connect to Solr: {}", e);
+            throw new RuntimeException(e);
+        }
+
+        this.eventCounter = context.registerMetric("SolrIndexerBolt",
+                new MultiCountMetric(), 10);
+    }
+
+    @Override
+    public void cleanup() {
+        if (connection != null)
+            try {
+                connection.close();
+            } catch (Exception e) {
+                LOG.error("Can't close connection to Solr: {}", e);
+            }
+    }
+
+    @Override
+    public void execute(Tuple tuple) {
+
+        String url = tuple.getStringByField("url");
+        Metadata metadata = (Metadata) tuple.getValueByField("metadata");
+        String text = tuple.getStringByField("text");
+
+        boolean keep = filterDocument(metadata);
+        if (!keep) {
+            eventCounter.scope("Filtered").incrBy(1);
+            _collector.ack(tuple);
+            return;
+        }
+
+        try {
+            SolrInputDocument doc = new SolrInputDocument();
+
+            // index text content
+            if (fieldNameForText() != null) {
+                doc.addField(fieldNameForText(), text);
+            }
+
+            // url
+            if (fieldNameForURL() != null) {
+                doc.addField(fieldNameForURL(), url);
+            }
+
+            // select which metadata to index
+            Map<String, String[]> keyVals = filterMetadata(metadata);
+
+            Iterator<String> iterator = keyVals.keySet().iterator();
+            while (iterator.hasNext()) {
+                String fieldName = iterator.next();
+                String[] values = keyVals.get(fieldName);
+                for (String value : values) {
+                    doc.addField(fieldName, value);
+                }
+            }
+
+            connection.getClient().add(doc);
+            counter++;
+
+            _collector.ack(tuple);
+
+            if (counter % batchSize == 0) {
+                connection.getClient().commit();
+                counter = 0;
+            }
+
+            eventCounter.scope("Indexed").incrBy(1);
+        } catch (Exception e) {
+            LOG.error("Send update request to {} failed due to {}", collection,
+                    e);
+            _collector.fail(tuple);
+        }
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer outputFieldsDeclarer) {
+    }
+}

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/metrics/MetricsConsumer.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/metrics/MetricsConsumer.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.solr.metrics;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.apache.solr.common.SolrInputDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import backtype.storm.metric.api.IMetricsConsumer;
+import backtype.storm.task.IErrorReporter;
+import backtype.storm.task.TopologyContext;
+
+import com.digitalpebble.storm.crawler.solr.SolrConnection;
+import com.digitalpebble.storm.crawler.util.ConfUtils;
+
+public class MetricsConsumer implements IMetricsConsumer {
+
+    private final Logger LOG = LoggerFactory.getLogger(MetricsConsumer.class);
+
+    private static final String BOLT_TYPE = "metrics";
+
+    private static final String SolrIndexCollection = "solr.metrics.collection";
+    private static final String SolrBatchSizeParam = "solr.metrics.batch.size";
+    private static final String SolrTTLParamName = "solr.metrics.ttl";
+    private static final String SolrTTLFieldParamName = "solr.metrics.ttl.field";
+
+    private String collection;
+    private String ttlField;
+    private String ttl;
+    private int batchSize;
+    private int counter = 0;
+
+    private SolrConnection connection;
+
+    @Override
+    public void prepare(Map stormConf, Object registrationArgument,
+            TopologyContext topologyContext, IErrorReporter errorReporter) {
+
+        collection = ConfUtils.getString(stormConf, SolrIndexCollection,
+                "metrics");
+        ttlField = ConfUtils.getString(stormConf, SolrTTLFieldParamName,
+                "__ttl__");
+        ttl = ConfUtils.getString(stormConf, SolrTTLParamName, null);
+        batchSize = ConfUtils.getInt(stormConf, SolrBatchSizeParam, 250);
+
+        try {
+            connection = SolrConnection.getConnection(stormConf, BOLT_TYPE);
+        } catch (Exception e) {
+            LOG.error("Can't connect to Solr: {}", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void handleDataPoints(TaskInfo taskInfo,
+            Collection<DataPoint> dataPoints) {
+
+        final Iterator<DataPoint> datapointsIterator = dataPoints.iterator();
+
+        while (datapointsIterator.hasNext()) {
+            final DataPoint dataPoint = datapointsIterator.next();
+
+            String name = dataPoint.name;
+
+            Date now = new Date();
+
+            if (dataPoint.value instanceof Map) {
+                Iterator<Map.Entry> keyValiter = ((Map) dataPoint.value)
+                        .entrySet().iterator();
+                while (keyValiter.hasNext()) {
+                    Map.Entry entry = keyValiter.next();
+                    if (!(entry.getValue() instanceof Number)) {
+                        LOG.error("Found data point value of class {}", entry
+                                .getValue().getClass().toString());
+                        continue;
+                    }
+                    Double value = ((Number) entry.getValue()).doubleValue();
+                    indexDataPoint(taskInfo, now, name + "." + entry.getKey(),
+                            value);
+                    counter++;
+                }
+            } else if (dataPoint.value instanceof Number) {
+                indexDataPoint(taskInfo, now, name,
+                        ((Number) dataPoint.value).doubleValue());
+                counter++;
+            } else {
+                LOG.error("Found data point value of class {}", dataPoint.value
+                        .getClass().toString());
+            }
+
+            try {
+                if (counter % batchSize == 0 || (!datapointsIterator.hasNext())) {
+                    connection.getClient().commit();
+                    counter = 0;
+                }
+            } catch (Exception e) {
+                LOG.error("Send metric to Solr failed due to", e);
+            }
+        }
+    }
+
+    private void indexDataPoint(TaskInfo taskInfo, Date timestamp, String name,
+            double value) {
+        try {
+            SolrInputDocument doc = new SolrInputDocument();
+
+            doc.addField("srcComponentId", taskInfo.srcComponentId);
+            doc.addField("srcTaskId", taskInfo.srcTaskId);
+            doc.addField("srcWorkerHost", taskInfo.srcWorkerHost);
+            doc.addField("srcWorkerPort", taskInfo.srcWorkerPort);
+            doc.addField("name", name);
+            doc.addField("value", value);
+            doc.addField("timestamp", timestamp);
+
+            if (this.ttl != null) {
+                doc.addField(ttlField, ttl);
+            }
+
+            connection.getClient().add(doc);
+        } catch (Exception e) {
+            LOG.error("Problem building a document to Solr", e);
+        }
+    }
+
+    @Override
+    public void cleanup() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (Exception e) {
+                LOG.error("Can't close connection to Solr", e);
+            }
+        }
+    }
+}

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
@@ -1,0 +1,227 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.solr.persistence;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.topology.base.BaseRichSpout;
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.Values;
+
+import com.digitalpebble.storm.crawler.Metadata;
+import com.digitalpebble.storm.crawler.solr.SolrConnection;
+import com.digitalpebble.storm.crawler.util.ConfUtils;
+import com.digitalpebble.storm.crawler.util.URLPartitioner;
+
+public class SolrSpout extends BaseRichSpout {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SolrSpout.class);
+
+    private static final String BOLT_TYPE = "status";
+
+    private static final String SolrIndexCollection = "solr.status.collection";
+    private static final String SolrMaxInflightParam = "solr.status.max.inflight.urls.per.bucket";
+
+    private String collection;
+
+    private SpoutOutputCollector _collector;
+
+    private SolrConnection connection;
+
+    private final int bufferSize = 100;
+
+    private Queue<Values> buffer = new LinkedList<Values>();
+
+    private int lastStartOffset = 0;
+
+    private URLPartitioner partitioner;
+
+    private int maxInFlightURLsPerBucket = -1;
+
+    /** Keeps a count of the URLs being processed per host/domain/IP **/
+    private Map<String, Integer> inFlightTracker = new HashMap<String, Integer>();
+
+    // URL / politeness bucket (hostname / domain etc...)
+    private Map<String, String> beingProcessed = new HashMap<String, String>();
+
+    @Override
+    public void open(Map stormConf, TopologyContext context,
+            SpoutOutputCollector collector) {
+        collection = ConfUtils.getString(stormConf, SolrIndexCollection,
+                "status");
+        maxInFlightURLsPerBucket = ConfUtils.getInt(stormConf,
+                SolrMaxInflightParam, 1);
+
+        try {
+            connection = SolrConnection.getConnection(stormConf, BOLT_TYPE);
+        } catch (Exception e) {
+            LOG.error("Can't connect to Solr: {}", e);
+            throw new RuntimeException(e);
+        }
+
+        partitioner = new URLPartitioner();
+        partitioner.configure(stormConf);
+
+        _collector = collector;
+    }
+
+    @Override
+    public void close() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (Exception e) {
+                LOG.error("Can't close connection to Solr: {}", e);
+            }
+        }
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        declarer.declare(new Fields("url", "metadata"));
+    }
+
+    @Override
+    public void nextTuple() {
+        // have anything in the buffer?
+        if (!buffer.isEmpty()) {
+            Values fields = buffer.remove();
+            String url = fields.get(0).toString();
+            Metadata metadata = (Metadata) fields.get(1);
+
+            String partitionKey = partitioner.getPartition(url, metadata);
+
+            // check whether we already have too tuples in flight for this
+            // partition key
+
+            if (maxInFlightURLsPerBucket != -1) {
+                Integer inflightforthiskey = inFlightTracker.get(partitionKey);
+                if (inflightforthiskey == null)
+                    inflightforthiskey = new Integer(0);
+                if (inflightforthiskey.intValue() >= maxInFlightURLsPerBucket) {
+                    // do it later! left it out of the queue for now
+                    return;
+                }
+                int currentCount = inflightforthiskey.intValue();
+                inFlightTracker.put(partitionKey, ++currentCount);
+            }
+
+            beingProcessed.put(url, partitionKey);
+
+            this._collector.emit(fields, url);
+            return;
+        }
+
+        // re-populate the buffer
+        populateBuffer();
+    }
+
+    private void populateBuffer() {
+        // TODO Sames as the ElasticSearchSpout?
+        // TODO Use the cursor feature?
+        // https://cwiki.apache.org/confluence/display/solr/Pagination+of+Results
+        SolrQuery query = new SolrQuery();
+
+        query.setQuery("*:*").addFilterQuery("nextFetchDate:[* TO NOW]")
+                .setStart(lastStartOffset).setRows(this.bufferSize);
+
+        try {
+            QueryResponse response = connection.getClient().query(query);
+
+            SolrDocumentList docs = response.getResults();
+
+            int numhits = docs.size();
+
+            // no more results?
+            if (numhits == 0)
+                lastStartOffset = 0;
+            else
+                lastStartOffset += numhits;
+
+            for (SolrDocument doc : docs) {
+                String url = (String) doc.get("url");
+
+                // is already being processed - skip it!
+                if (beingProcessed.containsKey(url))
+                    continue;
+
+                Metadata metadata = new Metadata();
+
+                String mdAsString = (String) doc.get("metadata");
+                // get the serialized metadata information
+                if (mdAsString != null) {
+                    // parse the string and generate the MD accordingly
+                    // url.path: http://www.lemonde.fr/
+                    // depth: 1
+                    String[] kvs = mdAsString.split("\n");
+                    for (String pair : kvs) {
+                        String[] kv = pair.split(": ");
+                        if (kv.length != 2) {
+                            LOG.info("Invalid key value pair {}", pair);
+                            continue;
+                        }
+                        metadata.addValue(kv[0], kv[1]);
+                    }
+                }
+
+                buffer.add(new Values(url, metadata));
+            }
+
+        } catch (Exception e) {
+            LOG.error("Can't query Solr: {}", e);
+        }
+    }
+
+    @Override
+    public void ack(Object msgId) {
+        super.ack(msgId);
+        String partitionKey = beingProcessed.remove(msgId);
+        decrementPartitionKey(partitionKey);
+    }
+
+    @Override
+    public void fail(Object msgId) {
+        super.fail(msgId);
+        String partitionKey = beingProcessed.remove(msgId);
+        decrementPartitionKey(partitionKey);
+    }
+
+    private void decrementPartitionKey(String partitionKey) {
+        if (partitionKey == null)
+            return;
+        Integer currentValue = this.inFlightTracker.get(partitionKey);
+        if (currentValue == null)
+            return;
+        int currentVal = currentValue.intValue();
+        currentVal--;
+        this.inFlightTracker.put(partitionKey, currentVal);
+    }
+}

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/StatusUpdaterBolt.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/StatusUpdaterBolt.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.solr.persistence;
+
+import java.util.Date;
+import java.util.Map;
+
+import org.apache.solr.common.SolrInputDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import backtype.storm.task.OutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.OutputFieldsDeclarer;
+
+import com.digitalpebble.storm.crawler.Metadata;
+import com.digitalpebble.storm.crawler.persistence.AbstractStatusUpdaterBolt;
+import com.digitalpebble.storm.crawler.persistence.Status;
+import com.digitalpebble.storm.crawler.solr.SolrConnection;
+import com.digitalpebble.storm.crawler.util.ConfUtils;
+
+public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(StatusUpdaterBolt.class);
+
+    private static final String BOLT_TYPE = "status";
+
+    private static final String SolrIndexCollection = "solr.status.collection";
+    private static final String SolrBatchSizeParam = "solr.status.commit.size";
+
+    private String collection;
+    private int batchSize;
+    private int counter = 0;
+
+    private SolrConnection connection;
+
+    @Override
+    public void prepare(Map stormConf, TopologyContext context,
+            OutputCollector collector) {
+
+        super.prepare(stormConf, context, collector);
+
+        collection = ConfUtils.getString(stormConf, SolrIndexCollection,
+                "status");
+        batchSize = ConfUtils.getInt(stormConf, SolrBatchSizeParam, 250);
+
+        try {
+            connection = SolrConnection.getConnection(stormConf, BOLT_TYPE);
+        } catch (Exception e) {
+            LOG.error("Can't connect to Solr: {}", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+    }
+
+    @Override
+    public void store(String url, Status status, Metadata metadata,
+            Date nextFetch) throws Exception {
+
+        SolrInputDocument doc = new SolrInputDocument();
+
+        doc.setField("url", url);
+        doc.setField("status", status);
+
+        doc.setField("metadata", metadata.toString());
+        doc.setField("nextFetchDate", nextFetch);
+
+        connection.getClient().add(doc);
+        counter++;
+
+        if (counter % batchSize == 0) {
+            try {
+                connection.getClient().commit();
+            } catch (Exception e) {
+                LOG.error("Updating status for {} failed due to: {}", url, e);
+            }
+
+            counter = 0;
+        }
+    }
+
+    @Override
+    public void cleanup() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (Exception e) {
+                LOG.error("Can't close connection to Solr: {}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Solr resources for StormCrawler, this add support for:
* IndexerBolt
* MetricsConsumer
* SolrSpout/StatusUpdaterBolt
* SolrConnection
* SolrCrawlTopology

The `SolrConnection` class have support for both the SolrCloud and a single Solr server by the ConcurrentUpdateSolrClient (CUSC). For using SolrCloud a `solr.TYPE.zkhost` needs to be specified instead of the `solr.TYPE.url`, also an additional parameter `solr.TYPE.collection` needs to be provided for the SolrCloud. I've detected a bug in the solr-solrj library regarding the use of the collection parameter in some methods (https://issues.apache.org/jira/browse/SOLR-7729), once this is fixed should simplify the code for the CUSC case, for now I recommend using the `url` parameter for the CUSC case to point directly to the solr collection that wants to be used(`external-conf.yaml`).

The `solr.metrics.commit.size` config option is basically a batch size to issue a hard commit against the server, this is not required (as is initialized in 250 by default) and could be leveraged by configuring autocommit in the server. 

The `MetricsConsumer` has support for automatic Document Expiration (TTL), a couple of additional parameters are provided in this class: `solr.metrics.ttl` and `solr.metrics.ttl.field` for configuring the Date language expression in the first case and the target field in the later. Of course this also needs some configuration in the Solr side. The date expression used in `solr.metrics.ttl` is not validated in the code. 

For `SolrCrawlTopology` to work at least an URL in the status collection is required to be present. 