### PR TITLE
Adding support for using the canonical URL in the IndexerBolts

### DIFF
--- a/core/src/test/java/com/digitalpebble/storm/crawler/indexer/BasicIndexingTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/indexer/BasicIndexingTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.indexer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import clojure.lang.PersistentVector;
+
+import com.digitalpebble.storm.crawler.Metadata;
+import com.digitalpebble.storm.crawler.indexing.AbstractIndexerBolt;
+
+public class BasicIndexingTest extends IndexerTester {
+
+    private static final String URL = "http://www.digitalpebble.com";
+
+    @Before
+    public void setupIndexerBolt() {
+        bolt = new DummyIndexer();
+        setupIndexerBolt(bolt);
+    }
+
+    @Test
+    public void testEmptyCanonicalURL() throws Exception {
+        Map config = new HashMap();
+        config.put(AbstractIndexerBolt.urlFieldParamName, "url");
+        config.put(AbstractIndexerBolt.canonicalMetadataParamName, "canonical");
+
+        prepareIndexerBolt(config);
+
+        index(URL, new Metadata());
+        Map<String, String> fields = ((DummyIndexer) bolt).returnFields();
+
+        Assert.assertEquals(
+                "The URL should be used if no canonical URL is found", URL,
+                fields.get("url"));
+    }
+
+    @Test
+    public void testCanonicalURL() throws Exception {
+        Map config = new HashMap();
+        config.put(AbstractIndexerBolt.urlFieldParamName, "url");
+        config.put(AbstractIndexerBolt.canonicalMetadataParamName, "canonical");
+
+        Metadata metadata = new Metadata();
+        metadata.setValue("canonical", "http://www.digitalpebble.com/");
+
+        prepareIndexerBolt(config);
+
+        index(URL, metadata);
+        Map<String, String> fields = ((DummyIndexer) bolt).returnFields();
+
+        Assert.assertEquals("Use the canonical URL if found",
+                "http://www.digitalpebble.com/", fields.get("url"));
+    }
+
+    @Test
+    public void testRelativeCanonicalURL() throws Exception {
+        Map config = new HashMap();
+        config.put(AbstractIndexerBolt.urlFieldParamName, "url");
+        config.put(AbstractIndexerBolt.canonicalMetadataParamName, "canonical");
+
+        Metadata metadata = new Metadata();
+        metadata.setValue("canonical", "/home");
+
+        prepareIndexerBolt(config);
+
+        index(URL, metadata);
+        Map<String, String> fields = ((DummyIndexer) bolt).returnFields();
+
+        Assert.assertEquals("Use the canonical URL if found",
+                "http://www.digitalpebble.com/home", fields.get("url"));
+    }
+
+    @Test
+    public void testBadCanonicalURL() throws Exception {
+        Map config = new HashMap();
+        config.put(AbstractIndexerBolt.urlFieldParamName, "url");
+        config.put(AbstractIndexerBolt.canonicalMetadataParamName, "canonical");
+
+        Metadata metadata = new Metadata();
+        metadata.setValue("canonical", "htp://www.digitalpebble.com/");
+
+        prepareIndexerBolt(config);
+
+        index(URL, metadata);
+        Map<String, String> fields = ((DummyIndexer) bolt).returnFields();
+
+        Assert.assertEquals(
+                "Use the default URL if a bad canonical URL is found",
+                "http://www.digitalpebble.com", fields.get("url"));
+    }
+
+    @Test
+    public void testOtherHostCanonicalURL() throws Exception {
+        Map config = new HashMap();
+        config.put(AbstractIndexerBolt.urlFieldParamName, "url");
+        config.put(AbstractIndexerBolt.canonicalMetadataParamName, "canonical");
+
+        Metadata metadata = new Metadata();
+        metadata.setValue("canonical", "http://www.google.com/");
+
+        prepareIndexerBolt(config);
+
+        index(URL, metadata);
+        Map<String, String> fields = ((DummyIndexer) bolt).returnFields();
+
+        Assert.assertEquals(
+                "Ignore if the canonical URL references other host",
+                "http://www.digitalpebble.com", fields.get("url"));
+    }
+
+    @Test
+    public void testMissingCanonicalParamConfiguration() throws Exception {
+        Map config = new HashMap();
+        config.put(AbstractIndexerBolt.urlFieldParamName, "url");
+
+        Metadata metadata = new Metadata();
+        metadata.setValue("canonical", "http://www.digitalpebble.com/");
+
+        prepareIndexerBolt(config);
+
+        index(URL, metadata);
+        Map<String, String> fields = ((DummyIndexer) bolt).returnFields();
+
+        Assert.assertEquals("Use the canonical URL if found",
+                "http://www.digitalpebble.com", fields.get("url"));
+    }
+
+    @Test
+    public void testFilterDocumentWithMetadata() throws Exception {
+        Map config = new HashMap();
+        config.put(AbstractIndexerBolt.urlFieldParamName, "url");
+        config.put(AbstractIndexerBolt.metadataFilterParamName, "key1=value1");
+
+        Metadata metadata = new Metadata();
+        metadata.setValue("key1", "value1");
+
+        prepareIndexerBolt(config);
+
+        index(URL, metadata);
+        Map<String, String> fields = ((DummyIndexer) bolt).returnFields();
+
+        Assert.assertEquals(
+                "The document must pass if the key/value is found in the metadata",
+                "http://www.digitalpebble.com", fields.get("url"));
+    }
+
+    @Test
+    public void testFilterDocumentWithoutMetadata() throws Exception {
+        Map config = new HashMap();
+        config.put(AbstractIndexerBolt.urlFieldParamName, "url");
+        config.put(AbstractIndexerBolt.metadataFilterParamName, "key1=value1");
+
+        prepareIndexerBolt(config);
+
+        index(URL, new Metadata());
+        Map<String, String> fields = ((DummyIndexer) bolt).returnFields();
+
+        Assert.assertEquals(
+                "The document must not pass if the key/value is not found in the metadata",
+                0, fields.size());
+    }
+
+    @Test
+    public void testFilterMetadata() throws Exception {
+        Map config = new HashMap();
+        config.put(AbstractIndexerBolt.urlFieldParamName, "url");
+
+        final PersistentVector vector = PersistentVector.create(
+                "parse.title=title", "parse.keywords=keywords");
+
+        config.put(AbstractIndexerBolt.metadata2fieldParamName, vector);
+
+        prepareIndexerBolt(config);
+
+        Metadata metadata = new Metadata();
+        metadata.setValue("parse.title", "This is the title");
+        metadata.setValue("parse.keywords", "keyword1, keyword2, keyword3");
+        metadata.setValue("parse.description", "This is the description");
+
+        index(URL, metadata);
+        Map<String, String> fields = ((DummyIndexer) bolt).returnFields();
+
+        Assert.assertArrayEquals(
+                "Only the mapped metadata attributes should be indexed",
+                new String[] { "title", "keywords", "url" }, fields.keySet()
+                        .toArray());
+    }
+
+    @Test
+    public void testEmptyFilterMetadata() throws Exception {
+        Map config = new HashMap();
+        config.put(AbstractIndexerBolt.urlFieldParamName, "url");
+
+        prepareIndexerBolt(config);
+
+        Metadata metadata = new Metadata();
+        metadata.setValue("parse.title", "This is the title");
+        metadata.setValue("parse.keywords", "keyword1, keyword2, keyword3");
+        metadata.setValue("parse.description", "This is the description");
+
+        index(URL, metadata);
+        Map<String, String> fields = ((DummyIndexer) bolt).returnFields();
+
+        Assert.assertArrayEquals(
+                "Index only the URL if no mapping is provided",
+                new String[] { "url" }, fields.keySet().toArray());
+    }
+}

--- a/core/src/test/java/com/digitalpebble/storm/crawler/indexer/IndexerTester.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/indexer/IndexerTester.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.storm.crawler.indexer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.After;
+
+import backtype.storm.task.OutputCollector;
+import backtype.storm.tuple.Tuple;
+
+import com.digitalpebble.storm.crawler.Metadata;
+import com.digitalpebble.storm.crawler.TestOutputCollector;
+import com.digitalpebble.storm.crawler.TestUtil;
+import com.digitalpebble.storm.crawler.indexing.AbstractIndexerBolt;
+
+public class IndexerTester {
+    AbstractIndexerBolt bolt;
+    protected TestOutputCollector output;
+
+    protected void setupIndexerBolt(AbstractIndexerBolt bolt) {
+        this.bolt = bolt;
+        output = new TestOutputCollector();
+    }
+
+    @After
+    public void cleanupBolt() {
+        if (bolt != null) {
+            bolt.cleanup();
+        }
+        output = null;
+    }
+
+    protected void prepareIndexerBolt(Map config) {
+        bolt.prepare(config, TestUtil.getMockedTopologyContext(),
+                new OutputCollector(output));
+    }
+
+    protected void index(String url, Metadata metadata) {
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getStringByField("url")).thenReturn(url);
+        when(tuple.getValueByField("metadata")).thenReturn(metadata);
+        bolt.execute(tuple);
+    }
+
+    protected void index(String url, String content, Metadata metadata)
+            throws IOException {
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getBinaryByField("content")).thenReturn(content.getBytes());
+        when(tuple.getStringByField("url")).thenReturn(url);
+        when(tuple.getValueByField("metadata")).thenReturn(metadata);
+        bolt.execute(tuple);
+    }
+}

--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/bolt/IndexerBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/bolt/IndexerBolt.java
@@ -100,7 +100,7 @@ public class IndexerBolt extends AbstractIndexerBolt {
     @Override
     public void execute(Tuple tuple) {
 
-        String url = tuple.getStringByField("url");
+        String url = valueForURL(tuple);
         Metadata metadata = (Metadata) tuple.getValueByField("metadata");
         String text = tuple.getStringByField("text");
 

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/bolt/IndexerBolt.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/bolt/IndexerBolt.java
@@ -91,7 +91,7 @@ public class IndexerBolt extends AbstractIndexerBolt {
     @Override
     public void execute(Tuple tuple) {
 
-        String url = tuple.getStringByField("url");
+        String url = valueForURL(tuple);
         Metadata metadata = (Metadata) tuple.getValueByField("metadata");
         String text = tuple.getStringByField("text");
 


### PR DESCRIPTION
This address the https://github.com/DigitalPebble/storm-crawler/issues/149 issue which provides a method in the `AbstractIndexerBolt` that returns the right URL to be indexed. In this case if a canonical URL is found its used instead of the original URL. Some sanity checks are done:
* The URL is resolved to avoid relative URLs
* The host of the canonical URL is compared with the host of the original URL and only used if is the same.

I've also updated the `StdOutIndexer` and the `IndexerBolt` of both Solr and Elasticsearch.

I wanted to test the logic in the new method so I've added a basic testing framework very similar to `com.digitalpebble.storm.crawler.parse` to easy the task. I've also created a `DummyIndexer` that is used to test the output, since the IndexerBolts are the end of the chain. I wrote tests for the canonical URL and also some scenarios for document and metadata filtering. This tests are independent of the parsing tests.

I don't think this is suitable for testing Solr or Elasticsearch modules, mainly because each of the `IndexerBolts` of this "framework" interacts with a Solr/ES backend (outside of Storm Crawler) and for this cases using something like solr-test-framework (for Solr) makes more sense. 

Would love some feedback about this.