### PR TITLE
Adding support for field collapsing in the Solr Spout

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/JSoupParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/JSoupParserBolt.java
@@ -157,10 +157,15 @@ public class JSoupParserBolt extends BaseRichBolt {
                 CT_OK = true;
             }
         }
+        // simply ignore cases where the content type has not been set
         // TODO sniff content with Tika?
+        else {
+            CT_OK = true;
+        }
 
         if (!CT_OK) {
-            String errorMessage = "Exception content-type" + httpCT;
+            String errorMessage = "Exception content-type " + httpCT + " for "
+                    + url;
             RuntimeException e = new RuntimeException(errorMessage);
             handleException(url, e, metadata, tuple, "content-type checking",
                     errorMessage);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/JSoupParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/JSoupParserBolt.java
@@ -52,9 +52,9 @@ import com.digitalpebble.storm.crawler.filtering.URLFilters;
 import com.digitalpebble.storm.crawler.parse.JSoupDOMBuilder;
 import com.digitalpebble.storm.crawler.parse.Outlink;
 import com.digitalpebble.storm.crawler.parse.ParseData;
-import com.digitalpebble.storm.crawler.parse.ParseResult;
 import com.digitalpebble.storm.crawler.parse.ParseFilter;
 import com.digitalpebble.storm.crawler.parse.ParseFilters;
+import com.digitalpebble.storm.crawler.parse.ParseResult;
 import com.digitalpebble.storm.crawler.persistence.Status;
 import com.digitalpebble.storm.crawler.protocol.HttpHeaders;
 import com.digitalpebble.storm.crawler.util.ConfUtils;
@@ -148,6 +148,25 @@ public class JSoupParserBolt extends BaseRichBolt {
         String url = tuple.getStringByField("url");
         Metadata metadata = (Metadata) tuple.getValueByField("metadata");
 
+        // check that its content type is HTML
+        // look at value found in HTTP headers
+        boolean CT_OK = false;
+        String httpCT = metadata.getFirstValue(HttpHeaders.CONTENT_TYPE);
+        if (StringUtils.isNotBlank(httpCT)) {
+            if (httpCT.toLowerCase().contains("html")) {
+                CT_OK = true;
+            }
+        }
+        // TODO sniff content with Tika?
+
+        if (!CT_OK) {
+            String errorMessage = "Exception content-type" + httpCT;
+            RuntimeException e = new RuntimeException(errorMessage);
+            handleException(url, e, metadata, tuple, "content-type checking",
+                    errorMessage);
+            return;
+        }
+
         LOG.info("Parsing : starting {}", url);
 
         long start = System.currentTimeMillis();
@@ -162,6 +181,7 @@ public class JSoupParserBolt extends BaseRichBolt {
         DocumentFragment fragment;
         try (ByteArrayInputStream bais = new ByteArrayInputStream(content)) {
             org.jsoup.nodes.Document jsoupDoc = Jsoup.parse(bais, charset, url);
+
             fragment = JSoupDOMBuilder.jsoup2HTML(jsoupDoc);
 
             // extracts the robots directives from the meta tags
@@ -219,20 +239,8 @@ public class JSoupParserBolt extends BaseRichBolt {
 
         } catch (Throwable e) {
             String errorMessage = "Exception while parsing " + url + ": " + e;
-            LOG.error(errorMessage);
-            // send to status stream in case another component wants to update
-            // its status
-            metadata.setValue(Constants.STATUS_ERROR_SOURCE, "content parsing");
-            metadata.setValue(Constants.STATUS_ERROR_MESSAGE, errorMessage);
-            collector.emit(StatusStreamName, tuple, new Values(url, metadata,
-                    Status.ERROR));
-            collector.ack(tuple);
-            // Increment metric that is context specific
-            eventCounter.scope(
-                    "error_content_parsing_" + e.getClass().getSimpleName())
-                    .incrBy(1);
-            // Increment general metric
-            eventCounter.scope("parse exception").incrBy(1);
+            handleException(url, e, metadata, tuple, "content parsing",
+                    errorMessage);
             return;
         }
 
@@ -258,21 +266,11 @@ public class JSoupParserBolt extends BaseRichBolt {
         try {
             parseFilters.filter(url, content, fragment, parse);
         } catch (RuntimeException e) {
+
             String errorMessage = "Exception while running parse filters on "
                     + url + ": " + e;
-            LOG.error(errorMessage);
-            metadata.setValue(Constants.STATUS_ERROR_SOURCE,
-                    "content filtering");
-            metadata.setValue(Constants.STATUS_ERROR_MESSAGE, errorMessage);
-            collector.emit(StatusStreamName, tuple, new Values(url, metadata,
-                    Status.ERROR));
-            collector.ack(tuple);
-            // Increment metric that is context specific
-            eventCounter.scope(
-                    "error_content_filtering_" + e.getClass().getSimpleName())
-                    .incrBy(1);
-            // Increment general metric
-            eventCounter.scope("parse exception").incrBy(1);
+            handleException(url, e, metadata, tuple, "content filtering",
+                    errorMessage);
             return;
         }
 
@@ -298,6 +296,23 @@ public class JSoupParserBolt extends BaseRichBolt {
 
         collector.ack(tuple);
         eventCounter.scope("tuple_success").incr();
+    }
+
+    private void handleException(String url, Throwable e, Metadata metadata,
+            Tuple tuple, String errorSource, String errorMessage) {
+        LOG.error(errorMessage);
+        // send to status stream in case another component wants to update
+        // its status
+        metadata.setValue(Constants.STATUS_ERROR_SOURCE, errorSource);
+        metadata.setValue(Constants.STATUS_ERROR_MESSAGE, errorMessage);
+        collector.emit(StatusStreamName, tuple, new Values(url, metadata,
+                Status.ERROR));
+        collector.ack(tuple);
+        // Increment metric that is context specific
+        String s = "error_" + errorSource.replaceAll(" ", "_") + "_";
+        eventCounter.scope(s + e.getClass().getSimpleName()).incrBy(1);
+        // Increment general metric
+        eventCounter.scope("parse exception").incrBy(1);
     }
 
     @Override

--- a/external/solr/README.md
+++ b/external/solr/README.md
@@ -55,12 +55,32 @@ For configuring the connection with the Solr server, the following parameters ar
 
 ## Additional configuration options
 
+#### MetricsConsumer
+
 In the case of the `MetricsConsumer` class a couple of additional configuration parameters are provided to use the Document Expiration feature available in Solr since version 4.8.
 
 * `solr.metrics.ttl`: [Date expression](https://cwiki.apache.org/confluence/display/solr/Working+with+Dates) to specify when the document should expire.
 * `solr.metrics.ttl.field`: Field to be used to specify the [date expression](https://cwiki.apache.org/confluence/display/solr/Working+with+Dates) that defines when the document should expire.
 
 *Note: The date expression specified in the `solr.metrics.ttl` parameter is not validated. And to use this feature some changes in the Solr configuration must be done.*
+
+#### SolrSpout
+
+For the `SolrSpout` class a couple of additional configuration parameters are available to guarantee some *diversity* in the URLs fetched from Solr, in the case that you want to have better coverage of your URLs. This is done using the [collapse and expand](https://cwiki.apache.org/confluence/display/solr/Collapse+and+Expand+Results) feature available in Solr.
+
+* `solr.status.bucket.field`: Field to be used to collapse the documents.
+* `solr.status.bucket.maxsize`: Amount of documents to return for each *bucket*.
+
+For instance if you are crawling URLs from different domains, perhaps is of your interest to *balance* the amount of URLs to be processed from each domain, instead of crawling all the available URLs from one domain and then the other.
+
+For this scenario you'll want to collapse on the `host` field (that already is indexed by the `StatusUpdaterBolt`) and perhaps you just want to crawl 100 URLs per domain. For this case is enough to add this to your configuration:
+
+```yaml
+solr.status.bucket.field: host
+solr.status.bucket.maxsize: 100
+```
+
+This feature can be combined with the [partition features](https://github.com/DigitalPebble/storm-crawler/wiki/Configuration#fetching-and-partitioning) provided by storm-crawler to balance the crawling process and not just the URL coverage.
 
 ## Using SolrCloud
 

--- a/external/solr/pom.xml
+++ b/external/solr/pom.xml
@@ -1,90 +1,112 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>com.digitalpebble</groupId>
-        <artifactId>storm-crawler</artifactId>
-        <version>0.6-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
+	<parent>
+		<groupId>com.digitalpebble</groupId>
+		<artifactId>storm-crawler</artifactId>
+		<version>0.6-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 
-    <artifactId>storm-crawler-solr</artifactId>
-    <packaging>jar</packaging>
+	<artifactId>storm-crawler-solr</artifactId>
+	<packaging>jar</packaging>
 
-    <name>storm-crawler-solr</name>
-    <url>https://github.com/DigitalPebble/storm-crawler/external/solr</url>
-    <description>Solr resources for StormCrawler</description>
+	<name>storm-crawler-solr</name>
+	<url>https://github.com/DigitalPebble/storm-crawler/external/solr</url>
+	<description>Solr resources for StormCrawler</description>
 
-    <properties>
-        <!-- dependency versions -->
-        <solr.version>5.1.0</solr.version>
-    </properties>
+	<properties>
+		<!-- dependency versions -->
+		<solr.version>5.1.0</solr.version>
+	</properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
 
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                    </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>1.3.3</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
-                    <!-- no test jar for storm-crawler-external -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <version>2.5</version>
-                        <executions>
-                            <execution>
-                                <id>attach-test</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+					</plugin>
 
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+					<!-- no test jar for storm-crawler-external -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-jar-plugin</artifactId>
+						<version>2.5</version>
+						<executions>
+							<execution>
+								<id>attach-test</id>
+								<phase>none</phase>
+							</execution>
+						</executions>
+					</plugin>
 
-    <dependencies>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
-        <dependency>
-            <groupId>org.apache.storm</groupId>
-            <artifactId>storm-core</artifactId>
-        </dependency>
+	<dependencies>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.storm</groupId>
+			<artifactId>storm-core</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>com.digitalpebble</groupId>
-            <artifactId>storm-crawler-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.apache.solr</groupId>
-            <artifactId>solr-solrj</artifactId>
-            <version>${solr.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>com.digitalpebble</groupId>
+			<artifactId>storm-crawler-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
-    </dependencies>
+		<dependency>
+			<groupId>org.apache.solr</groupId>
+			<artifactId>solr-solrj</artifactId>
+			<version>${solr.version}</version>
+		</dependency>
+
+	</dependencies>
 </project>

--- a/external/solr/solr-conf.yaml
+++ b/external/solr/solr-conf.yaml
@@ -9,6 +9,7 @@ solr.status.url: "http://localhost:8983/solr/status"
 solr.status.threads: 1
 solr.status.queue.size: 100
 solr.status.commit.size: 1
+solr.status.bucket.field: host
 
 # Solr MetricsConsumer
 solr.metrics.url: "http://localhost:8983/solr/metrics"

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/metrics/MetricsConsumer.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/metrics/MetricsConsumer.java
@@ -40,7 +40,7 @@ public class MetricsConsumer implements IMetricsConsumer {
     private static final String BOLT_TYPE = "metrics";
 
     private static final String SolrIndexCollection = "solr.metrics.collection";
-    private static final String SolrBatchSizeParam = "solr.metrics.batch.size";
+    private static final String SolrBatchSizeParam = "solr.metrics.commit.size";
     private static final String SolrTTLParamName = "solr.metrics.ttl";
     private static final String SolrTTLFieldParamName = "solr.metrics.ttl.field";
 

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/StatusUpdaterBolt.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/StatusUpdaterBolt.java
@@ -24,15 +24,16 @@ import org.apache.solr.common.SolrInputDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import backtype.storm.task.OutputCollector;
-import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.OutputFieldsDeclarer;
-
 import com.digitalpebble.storm.crawler.Metadata;
 import com.digitalpebble.storm.crawler.persistence.AbstractStatusUpdaterBolt;
 import com.digitalpebble.storm.crawler.persistence.Status;
 import com.digitalpebble.storm.crawler.solr.SolrConnection;
 import com.digitalpebble.storm.crawler.util.ConfUtils;
+import com.digitalpebble.storm.crawler.util.URLUtil;
+
+import backtype.storm.task.OutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.OutputFieldsDeclarer;
 
 public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
@@ -79,6 +80,9 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
         SolrInputDocument doc = new SolrInputDocument();
 
         doc.setField("url", url);
+
+        doc.setField("host", URLUtil.getHost(url));
+
         doc.setField("status", status);
 
         doc.setField("metadata", metadata.toString());

--- a/external/tika/pom.xml
+++ b/external/tika/pom.xml
@@ -16,7 +16,7 @@
 	<description>Tika-based parser bolt for StormCrawler</description>
 
 	<properties>
-		<tika-parsers.version>1.8</tika-parsers.version>
+		<tika-parsers.version>1.9</tika-parsers.version>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>pom</packaging>
 
 	<name>storm-crawler</name>
-	<description>A collection of resources for building low-latency, large scale web crawlers on Storm.</description>
+	<description>A collection of resources for building low-latency, scalable web crawlers on Apache Storm.</description>
 	<url>https://github.com/DigitalPebble/storm-crawler</url>
 
 	<licenses>


### PR DESCRIPTION
A couple of parameters were added to handle diversity Issue #156: 

* `solr.status.diversity.field.name`: Indicates the name of the field to be collapsed on.
* `solr.status.diversity.field.bucket`: Indicates the maximum bucket size of each expanded group. 

One good example to add to the wiki/documentation around this is to use the `status` field, which can have a small set of values, so it will be easy to explain and is a field that is populated by default, and provide a good balance between each type of URLs. 

I'm going to make other commit adding some explanation to the README file in the Solr module, if thats ok.

A better param name is welcome :smile: 

Also this PR fix a small typo in a parameter configuration of the `MetricsConsumer` class.