### PR TITLE
If each url is unique per host, the Solr spout is locked

### DIFF
--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
@@ -172,24 +172,27 @@ public class SolrSpout extends BaseRichSpout {
             QueryResponse response = connection.getClient().query(query);
             SolrDocumentList docs = new SolrDocumentList();
 
+            int numhits = response.getResults().size();
+      
             if (StringUtils.isNotBlank(diversityField)) {
-                Map<String, SolrDocumentList> expandedResults = response
-                        .getExpandedResults();
+              //get expand result
+              Map<String, SolrDocumentList> expandedResults = response
+                      .getExpandedResults();
 
-                for (String key : expandedResults.keySet()) {
-                    docs.addAll(expandedResults.get(key));
-                }
+              for (SolrDocument doc : response.getResults()) {
+                String df = (String) doc.get(diversityField);
 
-                // if all the urls are unique
-                // the expand result is empty
-                if (expandedResults.isEmpty()) {
-                  docs = response.getResults();
+                //is there multiple urls for this host
+                SolrDocumentList dfList = expandedResults.get(df);
+                if (dfList != null) {
+                  docs.addAll(dfList);
+                } else {
+                  docs.add(doc);
                 }
+              }
             } else {
-                docs = response.getResults();
+              docs = response.getResults();
             }
-
-            int numhits = docs.size();
 
             // no more results?
             if (numhits == 0)

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
@@ -180,11 +180,6 @@ public class SolrSpout extends BaseRichSpout {
                     docs.addAll(expandedResults.get(key));
                 }
 
-                // if all the urls are unique
-                // the expand result is empty
-                if (expandedResults.isEmpty()) {
-                  docs = response.getResults();
-                }
             } else {
                 docs = response.getResults();
             }

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
@@ -172,27 +172,24 @@ public class SolrSpout extends BaseRichSpout {
             QueryResponse response = connection.getClient().query(query);
             SolrDocumentList docs = new SolrDocumentList();
 
-            int numhits = response.getResults().size();
-      
             if (StringUtils.isNotBlank(diversityField)) {
-              //get expand result
-              Map<String, SolrDocumentList> expandedResults = response
-                      .getExpandedResults();
+                Map<String, SolrDocumentList> expandedResults = response
+                        .getExpandedResults();
 
-              for (SolrDocument doc : response.getResults()) {
-                String df = (String) doc.get(diversityField);
-
-                //is there multiple urls for this host
-                SolrDocumentList dfList = expandedResults.get(df);
-                if (dfList != null) {
-                  docs.addAll(dfList);
-                } else {
-                  docs.add(doc);
+                for (String key : expandedResults.keySet()) {
+                    docs.addAll(expandedResults.get(key));
                 }
-              }
+
+                // if all the urls are unique
+                // the expand result is empty
+                if (expandedResults.isEmpty()) {
+                  docs = response.getResults();
+                }
             } else {
-              docs = response.getResults();
+                docs = response.getResults();
             }
+
+            int numhits = docs.size();
 
             // no more results?
             if (numhits == 0)

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
@@ -180,6 +180,11 @@ public class SolrSpout extends BaseRichSpout {
                     docs.addAll(expandedResults.get(key));
                 }
 
+                // if all the urls are unique
+                // the expand result is empty
+                if (expandedResults.isEmpty()) {
+                  docs = response.getResults();
+                }
             } else {
                 docs = response.getResults();
             }

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
@@ -172,10 +172,17 @@ public class SolrSpout extends BaseRichSpout {
             QueryResponse response = connection.getClient().query(query);
             SolrDocumentList docs = new SolrDocumentList();
 
+            int numhits = response.getResults().size();
+            
             if (StringUtils.isNotBlank(diversityField)) {
                 Map<String, SolrDocumentList> expandedResults = response
                         .getExpandedResults();
 
+                //urls of the main result are not included in the collapsed result
+                //add urls of the main collapsed result
+                docs.addAll(response.getResults());
+                
+                //add urls of the expanded result if any
                 for (String key : expandedResults.keySet()) {
                     docs.addAll(expandedResults.get(key));
                 }
@@ -183,8 +190,6 @@ public class SolrSpout extends BaseRichSpout {
             } else {
                 docs = response.getResults();
             }
-
-            int numhits = docs.size();
 
             // no more results?
             if (numhits == 0)


### PR DESCRIPTION
The expand result of Solr is empty if each group contains only one document.
That causes a lock in the Solr spout.