### PR TITLE
loadConf() already calls putAll()

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/ConfigurableTopology.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/ConfigurableTopology.java
@@ -89,7 +89,7 @@ public abstract class ConfigurableTopology {
                 iter.remove();
                 String resource = iter.next();
                 try {
-                    conf.putAll(ConfUtils.loadConf(resource));
+                    ConfUtils.loadConf(resource, conf);
                 } catch (FileNotFoundException e) {
                     throw new RuntimeException("File not found : " + resource);
                 }

--- a/core/src/main/java/com/digitalpebble/storm/crawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/protocol/httpclient/HttpProtocol.java
@@ -177,10 +177,10 @@ public class HttpProtocol extends AbstractHttpProtocol implements
 
     public static void main(String args[]) throws Exception {
         HttpProtocol protocol = new HttpProtocol();
+        Config conf = new Config();
 
         String url = args[0];
-        Config conf = ConfUtils.loadConf(args[1]);
-
+        ConfUtils.loadConf(args[1], conf);
         protocol.configure(conf);
 
         if (!protocol.skipRobots) {

--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/ConfUtils.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/ConfUtils.java
@@ -67,8 +67,8 @@ public class ConfUtils {
         return (String) Utils.get(conf, key, defaultValue);
     }
 
-    public static Config loadConf(String resource) throws FileNotFoundException {
-        Config conf = new Config();
+    public static Config loadConf(String resource, Config conf)
+            throws FileNotFoundException {
         Yaml yaml = new Yaml();
         Map ret = (Map) yaml.load(new InputStreamReader(new FileInputStream(
                 resource), Charset.defaultCharset()));

--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/MetadataTransfer.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/MetadataTransfer.java
@@ -155,11 +155,11 @@ public class MetadataTransfer {
     public Metadata filter(Metadata metadata) {
         Metadata md = new Metadata();
 
-        //no metadata ?
+        // no metadata ?
         if (metadata == null) {
-          return md;
+            return md;
         }
-                
+
         List<String> metadataToKeep = new ArrayList<String>(mdToKeep.size());
         metadataToKeep.addAll(mdToKeep);
 


### PR DESCRIPTION
At the end of ConfUtils.loadConf(), you either have a (Config + yaml options) Map or a Config Map. Either way, there is no need for a second putAll().