### PR TITLE
Revert "Correction of a NPE in metadata transfert function"

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/MetadataTransfer.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/MetadataTransfer.java
@@ -155,11 +155,6 @@ public class MetadataTransfer {
     public Metadata filter(Metadata metadata) {
         Metadata md = new Metadata();
 
-        //no metadata ?
-        if (metadata == null) {
-          return md;
-        }
-                
         List<String> metadataToKeep = new ArrayList<String>(mdToKeep.size());
         metadataToKeep.addAll(mdToKeep);
 


### PR DESCRIPTION
Reverts DigitalPebble/storm-crawler#169

Better to know that a Metadata is null than silently ignore it