### PR TITLE
Fixing issue with unique URL per host causing the Solr spout to lockup 

### DIFF
--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
@@ -173,6 +173,9 @@ public class SolrSpout extends BaseRichSpout {
             SolrDocumentList docs = new SolrDocumentList();
 
             if (StringUtils.isNotBlank(diversityField)) {
+                // Add the main documents collapsed by the CollapsingQParser plugin
+                docs.addAll(response.getResults());
+
                 Map<String, SolrDocumentList> expandedResults = response
                         .getExpandedResults();
 
@@ -184,7 +187,7 @@ public class SolrSpout extends BaseRichSpout {
                 docs = response.getResults();
             }
 
-            int numhits = docs.size();
+            int numhits = response.getResults().size();
 
             // no more results?
             if (numhits == 0)


### PR DESCRIPTION
Merge the main result set with the expanded result set when a diversity field is used.
Use the size of the main results section for pagination