### PR TITLE
Initialize the metadata in the StringTabScheme, should never be null

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/StringTabScheme.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/StringTabScheme.java
@@ -68,6 +68,9 @@ public class StringTabScheme implements Scheme {
             metadata.addValue(key, value);
         }
 
+        if (metadata == null)
+            metadata = new Metadata();
+        
         if (withStatus != null)
             return new Values(url, metadata, withStatus);
 


### PR DESCRIPTION
This is a fix for the issue #168