### PR TITLE
[External][Solr] The Solr storage should use 'autoSoftCommit' and 'autoCommit'

### DIFF
--- a/external/solr/solr-conf.yaml
+++ b/external/solr/solr-conf.yaml
@@ -1,21 +1,12 @@
 # Solr indexer bolt
 solr.indexer.url: "http://localhost:8983/solr/collection1"
-solr.indexer.threads: 1
-solr.indexer.queue.size: 100
-solr.indexer.commit.size: 1
 
 # Solr spout and persistence bolt
 solr.status.url: "http://localhost:8983/solr/status"
-solr.status.threads: 1
-solr.status.queue.size: 100
-solr.status.commit.size: 1
 solr.status.bucket.field: host
 
 # Solr MetricsConsumer
 solr.metrics.url: "http://localhost:8983/solr/metrics"
-solr.metrics.threads: 1
-solr.metrics.queue.size: 100
-solr.metrics.commit.size: 1
 
 # For SolrCloud, this settings instead of solr.indexer.url
 #

--- a/external/solr/solr-example-cores/metrics/conf/solrconfig.xml
+++ b/external/solr/solr-example-cores/metrics/conf/solrconfig.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
-	<luceneMatchVersion>LUCENE_5_1</luceneMatchVersion>
+	<luceneMatchVersion>5.3.0</luceneMatchVersion>
 	<requestDispatcher handleSelect="false">
 		<httpCaching never304="true" />
 	</requestDispatcher>
+
+	<updateHandler class="solr.DirectUpdateHandler2">
+		<autoCommit>
+			<maxDocs>10000</maxDocs>
+			<maxTime>10000</maxTime>
+			<openSearcher>false</openSearcher>
+		</autoCommit>
+		<autoSoftCommit>
+			<maxTime>1000</maxTime>
+		</autoSoftCommit>
+	</updateHandler>
 
 	<updateRequestProcessorChain name="uuid">  
 	   <processor class="solr.UUIDUpdateProcessorFactory">  

--- a/external/solr/solr-example-cores/parse/conf/solrconfig.xml
+++ b/external/solr/solr-example-cores/parse/conf/solrconfig.xml
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
-	<luceneMatchVersion>LUCENE_5_1</luceneMatchVersion>
+	<luceneMatchVersion>5.3.0</luceneMatchVersion>
 	<requestDispatcher handleSelect="false">
 		<httpCaching never304="true" />
 	</requestDispatcher>
+	<updateHandler class="solr.DirectUpdateHandler2">
+		<autoCommit>
+			<maxDocs>10000</maxDocs>
+			<maxTime>10000</maxTime>
+			<openSearcher>false</openSearcher>
+		</autoCommit>
+		<autoSoftCommit>
+			<maxTime>1000</maxTime>
+		</autoSoftCommit>
+	</updateHandler>
 	<requestHandler name="/select"   class="solr.SearchHandler" />
 	<requestHandler name="/update" class="solr.UpdateRequestHandler" />
 	<requestHandler name="/admin" class="solr.admin.AdminHandlers" />

--- a/external/solr/solr-example-cores/status/conf/solrconfig.xml
+++ b/external/solr/solr-example-cores/status/conf/solrconfig.xml
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
-	<luceneMatchVersion>LUCENE_5_1</luceneMatchVersion>
+	<luceneMatchVersion>5.3.0</luceneMatchVersion>
 	<requestDispatcher handleSelect="false">
 		<httpCaching never304="true" />
 	</requestDispatcher>
+	<updateHandler class="solr.DirectUpdateHandler2">
+		<autoCommit>
+			<maxDocs>10000</maxDocs>
+			<maxTime>10000</maxTime>
+			<openSearcher>false</openSearcher>
+		</autoCommit>
+		<autoSoftCommit>
+			<maxTime>1000</maxTime>
+		</autoSoftCommit>
+	</updateHandler>
 	<requestHandler name="/select"   class="solr.SearchHandler" />
 	<requestHandler name="/update" class="solr.UpdateRequestHandler" />
 	<requestHandler name="/admin" class="solr.admin.AdminHandlers" />

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/SolrConnection.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/SolrConnection.java
@@ -23,10 +23,10 @@ import java.util.Map;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
-import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 
 import com.digitalpebble.storm.crawler.util.ConfUtils;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 
 @SuppressWarnings("serial")
 public class SolrConnection {
@@ -55,10 +55,6 @@ public class SolrConnection {
                 + ".url", "localhost");
         String collection = ConfUtils.getString(stormConf, "solr." + boltType
                 + ".collection", null);
-        int threads = ConfUtils.getInt(stormConf, "solr." + boltType
-                + ".threads", 1);
-        int queueSize = ConfUtils.getInt(stormConf, "solr." + boltType
-                + ".queue.size", 250);
 
         SolrClient client;
 
@@ -66,16 +62,7 @@ public class SolrConnection {
             client = new CloudSolrClient(zkHost);
             ((CloudSolrClient) client).setDefaultCollection(collection);
         } else {
-            // TODO This shouldn't be necessary once SOLR-7729 is fixed in solrj
-            if (collection != null) {
-                if (solrUrl.endsWith("/")) {
-                    solrUrl = solrUrl + collection;
-                } else {
-                    solrUrl = solrUrl + "/" + collection;
-                }
-            }
-
-            client = new ConcurrentUpdateSolrClient(solrUrl, queueSize, threads);
+            client = new HttpSolrClient(solrUrl);
         }
 
         return client;

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/bolt/IndexerBolt.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/bolt/IndexerBolt.java
@@ -43,13 +43,10 @@ public class IndexerBolt extends AbstractIndexerBolt {
     private static final String BOLT_TYPE = "indexer";
 
     private static final String SolrIndexCollection = "solr.indexer.collection";
-    private static final String SolrBatchSizeParam = "solr.indexer.commit.size";
 
     private OutputCollector _collector;
 
     private String collection;
-    private int batchSize;
-    private int counter = 0;
 
     private MultiCountMetric eventCounter;
 
@@ -65,7 +62,6 @@ public class IndexerBolt extends AbstractIndexerBolt {
 
         collection = ConfUtils.getString(conf, IndexerBolt.SolrIndexCollection,
                 "collection1");
-        batchSize = ConfUtils.getInt(conf, IndexerBolt.SolrBatchSizeParam, 250);
 
         try {
             connection = SolrConnection.getConnection(conf, BOLT_TYPE);
@@ -128,14 +124,8 @@ public class IndexerBolt extends AbstractIndexerBolt {
             }
 
             connection.getClient().add(doc);
-            counter++;
 
             _collector.ack(tuple);
-
-            if (counter % batchSize == 0) {
-                connection.getClient().commit();
-                counter = 0;
-            }
 
             eventCounter.scope("Indexed").incrBy(1);
         } catch (Exception e) {

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/StatusUpdaterBolt.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/StatusUpdaterBolt.java
@@ -43,11 +43,8 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
     private static final String BOLT_TYPE = "status";
 
     private static final String SolrIndexCollection = "solr.status.collection";
-    private static final String SolrBatchSizeParam = "solr.status.commit.size";
 
     private String collection;
-    private int batchSize;
-    private int counter = 0;
 
     private SolrConnection connection;
 
@@ -59,7 +56,6 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
         collection = ConfUtils.getString(stormConf, SolrIndexCollection,
                 "status");
-        batchSize = ConfUtils.getInt(stormConf, SolrBatchSizeParam, 250);
 
         try {
             connection = SolrConnection.getConnection(stormConf, BOLT_TYPE);
@@ -89,17 +85,6 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
         doc.setField("nextFetchDate", nextFetch);
 
         connection.getClient().add(doc);
-        counter++;
-
-        if (counter % batchSize == 0) {
-            try {
-                connection.getClient().commit();
-            } catch (Exception e) {
-                LOG.error("Updating status for {} failed due to: {}", url, e);
-            }
-
-            counter = 0;
-        }
     }
 
     @Override


### PR DESCRIPTION
This is a fix proposal for the issue #177.

- No explicits commit in the code
- Add autoCommit and autoSoftCommit in solrconfig files
- Update Lucene version in solrconfig files