### PR TITLE
Include missing JAR dependencies in pom.xml

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,6 +24,8 @@
 		<icu4j.version>54.1.1</icu4j.version>
 		<xerces.version>2.11.0</xerces.version>
 		<httpclient.version>4.4.1</httpclient.version>
+		<snakeyaml.version>1.1.6</snakeyaml.version>
+		<commons.version>2.6</commons.version>
 	</properties>
 
 	<build>
@@ -188,5 +190,16 @@
 			<version>${httpclient.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<version>${snakeyaml.version}</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>${commons.version}</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@
 		<xerces.version>2.11.0</xerces.version>
 		<httpclient.version>4.4.1</httpclient.version>
 		<snakeyaml.version>1.1.6</snakeyaml.version>
-		<commons.version>2.6</commons.version>
+		<commons.lang.version>2.6</commons.lang.version>
 	</properties>
 
 	<build>
@@ -199,7 +199,7 @@
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
-			<version>${commons.version}</version>
+			<version>${commons.lang.version}</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Updated the dependencies section to include snakeyaml and commons-lang as dependencies. Otherwise, the storm program and topology throw CNFEs.