### PR TITLE
Fixed snakeyaml version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
 		<icu4j.version>54.1.1</icu4j.version>
 		<xerces.version>2.11.0</xerces.version>
 		<httpclient.version>4.4.1</httpclient.version>
-		<snakeyaml.version>1.1.6</snakeyaml.version>
+		<snakeyaml.version>1.16</snakeyaml.version>
 		<commons.lang.version>2.6</commons.lang.version>
 	</properties>
 


### PR DESCRIPTION
Was 1.1.6 which looks like a typo. This is a build failure since it can't be found in maven repo.