### PR TITLE
Upgraded storm-core to 0.10.0 version

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/FetcherBolt.java
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.storm.guava.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +66,7 @@ import com.digitalpebble.storm.crawler.util.ConfUtils;
 import com.digitalpebble.storm.crawler.util.MetadataTransfer;
 import com.digitalpebble.storm.crawler.util.PerSecondReducer;
 import com.digitalpebble.storm.crawler.util.URLUtil;
+import com.google.common.collect.Iterables;
 
 import crawlercommons.robots.BaseRobotRules;
 import crawlercommons.url.PaidLevelDomain;

--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/SimpleFetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/SimpleFetcherBolt.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.storm.guava.cache.Cache;
-import org.apache.storm.guava.cache.CacheBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +42,8 @@ import com.digitalpebble.storm.crawler.util.ConfUtils;
 import com.digitalpebble.storm.crawler.util.MetadataTransfer;
 import com.digitalpebble.storm.crawler.util.PerSecondReducer;
 import com.digitalpebble.storm.crawler.util.URLUtil;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 
 import backtype.storm.Config;
 import backtype.storm.metric.api.MeanReducer;

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- dependency versions -->
 		<junit.version>4.11</junit.version>
-		<storm-core.version>0.9.5</storm-core.version>
+		<storm-core.version>0.10.0</storm-core.version>
 		<jackson-databind.version>2.4.0</jackson-databind.version>
 	</properties>
 


### PR DESCRIPTION
To make it work on 0.10.0, I had to migrate guava dependencies to com.google.guava instead of org.apache.storm.guava. This library has been removed from Storm in 0.10.0 version. 