### PR TITLE
ES Sharding

### DIFF
--- a/external/elasticsearch/es-conf.yaml
+++ b/external/elasticsearch/es-conf.yaml
@@ -19,7 +19,8 @@ es.status.index.name: "status"
 es.status.doc.type: "status"
 es.status.hostname: "localhost"
 es.status.cluster.name: "elasticsearch"
-# es.status.metadata.routing: "aKeyName"
+es.status.routing: true
+es.status.routing.fieldname: "hostname"
 
 # ES Spout throttling. Uses configuration of URLPartitionerBolt for the bucket key.
 es.status.max.inflight.urls.per.bucket: -1


### PR DESCRIPTION
This PR leverages the sharding functionalities of Elasticsearch to group URLs into shards per domain/host/IP. This is done so that one instance of the ES spouts can be used per shard and hence guarantee a good diversity of URLs into the topology and optimise the performance of the crawl.

When setting `es.status.routing` to true the StatusUpdater will generate a partition key for a URL (based on the value of 'partition.url.mode') to send a document to a specific shard.  Optionally the value used for sharding can be stored in the metadata under the field name specified in 'es.status.routing.fieldname'.

In order for the sharding to be used by the ES spouts, there must be as many instances created as there are shards in the index as each instance becomes responsible of a given shard.

The routing is not enabled by default so the existing behaviour is maintained.