### PR TITLE
Use default of "nextFetchDate" for bucket sorting

### DIFF
--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/AggregationSpout.java
@@ -133,7 +133,7 @@ public class AggregationSpout extends BaseRichSpout {
                 ESStatusRoutingFieldParamName);
 
         bucketSortField = ConfUtils.getString(stormConf,
-                ESStatusBucketSortFieldParamName);
+                ESStatusBucketSortFieldParamName, bucketSortField);
 
         maxURLsPerBucket = ConfUtils.getInt(stormConf,
                 ESStatusMaxURLsParamName, 1);


### PR DESCRIPTION
The `bucketSortField` variable was initialised with the default of `nextFetchDate` but then later overwritten.
Unlikely to be a problem since the default is also in the conf file.