### PR TITLE
AbstractStatusUpdaterBolt allow proper acking of tuples

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/persistence/AbstractStatusUpdaterBolt.java
@@ -175,7 +175,7 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
      * Must be overridden for implementations where the actual writing can be
      * delayed e.g. put in a buffer
      **/
-    public void ack(Tuple t, String url) {
+    protected void ack(Tuple t, String url) {
         // keep the URL in the cache
         if (useCache) {
             cache.put(url, "");
@@ -184,7 +184,7 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
         _collector.ack(t);
     }
 
-    public abstract void store(String url, Status status, Metadata metadata,
+    protected abstract void store(String url, Status status, Metadata metadata,
             Date nextFetch) throws Exception;
 
     @Override

--- a/core/src/main/java/com/digitalpebble/storm/crawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/persistence/AbstractStatusUpdaterBolt.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import backtype.storm.metric.api.IMetric;
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.OutputFieldsDeclarer;
@@ -89,6 +90,13 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
             String spec = "maximumSize=10000,expireAfterAccess=1h";
             spec = ConfUtils.getString(stormConf, cacheConfigParamName, spec);
             cache = CacheBuilder.from(spec).build();
+
+            context.registerMetric("cache size", new IMetric() {
+                @Override
+                public Object getValueAndReset() {
+                    return cache.size();
+                }
+            }, 30);
         }
 
         maxFetchErrors = ConfUtils

--- a/core/src/main/java/com/digitalpebble/storm/crawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/persistence/AbstractStatusUpdaterBolt.java
@@ -91,8 +91,8 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
             cache = CacheBuilder.from(spec).build();
         }
 
-        maxFetchErrors = ConfUtils.getInt(stormConf, maxFetchErrorsParamName,
-                3);
+        maxFetchErrors = ConfUtils
+                .getInt(stormConf, maxFetchErrorsParamName, 3);
     }
 
     @Override
@@ -160,12 +160,20 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
             return;
         }
 
+        ack(tuple, url);
+    }
+
+    /**
+     * Must be overridden for implementations where the actual writing can be
+     * delayed e.g. put in a buffer
+     **/
+    public void ack(Tuple t, String url) {
         // keep the URL in the cache
         if (useCache) {
-            cache.put(url, status);
+            cache.put(url, "");
         }
 
-        _collector.ack(tuple);
+        _collector.ack(t);
     }
 
     public abstract void store(String url, Status status, Metadata metadata,

--- a/external/elasticsearch/es-conf.yaml
+++ b/external/elasticsearch/es-conf.yaml
@@ -37,6 +37,8 @@ es.status.doc.type: "status"
 es.status.cluster.name: "elasticsearch"
 es.status.routing: true
 es.status.routing.fieldname: "hostname"
+es.status.bulkActions: 500
+es.status.flushInterval: "10s"
 
 # ES Spout throttling. Uses configuration of URLPartitionerBolt for the bucket key.
 es.status.max.inflight.urls.per.bucket: -1

--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/ESCrawlTopology.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/ESCrawlTopology.java
@@ -25,7 +25,7 @@ import com.digitalpebble.storm.crawler.bolt.SiteMapParserBolt;
 import com.digitalpebble.storm.crawler.bolt.URLPartitionerBolt;
 import com.digitalpebble.storm.crawler.elasticsearch.bolt.IndexerBolt;
 import com.digitalpebble.storm.crawler.elasticsearch.metrics.MetricsConsumer;
-import com.digitalpebble.storm.crawler.elasticsearch.persistence.ElasticSearchSpout;
+import com.digitalpebble.storm.crawler.elasticsearch.persistence.AggregationSpout;
 import com.digitalpebble.storm.crawler.elasticsearch.persistence.StatusUpdaterBolt;
 import com.digitalpebble.storm.crawler.util.ConfUtils;
 
@@ -53,9 +53,9 @@ public class ESCrawlTopology extends ConfigurableTopology {
 
         // set to the real number of shards ONLY if es.status.routing is set to
         // true in the configuration
-        int numShards = 1;
+        int numShards = 5;
 
-        builder.setSpout("spout", new ElasticSearchSpout(), numShards);
+        builder.setSpout("spout", new AggregationSpout(), numShards);
 
         builder.setBolt("partitioner", new URLPartitionerBolt(), numWorkers)
                 .shuffleGrouping("spout");
@@ -80,7 +80,7 @@ public class ESCrawlTopology extends ConfigurableTopology {
                 .localOrShuffleGrouping("indexer", Constants.StatusStreamName);
 
         conf.registerMetricsConsumer(MetricsConsumer.class);
-        conf.registerMetricsConsumer(LoggingMetricsConsumer.class);
+        // conf.registerMetricsConsumer(LoggingMetricsConsumer.class);
 
         return submit("crawl", conf, builder);
     }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/StatusUpdaterBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/StatusUpdaterBolt.java
@@ -209,8 +209,9 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
                 Boolean success = (Boolean) keyval[2];
                 if (success)
                     super.ack((Tuple) keyval[1], (String) keyval[0]);
-                else
-                    super.fail((Tuple) keyval[1], (String) keyval[0]);
+				// TODO                
+				// else
+                //    super.fail((Tuple) keyval[1], (String) keyval[0]);
             }
         }
     }


### PR DESCRIPTION
Decoupled acking of tuples in AbstractStatusUpdaterBolt + ES StatusUpdaterBolt now properly acks tuples **after** they've been sent to ES.

Implements #216 

This prevents URLs from being excessively replayed by the ES spout. They were acked before being actually sent to ES, removed from the cache in the spout then refetched immediately as their status had not been changed.

~~@mattburns do you want to give this a try?~~ Still WIP and not quite ready to be used. 