### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>"……) to reduce the verbosity of generics code.

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/ConfigurableTopology.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/ConfigurableTopology.java
@@ -82,7 +82,7 @@ public abstract class ConfigurableTopology {
 
     private String[] parse(String args[]) {
 
-        List<String> newArgs = new ArrayList<String>();
+        List<String> newArgs = new ArrayList<>();
         Collections.addAll(newArgs, args);
 
         Iterator<String> iter = newArgs.iterator();

--- a/core/src/main/java/com/digitalpebble/storm/crawler/Metadata.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/Metadata.java
@@ -42,7 +42,7 @@ public class Metadata {
             Collections.<String, String[]> emptyMap());
 
     public Metadata() {
-        md = new HashMap<String, String[]>();
+        md = new HashMap<>();
     }
 
     /**
@@ -116,7 +116,7 @@ public class Metadata {
             return;
         }
 
-        ArrayList<String> existing = new ArrayList<String>(existingvals.length
+        ArrayList<String> existing = new ArrayList<>(existingvals.length
                 + values.size());
         for (String v : existingvals)
             existing.add(v);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/FetcherBolt.java
@@ -194,7 +194,7 @@ public class FetcherBolt extends BaseRichBolt {
      * progress and elapsed time between requests.
      */
     private static class FetchItemQueue {
-        Deque<FetchItem> queue = new LinkedBlockingDeque<FetcherBolt.FetchItem>();
+        Deque<FetchItem> queue = new LinkedBlockingDeque<>();
 
         AtomicInteger inProgress = new AtomicInteger();
         AtomicLong nextFetchTime = new AtomicLong();
@@ -271,7 +271,7 @@ public class FetcherBolt extends BaseRichBolt {
      */
     private static class FetchItemQueues {
 
-        Map<String, FetchItemQueue> queues = new LinkedHashMap<String, FetchItemQueue>();
+        Map<String, FetchItemQueue> queues = new LinkedHashMap<>();
         Iterator<String> it = Iterables.cycle(queues.keySet()).iterator();
 
         AtomicInteger inQueues = new AtomicInteger(0);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/JSoupParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/JSoupParserBolt.java
@@ -199,10 +199,10 @@ public class JSoupParserBolt extends BaseRichBolt {
             // do not extract the links if no follow has been set
             // and we are in strict mode
             if (robotsTags.isNoFollow() && robots_noFollow_strict) {
-                slinks = new HashMap<String, List<String>>(0);
+                slinks = new HashMap<>(0);
             } else {
                 Elements links = jsoupDoc.select("a[href]");
-                slinks = new HashMap<String, List<String>>(links.size());
+                slinks = new HashMap<>(links.size());
                 for (Element link : links) {
                     // abs:href tells jsoup to return fully qualified domains
                     // for
@@ -229,7 +229,7 @@ public class JSoupParserBolt extends BaseRichBolt {
                         // any existing anchors for the same target?
                         List<String> anchors = slinks.get(targetURL);
                         if (anchors == null) {
-                            anchors = new LinkedList<String>();
+                            anchors = new LinkedList<>();
                             slinks.put(targetURL, anchors);
                         }
                         // track the anchors only if no follow is false
@@ -366,7 +366,7 @@ public class JSoupParserBolt extends BaseRichBolt {
 
     private List<Outlink> toOutlinks(String url, Metadata metadata,
             Map<String, List<String>> slinks) {
-        List<Outlink> outlinks = new LinkedList<Outlink>();
+        List<Outlink> outlinks = new LinkedList<>();
         URL sourceUrl;
         try {
             sourceUrl = new URL(url);
@@ -378,7 +378,7 @@ public class JSoupParserBolt extends BaseRichBolt {
             return outlinks;
         }
 
-        Map<String, List<String>> linksKept = new HashMap<String, List<String>>();
+        Map<String, List<String>> linksKept = new HashMap<>();
 
         for (Map.Entry<String, List<String>> linkEntry : slinks.entrySet()) {
             String targetURL = linkEntry.getKey();

--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/SiteMapParserBolt.java
@@ -194,7 +194,7 @@ public class SiteMapParserBolt extends BaseRichBolt {
             siteMap = parser.parseSiteMap(contentType, content, sURL);
         }
 
-        List<Outlink> links = new ArrayList<Outlink>();
+        List<Outlink> links = new ArrayList<>();
 
         if (siteMap.isIndex()) {
             SiteMapIndex smi = ((SiteMapIndex) siteMap);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/filtering/URLFilters.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/filtering/URLFilters.java
@@ -88,7 +88,7 @@ public class URLFilters implements URLFilter {
     @Override
     public void configure(Map stormConf, JsonNode jsonNode) {
         // initialises the filters
-        List<URLFilter> filterLists = new ArrayList<URLFilter>();
+        List<URLFilter> filterLists = new ArrayList<>();
 
         // get the filters part
         String name = getClass().getCanonicalName();

--- a/core/src/main/java/com/digitalpebble/storm/crawler/filtering/basic/BasicURLNormalizer.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/filtering/basic/BasicURLNormalizer.java
@@ -118,7 +118,7 @@ public class BasicURLNormalizer implements URLFilter {
                 return urlToFilter;
             }
 
-            List<NameValuePair> pairs = new ArrayList<NameValuePair>();
+            List<NameValuePair> pairs = new ArrayList<>();
             URLEncodedUtils.parse(pairs, new Scanner(url.getQuery()), "UTF-8");
             Iterator<NameValuePair> pairsIterator = pairs.iterator();
             while (pairsIterator.hasNext()) {

--- a/core/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLFilterBase.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLFilterBase.java
@@ -67,7 +67,7 @@ public abstract class RegexURLFilterBase implements URLFilter {
 
     /** Populates a List of Rules off of JsonNode. */
     private List<RegexRule> readRules(ArrayNode rulesList) {
-        List<RegexRule> rules = new ArrayList<RegexRule>();
+        List<RegexRule> rules = new ArrayList<>();
         for (JsonNode urlFilterNode : rulesList) {
             try {
                 RegexRule rule = createRule(urlFilterNode.asText());
@@ -83,7 +83,7 @@ public abstract class RegexURLFilterBase implements URLFilter {
     }
 
     private List<RegexRule> readRules(String rulesFile) {
-        List<RegexRule> rules = new ArrayList<RegexRule>();
+        List<RegexRule> rules = new ArrayList<>();
 
         try {
             InputStream regexStream = getClass().getClassLoader()

--- a/core/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLNormalizer.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/filtering/regex/RegexURLNormalizer.java
@@ -119,7 +119,7 @@ public class RegexURLNormalizer implements URLFilter {
 
     /** Populates a List of Rules off of JsonNode. */
     private List<Rule> readRules(ArrayNode rulesList) {
-        List<Rule> rules = new ArrayList<Rule>();
+        List<Rule> rules = new ArrayList<>();
         for (JsonNode regexNode : rulesList) {
             if (regexNode == null || regexNode.isNull()) {
                 LOG.warn("bad config: 'regex' element is null");
@@ -161,7 +161,7 @@ public class RegexURLNormalizer implements URLFilter {
     }
 
     private List<Rule> readConfiguration(Reader reader) {
-        List<Rule> rules = new ArrayList<Rule>();
+        List<Rule> rules = new ArrayList<>();
         try {
 
             // borrowed heavily from code in Configuration.java

--- a/core/src/main/java/com/digitalpebble/storm/crawler/indexing/AbstractIndexerBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/indexing/AbstractIndexerBolt.java
@@ -74,7 +74,7 @@ public abstract class AbstractIndexerBolt extends BaseRichBolt {
 
     private String[] filterKeyValue = null;
 
-    private Map<String, String> metadata2field = new HashMap<String, String>();
+    private Map<String, String> metadata2field = new HashMap<>();
 
     private String fieldNameForText = null;
 
@@ -157,7 +157,7 @@ public abstract class AbstractIndexerBolt extends BaseRichBolt {
 
         Pattern indexValuePattern = Pattern.compile("\\[(\\d+)\\]");
 
-        Map<String, String[]> fieldVals = new HashMap<String, String[]>();
+        Map<String, String[]> fieldVals = new HashMap<>();
         Iterator<Entry<String, String>> iter = metadata2field.entrySet()
                 .iterator();
         while (iter.hasNext()) {

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilters.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilters.java
@@ -79,7 +79,7 @@ public class ParseFilters extends ParseFilter {
     @Override
     public void configure(Map stormConf, JsonNode filtersConf) {
         // initialises the filters
-        List<ParseFilter> filterLists = new ArrayList<ParseFilter>();
+        List<ParseFilter> filterLists = new ArrayList<>();
 
         // get the filters part
         String name = getClass().getCanonicalName();

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/filter/ContentFilter.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/filter/ContentFilter.java
@@ -102,7 +102,7 @@ public class ContentFilter extends ParseFilter {
     @SuppressWarnings("rawtypes")
     @Override
     public void configure(Map stormConf, JsonNode filterParams) {
-        expressions = new ArrayList<XPathExpression>();
+        expressions = new ArrayList<>();
         java.util.Iterator<Entry<String, JsonNode>> iter = filterParams
                 .fields();
         while (iter.hasNext()) {

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/filter/XPathFilter.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/filter/XPathFilter.java
@@ -77,7 +77,7 @@ public class XPathFilter extends ParseFilter {
     private XPathFactory factory = XPathFactory.newInstance();
     private XPath xpath = factory.newXPath();
 
-    private final Map<String, List<LabelledExpression>> expressions = new HashMap<String, List<LabelledExpression>>();
+    private final Map<String, List<LabelledExpression>> expressions = new HashMap<>();
 
     private class LabelledExpression {
 
@@ -103,7 +103,7 @@ public class XPathFilter extends ParseFilter {
                 throws XPathExpressionException, IOException {
             Object evalResult = expression.evaluate(doc,
                     evalFunction.getReturnType());
-            List<String> values = new LinkedList<String>();
+            List<String> values = new LinkedList<>();
             switch (evalFunction) {
             case STRING:
                 if (evalResult != null) {

--- a/core/src/main/java/com/digitalpebble/storm/crawler/protocol/ProtocolFactory.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/protocol/ProtocolFactory.java
@@ -30,7 +30,7 @@ public class ProtocolFactory {
 
     private final Config config;
 
-    private final HashMap<String, Protocol> cache = new HashMap<String, Protocol>();
+    private final HashMap<String, Protocol> cache = new HashMap<>();
 
     public ProtocolFactory(Config conf) {
         config = conf;

--- a/core/src/main/java/com/digitalpebble/storm/crawler/protocol/RobotRulesParser.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/protocol/RobotRulesParser.java
@@ -46,7 +46,7 @@ public abstract class RobotRulesParser {
     public static final Logger LOG = LoggerFactory
             .getLogger(RobotRulesParser.class);
 
-    protected static final Hashtable<String, BaseRobotRules> CACHE = new Hashtable<String, BaseRobotRules>();
+    protected static final Hashtable<String, BaseRobotRules> CACHE = new Hashtable<>();
 
     /**
      * A {@link BaseRobotRules} object appropriate for use when the
@@ -82,7 +82,7 @@ public abstract class RobotRulesParser {
 
         String agentNames = ConfUtils.getString(conf, "http.robots.agents", "");
         StringTokenizer tok = new StringTokenizer(agentNames, ",");
-        ArrayList<String> agents = new ArrayList<String>();
+        ArrayList<String> agents = new ArrayList<>();
         while (tok.hasMoreTokens()) {
             agents.add(tok.nextToken().trim());
         }

--- a/core/src/main/java/com/digitalpebble/storm/crawler/spout/FileSpout.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/spout/FileSpout.java
@@ -57,12 +57,12 @@ public class FileSpout extends BaseRichSpout {
 
     private Scheme _scheme;
 
-    private LinkedList<byte[]> buffer = new LinkedList<byte[]>();
+    private LinkedList<byte[]> buffer = new LinkedList<>();
     private boolean active;
 
     public FileSpout(String dir, String filter, Scheme scheme) {
         Path pdir = Paths.get(dir);
-        _inputFiles = new LinkedList<String>();
+        _inputFiles = new LinkedList<>();
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(pdir,
                 filter)) {
             for (Path entry : stream) {
@@ -86,7 +86,7 @@ public class FileSpout extends BaseRichSpout {
                     "Must configure at least one inputFile");
         }
         _scheme = scheme;
-        _inputFiles = new LinkedList<String>();
+        _inputFiles = new LinkedList<>();
         for (String f : files)
             _inputFiles.add(f);
     }

--- a/core/src/main/java/com/digitalpebble/storm/crawler/spout/MemorySpout.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/spout/MemorySpout.java
@@ -41,7 +41,7 @@ public class MemorySpout extends BaseRichSpout {
     private StringTabScheme scheme = new StringTabScheme();
     private boolean active = true;
 
-    private static PriorityQueue<ScheduledURL> queue = new PriorityQueue<ScheduledURL>();
+    private static PriorityQueue<ScheduledURL> queue = new PriorityQueue<>();
 
     public MemorySpout(String... urls) {
         Date now = new Date();
@@ -103,7 +103,7 @@ public class MemorySpout extends BaseRichSpout {
                 return;
             }
 
-            List<Object> tobs = new LinkedList<Object>();
+            List<Object> tobs = new LinkedList<>();
             tobs.add(tuple.URL);
             tobs.add(tuple.m);
             _collector.emit(tobs, tuple.URL);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/MetadataTransfer.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/MetadataTransfer.java
@@ -62,7 +62,7 @@ public class MetadataTransfer {
     /** Metadata key name for tracking the depth */
     public static final String depthKeyName = "depth";
 
-    private List<String> mdToKeep = new ArrayList<String>();
+    private List<String> mdToKeep = new ArrayList<>();
 
     private boolean trackPath = true;
 
@@ -155,7 +155,7 @@ public class MetadataTransfer {
     public Metadata filter(Metadata metadata) {
         Metadata md = new Metadata();
 
-        List<String> metadataToKeep = new ArrayList<String>(mdToKeep.size());
+        List<String> metadataToKeep = new ArrayList<>(mdToKeep.size());
         metadataToKeep.addAll(mdToKeep);
 
         // keep the path but don't add anything to it

--- a/core/src/test/java/com/digitalpebble/storm/crawler/filtering/BasicURLNormalizerTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/filtering/BasicURLNormalizerTest.java
@@ -79,7 +79,7 @@ public class BasicURLNormalizerTest {
 
     private URLFilter createFilter(ObjectNode filterParams) {
         BasicURLNormalizer filter = new BasicURLNormalizer();
-        Map<String, Object> conf = new HashMap<String, Object>();
+        Map<String, Object> conf = new HashMap<>();
         filter.configure(conf, filterParams);
         return filter;
     }

--- a/core/src/test/java/com/digitalpebble/storm/crawler/filtering/HostURLFilterTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/filtering/HostURLFilterTest.java
@@ -44,7 +44,7 @@ public class HostURLFilterTest {
                 Boolean.valueOf(ignoreOutsideHost));
         filterParams.put("ignoreOutsideDomain",
                 Boolean.valueOf(ignoreOutsideDomain));
-        Map<String, Object> conf = new HashMap<String, Object>();
+        Map<String, Object> conf = new HashMap<>();
         filter.configure(conf, filterParams);
         return filter;
     }

--- a/core/src/test/java/com/digitalpebble/storm/crawler/util/MetadataTransferTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/util/MetadataTransferTest.java
@@ -28,7 +28,7 @@ import com.digitalpebble.storm.crawler.Metadata;
 public class MetadataTransferTest {
     @Test
     public void testTransfer() throws MalformedURLException {
-        Map<String, Object> conf = new HashMap<String, Object>();
+        Map<String, Object> conf = new HashMap<>();
         conf.put(MetadataTransfer.trackDepthParamName, true);
         MetadataTransfer mdt = MetadataTransfer.getInstance(conf);
         Metadata parentMD = new Metadata();
@@ -44,7 +44,7 @@ public class MetadataTransferTest {
 
     @Test
     public void testCustomTransferClass() throws MalformedURLException {
-        Map<String, Object> conf = new HashMap<String, Object>();
+        Map<String, Object> conf = new HashMap<>();
         conf.put(MetadataTransfer.metadataTransferClassParamName,
                 "thisclassnameWillNEVERexist");
         boolean hasThrownException = false;
@@ -55,7 +55,7 @@ public class MetadataTransferTest {
         }
         Assert.assertEquals(true, hasThrownException);
 
-        conf = new HashMap<String, Object>();
+        conf = new HashMap<>();
         conf.put(MetadataTransfer.metadataTransferClassParamName,
                 myCustomTransferClass.class.getName());
         hasThrownException = false;

--- a/external/aws/src/main/java/com/digitalpebble/stormcrawler/aws/bolt/CloudSearchIndexerBolt.java
+++ b/external/aws/src/main/java/com/digitalpebble/stormcrawler/aws/bolt/CloudSearchIndexerBolt.java
@@ -98,11 +98,11 @@ public class CloudSearchIndexerBolt extends AbstractIndexerBolt {
 
     private MultiCountMetric eventCounter;
 
-    private Map<String, String> csfields = new HashMap<String, String>();
+    private Map<String, String> csfields = new HashMap<>();
 
     private long timeLastBatchSent = System.currentTimeMillis();
 
-    private List<Tuple> unacked = new ArrayList<Tuple>();
+    private List<Tuple> unacked = new ArrayList<>();
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override

--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/AggregationSpout.java
@@ -106,9 +106,9 @@ public class AggregationSpout extends BaseRichSpout {
 
     private Client client;
 
-    private Set<String> beingProcessed = new HashSet<String>();
+    private Set<String> beingProcessed = new HashSet<>();
 
-    private Queue<Values> buffer = new LinkedList<Values>();
+    private Queue<Values> buffer = new LinkedList<>();
 
     /** Field name used for field collapsing e.g. metadata.hostname **/
     private String partitionField;

--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/ElasticSearchSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/ElasticSearchSpout.java
@@ -87,7 +87,7 @@ public class ElasticSearchSpout extends BaseRichSpout {
 
     private int maxBufferSize = 100;
 
-    private Queue<Values> buffer = new LinkedList<Values>();
+    private Queue<Values> buffer = new LinkedList<>();
 
     private int lastStartOffset = 0;
     private Date lastDate;
@@ -102,10 +102,10 @@ public class ElasticSearchSpout extends BaseRichSpout {
     boolean randomSort = true;
 
     /** Keeps a count of the URLs being processed per host/domain/IP **/
-    private Map<String, AtomicInteger> inFlightTracker = new HashMap<String, AtomicInteger>();
+    private Map<String, AtomicInteger> inFlightTracker = new HashMap<>();
 
     // URL / politeness bucket (hostname / domain etc...)
-    private Map<String, String> beingProcessed = new HashMap<String, String>();
+    private Map<String, String> beingProcessed = new HashMap<>();
 
     private MultiCountMetric eventCounter;
 

--- a/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
+++ b/external/solr/src/main/java/com/digitalpebble/storm/crawler/solr/persistence/SolrSpout.java
@@ -64,7 +64,7 @@ public class SolrSpout extends BaseRichSpout {
 
     private final int bufferSize = 100;
 
-    private Queue<Values> buffer = new LinkedList<Values>();
+    private Queue<Values> buffer = new LinkedList<>();
 
     private int lastStartOffset = 0;
 
@@ -79,10 +79,10 @@ public class SolrSpout extends BaseRichSpout {
     private String mdPrefix;
 
     /** Keeps a count of the URLs being processed per host/domain/IP **/
-    private Map<String, Integer> inFlightTracker = new HashMap<String, Integer>();
+    private Map<String, Integer> inFlightTracker = new HashMap<>();
 
     // URL / politeness bucket (hostname / domain etc...)
-    private Map<String, String> beingProcessed = new HashMap<String, String>();
+    private Map<String, String> beingProcessed = new HashMap<>();
 
     @Override
     public void open(Map stormConf, TopologyContext context,

--- a/external/sql/src/main/java/com/digitalpebble/storm/crawler/sql/SQLSpout.java
+++ b/external/sql/src/main/java/com/digitalpebble/storm/crawler/sql/SQLSpout.java
@@ -58,13 +58,13 @@ public class SQLSpout extends BaseRichSpout {
 
     private int bufferSize = 100;
 
-    private Queue<List<Object>> buffer = new LinkedList<List<Object>>();
+    private Queue<List<Object>> buffer = new LinkedList<>();
 
     /**
      * Keeps track of the URLs in flight so that we don't add them more than
      * once when the table contains just a few URLs
      **/
-    private Set<String> beingProcessed = new HashSet<String>();
+    private Set<String> beingProcessed = new HashSet<>();
 
     private boolean active;
 

--- a/external/tika/src/main/java/com/digitalpebble/storm/crawler/tika/DOMBuilder.java
+++ b/external/tika/src/main/java/com/digitalpebble/storm/crawler/tika/DOMBuilder.java
@@ -57,7 +57,7 @@ public class DOMBuilder implements ContentHandler, LexicalHandler {
     private DocumentFragment m_docFrag = null;
 
     /** Vector of element nodes */
-    private Stack<Element> m_elemStack = new Stack<Element>();
+    private Stack<Element> m_elemStack = new Stack<>();
 
     /**
      * Element recorded with this namespace will be converted to Node without a

--- a/external/tika/src/main/java/com/digitalpebble/storm/crawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/com/digitalpebble/storm/crawler/tika/ParserBolt.java
@@ -314,7 +314,7 @@ public class ParserBolt extends BaseRichBolt {
     private List<Outlink> toOutlinks(String parentURL, List<Link> links,
             Metadata parentMetadata) {
 
-        List<Outlink> outlinks = new ArrayList<Outlink>(links.size());
+        List<Outlink> outlinks = new ArrayList<>(links.size());
 
         URL url_;
         try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.