### PR TITLE
Adding private constructor to util classes (containing  static methods only)

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/Constants.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/Constants.java
@@ -44,4 +44,6 @@ public class Constants {
 
     public static final String fetchErrorCountParamName = "fetch.error.count";
 
+    private Constants() {
+    }
 }

--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/ConfUtils.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/ConfUtils.java
@@ -33,8 +33,11 @@ import backtype.storm.utils.Utils;
 
 public class ConfUtils {
 
+    private ConfUtils() {
+    }
+
     public static int getInt(Map<String, Object> conf, String key,
-            int defaultValue) {
+                             int defaultValue) {
         Object obj = Utils.get(conf, key, defaultValue);
         return Utils.getInt(obj);
     }

--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/URLUtil.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/URLUtil.java
@@ -27,6 +27,9 @@ import java.util.regex.Pattern;
 /** Utility class for URL analysis */
 public class URLUtil {
 
+    private URLUtil() {
+    }
+
     /**
      * Resolve relative URL-s and fix a few java.net.URL errors in handling of
      * URLs with embedded params and pure query targets.

--- a/core/src/test/java/com/digitalpebble/storm/crawler/TestUtil.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/TestUtil.java
@@ -34,6 +34,10 @@ import backtype.storm.task.TopologyContext;
 import backtype.storm.tuple.Tuple;
 
 public class TestUtil {
+
+    private TestUtil() {
+    }
+
     public static TopologyContext getMockedTopologyContext() {
         TopologyContext context = mock(TopologyContext.class);
         when(context.registerMetric(anyString(), any(IMetric.class), anyInt()))

--- a/external/aws/src/main/java/com/digitalpebble/stormcrawler/aws/bolt/CloudSearchUtils.java
+++ b/external/aws/src/main/java/com/digitalpebble/stormcrawler/aws/bolt/CloudSearchUtils.java
@@ -39,6 +39,9 @@ public class CloudSearchUtils {
         }
     }
 
+    private CloudSearchUtils() {
+    }
+
     /** Returns a normalised doc ID based on the URL of a document **/
     public static String getID(String url) {
 

--- a/external/sql/src/main/java/com/digitalpebble/storm/crawler/sql/Constants.java
+++ b/external/sql/src/main/java/com/digitalpebble/storm/crawler/sql/Constants.java
@@ -25,4 +25,7 @@ public class Constants {
     public static final String MYSQL_TABLE_PARAM_NAME = "mysql.table";
     public static final String MYSQL_BUFFERSIZE_PARAM_NAME = "mysql.buffer.size";
     public static final String MYSQL_MIN_QUERY_INTERVAL_PARAM_NAME = "mysql.min.query.interval";
+
+    private Constants() {
+    }
 }

--- a/external/sql/src/main/java/com/digitalpebble/storm/crawler/sql/SQLUtil.java
+++ b/external/sql/src/main/java/com/digitalpebble/storm/crawler/sql/SQLUtil.java
@@ -26,6 +26,9 @@ import com.digitalpebble.storm.crawler.util.ConfUtils;
 
 public class SQLUtil {
 
+    private SQLUtil() {
+    }
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     static Connection getConnection(Map stormConf) throws SQLException {
         // SQL connection details

--- a/external/tika/src/main/java/com/digitalpebble/storm/crawler/tika/XMLCharacterRecognizer.java
+++ b/external/tika/src/main/java/com/digitalpebble/storm/crawler/tika/XMLCharacterRecognizer.java
@@ -30,6 +30,9 @@ package com.digitalpebble.storm.crawler.tika;
  */
 class XMLCharacterRecognizer {
 
+    private XMLCharacterRecognizer() {
+    }
+
     /**
      * Returns whether the specified <var>ch</var> conforms to the XML 1.0
      * definition of whitespace. Refer to <A


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.