### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/SiteMapParserBolt.java
@@ -197,7 +197,7 @@ public class SiteMapParserBolt extends BaseRichBolt {
         List<Outlink> links = new ArrayList<Outlink>();
 
         if (siteMap.isIndex()) {
-            SiteMapIndex smi = ((SiteMapIndex) siteMap);
+            SiteMapIndex smi = (SiteMapIndex) siteMap;
             Collection<AbstractSiteMap> subsitemaps = smi.getSitemaps();
             // keep the subsitemaps as outlinks
             // they will be fetched and parsed in the following steps
@@ -234,7 +234,7 @@ public class SiteMapParserBolt extends BaseRichBolt {
         }
         // sitemap files
         else {
-            SiteMap sm = ((SiteMap) siteMap);
+            SiteMap sm = (SiteMap) siteMap;
             // TODO see what we can do with the LastModified info
             Collection<SiteMapURL> sitemapURLs = sm.getSiteMapUrls();
             Iterator<SiteMapURL> iter = sitemapURLs.iterator();

--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/URLPartitionerBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/URLPartitionerBolt.java
@@ -121,7 +121,7 @@ public class URLPartitionerBolt extends BaseRichBolt {
                     partitionKey = addr.getHostAddress();
                     long end = System.currentTimeMillis();
                     LOG.debug("Resolved IP {} in {} msec for : {}",
-                            partitionKey, (end - start), url);
+                            partitionKey, end - start, url);
 
                     // add to cache
                     cache.put(host, partitionKey);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/filtering/URLFilters.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/filtering/URLFilters.java
@@ -78,7 +78,7 @@ public class URLFilters implements URLFilter {
                     normalizedURL);
             long end = System.currentTimeMillis();
             LOG.debug("URLFilter {} took {} msec", filter.getClass().getName(),
-                    (end - start));
+                    end - start);
             if (normalizedURL == null)
                 break;
         }

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/JSoupDOMBuilder.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/JSoupDOMBuilder.java
@@ -97,14 +97,14 @@ public final class JSoupDOMBuilder {
 
         if (node instanceof org.jsoup.nodes.Document) {
 
-            org.jsoup.nodes.Document d = ((org.jsoup.nodes.Document) node);
+            org.jsoup.nodes.Document d = (org.jsoup.nodes.Document) node;
             for (org.jsoup.nodes.Node n : d.childNodes()) {
                 createDOM(n, out, doc, ns);
             }
 
         } else if (node instanceof org.jsoup.nodes.Element) {
 
-            org.jsoup.nodes.Element e = ((org.jsoup.nodes.Element) node);
+            org.jsoup.nodes.Element e = (org.jsoup.nodes.Element) node;
             org.w3c.dom.Element _e = doc.createElement(e.tagName());
             out.appendChild(_e);
             org.jsoup.nodes.Attributes atts = e.attributes();
@@ -136,7 +136,7 @@ public final class JSoupDOMBuilder {
 
         } else if (node instanceof org.jsoup.nodes.TextNode) {
 
-            org.jsoup.nodes.TextNode t = ((org.jsoup.nodes.TextNode) node);
+            org.jsoup.nodes.TextNode t = (org.jsoup.nodes.TextNode) node;
             if (!(out instanceof Document)) {
                 out.appendChild(doc.createTextNode(t.text()));
             }

--- a/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilters.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/parse/ParseFilters.java
@@ -167,7 +167,7 @@ public class ParseFilters extends ParseFilter {
             filter.filter(URL, content, doc, parse);
             long end = System.currentTimeMillis();
             LOG.debug("ParseFilter {} took {} msec", filter.getClass()
-                    .getName(), (end - start));
+                    .getName(), end - start);
         }
     }
 

--- a/core/src/main/java/com/digitalpebble/storm/crawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/protocol/httpclient/HttpProtocol.java
@@ -100,7 +100,7 @@ public class HttpProtocol extends AbstractHttpProtocol implements
         String proxyHost = ConfUtils.getString(conf, "http.proxy.host", null);
         int proxyPort = ConfUtils.getInt(conf, "http.proxy.port", 8080);
 
-        boolean useProxy = (proxyHost != null && proxyHost.length() > 0);
+        boolean useProxy = proxyHost != null && proxyHost.length() > 0;
 
         // use a proxy?
         if (useProxy) {

--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/PerSecondReducer.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/PerSecondReducer.java
@@ -30,7 +30,7 @@ public class PerSecondReducer implements IReducer<TimeReducerState> {
     @Override
     public Object extractResult(TimeReducerState accumulator) {
         // time spent
-        double msec = (System.currentTimeMillis() - accumulator.started);
+        double msec = System.currentTimeMillis() - accumulator.started;
         if (msec == 0)
             return 0;
         double permsec = accumulator.sum / msec;

--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/URLPartitioner.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/URLPartitioner.java
@@ -88,7 +88,7 @@ public class URLPartitioner {
                 partitionKey = addr.getHostAddress();
                 long end = System.currentTimeMillis();
                 LOG.debug("Resolved IP {} in {} msec for : {}", partitionKey,
-                        (end - start), url);
+                        end - start, url);
             } catch (final Exception e) {
                 LOG.warn("Unable to resolve IP for: {}", host);
                 return null;

--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/AggregationSpout.java
@@ -355,7 +355,7 @@ public class AggregationSpout extends BaseRichSpout {
 
         LOG.info(
                 "{} ES query returned {} hits from {} buckets in {} msec but {} already being processed",
-                logIdprefix, numhits, numBuckets, (end - start),
+                logIdprefix, numhits, numBuckets, end - start,
                 alreadyprocessed);
 
         eventCounter.scope("already_being_processed").incrBy(alreadyprocessed);

--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/ElasticSearchSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/ElasticSearchSpout.java
@@ -292,7 +292,7 @@ public class ElasticSearchSpout extends BaseRichSpout {
         SearchHits hits = response.getHits();
         int numhits = hits.getHits().length;
 
-        LOG.info("ES query returned {} hits in {} msec", numhits, (end - start));
+        LOG.info("ES query returned {} hits in {} msec", numhits, end - start);
 
         eventCounter.scope("ES_queries").incrBy(1);
         eventCounter.scope("ES_docs").incrBy(numhits);

--- a/external/tika/src/main/java/com/digitalpebble/storm/crawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/com/digitalpebble/storm/crawler/tika/ParserBolt.java
@@ -151,7 +151,7 @@ public class ParserBolt extends BaseRichBolt {
         tika = new Tika();
         long end = System.currentTimeMillis();
 
-        LOG.debug("Tika loaded in {} msec", (end - start));
+        LOG.debug("Tika loaded in {} msec", end - start);
 
         this.collector = collector;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.