### PR TITLE
Added option to BasicURLNormalizer for checking that a URL is a valid URI

### DIFF
--- a/core/src/main/java/com/digitalpebble/storm/crawler/filtering/basic/BasicURLNormalizer.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/filtering/basic/BasicURLNormalizer.java
@@ -18,6 +18,7 @@
 package com.digitalpebble.storm.crawler.filtering.basic;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -48,6 +49,7 @@ public class BasicURLNormalizer implements URLFilter {
 
     boolean removeAnchorPart = true;
     boolean unmangleQueryString = true;
+    boolean checkValidURI = true;
     final Set<String> queryElementsToRemove = new TreeSet<>();
 
     @Override
@@ -70,6 +72,14 @@ public class BasicURLNormalizer implements URLFilter {
 
         if (!queryElementsToRemove.isEmpty()) {
             urlToFilter = filterQueryElements(urlToFilter);
+        }
+
+        if (checkValidURI) {
+            try {
+                URI.create(urlToFilter);
+            } catch (java.lang.IllegalArgumentException e) {
+                return null;
+            }
         }
 
         return urlToFilter;
@@ -99,6 +109,11 @@ public class BasicURLNormalizer implements URLFilter {
                     queryElementsToRemove.add(element.asText());
                 }
             }
+        }
+
+        node = paramNode.get("checkValidURI");
+        if (node != null) {
+            checkValidURI = node.booleanValue();
         }
     }
 

--- a/core/src/main/java/com/digitalpebble/storm/crawler/filtering/basic/BasicURLNormalizer.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/filtering/basic/BasicURLNormalizer.java
@@ -78,6 +78,7 @@ public class BasicURLNormalizer implements URLFilter {
             try {
                 URI.create(urlToFilter);
             } catch (java.lang.IllegalArgumentException e) {
+                LOG.info("Invalid URI {}", urlToFilter);
                 return null;
             }
         }

--- a/core/src/main/resources/urlfilters.json
+++ b/core/src/main/resources/urlfilters.json
@@ -12,7 +12,8 @@
       "name": "BasicURLNormalizer",
       "params": {
         "removeAnchorPart": true, 
-        "unmangleQueryString": true
+        "unmangleQueryString": true,
+        "checkValidURI": true
       }
     },
     {


### PR DESCRIPTION
The http protocol implementation is based on httpclient and requires the URLs to be well formed URIs. Work is needed to normalise them  see #205 but what we can do here is to filter them out - no point trying to fetch them