### PR TITLE
ES config to accept multiple addresses at host:port format #259

### DIFF
--- a/external/elasticsearch/es-conf.yaml
+++ b/external/elasticsearch/es-conf.yaml
@@ -1,18 +1,18 @@
 # configuration for Elasticsearch resources
 
 # ES indexer bolt
-# Transport client will be used if a hostname is specified
+# Transport client will be used if at least one address is specified
 # Node client will be used otherwise
-# es.indexer.hostname: "localhost"
+# es.indexer.addresses: "localhost:9300"
 es.indexer.index.name: "index"
 es.indexer.doc.type: "doc"
 es.indexer.cluster.name: "elasticsearch"
 es.indexer.create: false
 
 # ES metricsConsumer
-# Transport client will be used if a hostname is specified
+# Transport client will be used if at least one address is specified
 # Node client will be used otherwise
-# es.metrics.hostname: "localhost"
+# es.metrics.addresses: "localhost:9300"
 es.metrics.index.name: "metrics"
 es.metrics.doc.type: "datapoint"
 es.metrics.cluster.name: "elasticsearch"
@@ -29,9 +29,11 @@ es.metrics.ttl: -1
 # - __receive.read_pos
 
 # ES spout and persistence bolt
-# Transport client will be used if a hostname is specified
+# Transport client will be used if at least one address is specified
 # Node client will be used otherwise
-# es.status.hostname: "localhost"
+# es.status.addresses: 
+# - localhost:9300
+# - localhost:9301
 es.status.index.name: "status"
 es.status.doc.type: "status"
 es.status.cluster.name: "elasticsearch"


### PR DESCRIPTION
Implements #259. Allows to specify a custom port and not just the hosts as well as multiple addresses for the TransportClient.

Note \: this change the config name from *.hostname to *.addresses and is not backward compatible. 

