### PR TITLE
SimpleFetcherBolt handles 304 correctly

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -138,6 +139,13 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>${mockito-all.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock</artifactId>
+			<version>1.57</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,6 +27,7 @@
 		<httpclient.version>4.4.1</httpclient.version>
 		<snakeyaml.version>1.16</snakeyaml.version>
 		<commons.lang.version>2.6</commons.lang.version>
+		<wiremock.version>1.57</wiremock.version>
 	</properties>
 
 	<build>
@@ -145,7 +146,7 @@
 		<dependency>
 			<groupId>com.github.tomakehurst</groupId>
 			<artifactId>wiremock</artifactId>
-			<version>1.57</version>
+			<version>${wiremock.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/core/src/main/java/com/digitalpebble/storm/crawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/bolt/FetcherBolt.java
@@ -411,7 +411,7 @@ public class FetcherBolt extends BaseRichBolt {
 
                 activeThreads.incrementAndGet(); // count threads
 
-                LOG.info(
+                LOG.debug(
                         "[Fetcher #{}] {}  => activeThreads={}, spinWaiting={}, queueID={}",
                         taskID, getName(), activeThreads, spinWaiting,
                         fit.queueID);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/protocol/httpclient/HttpProtocol.java
@@ -173,7 +173,10 @@ public class HttpProtocol extends AbstractHttpProtocol implements
 
     private static final byte[] toByteArray(final HttpEntity entity,
             int maxContent, MutableBoolean trimmed) throws IOException {
-        Args.notNull(entity, "Entity");
+
+        if (entity == null)
+            return new byte[] {};
+
         final InputStream instream = entity.getContent();
         if (instream == null) {
             return null;

--- a/core/src/test/java/com/digitalpebble/storm/crawler/bolt/AbstractFetcherBoltTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/bolt/AbstractFetcherBoltTest.java
@@ -17,6 +17,10 @@
 
 package com.digitalpebble.storm.crawler.bolt;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,19 +30,26 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+
+import com.digitalpebble.storm.crawler.Constants;
+import com.digitalpebble.storm.crawler.TestOutputCollector;
+import com.digitalpebble.storm.crawler.TestUtil;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 import backtype.storm.task.OutputCollector;
 import backtype.storm.topology.base.BaseRichBolt;
 import backtype.storm.tuple.Tuple;
 
-import com.digitalpebble.storm.crawler.Constants;
-import com.digitalpebble.storm.crawler.TestOutputCollector;
-import com.digitalpebble.storm.crawler.TestUtil;
-
 public abstract class AbstractFetcherBoltTest {
 
     BaseRichBolt bolt;
+
+    private final static int port = 8089;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(port);
 
     @Test
     public void testDodgyURL() throws IOException {
@@ -56,6 +67,47 @@ public abstract class AbstractFetcherBoltTest {
         when(tuple.getStringByField("url")).thenReturn("ahahaha");
         when(tuple.getValueByField("metadata")).thenReturn(null);
         bolt.execute(tuple);
+
+        boolean acked = output.getAckedTuples().contains(tuple);
+        boolean failed = output.getAckedTuples().contains(tuple);
+
+        // should be acked or failed
+        Assert.assertEquals(true, acked || failed);
+
+        List<List<Object>> statusTuples = output
+                .getEmitted(Constants.StatusStreamName);
+
+        // we should get one tuple on the status stream
+        // to notify that the URL is an error
+        Assert.assertEquals(1, statusTuples.size());
+    }
+
+    @Test
+    public void test304() {
+
+        stubFor(get(urlMatching(".+")).willReturn(aResponse().withStatus(304)));
+
+        TestOutputCollector output = new TestOutputCollector();
+
+        Map config = new HashMap();
+        config.put("http.agent.name", "this is only a test");
+        config.put("http.skip.robots", true);
+
+        bolt.prepare(config, TestUtil.getMockedTopologyContext(),
+                new OutputCollector(output));
+
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getSourceComponent()).thenReturn("source");
+        when(tuple.getStringByField("url")).thenReturn(
+                "http://localhost:" + port + "/");
+        when(tuple.getValueByField("metadata")).thenReturn(null);
+        bolt.execute(tuple);
+
+        // wait a bit so that the fetcher threads get a chance to process it
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+        }
 
         boolean acked = output.getAckedTuples().contains(tuple);
         boolean failed = output.getAckedTuples().contains(tuple);

--- a/core/src/test/java/com/digitalpebble/storm/crawler/bolt/AbstractFetcherBoltTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/bolt/AbstractFetcherBoltTest.java
@@ -17,10 +17,6 @@
 
 package com.digitalpebble.storm.crawler.bolt;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,13 +26,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
 
 import com.digitalpebble.storm.crawler.Constants;
 import com.digitalpebble.storm.crawler.TestOutputCollector;
 import com.digitalpebble.storm.crawler.TestUtil;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 import backtype.storm.task.OutputCollector;
 import backtype.storm.topology.base.BaseRichBolt;
@@ -45,11 +39,6 @@ import backtype.storm.tuple.Tuple;
 public abstract class AbstractFetcherBoltTest {
 
     BaseRichBolt bolt;
-
-    private final static int port = 8089;
-
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(port);
 
     @Test
     public void testDodgyURL() throws IOException {
@@ -67,47 +56,6 @@ public abstract class AbstractFetcherBoltTest {
         when(tuple.getStringByField("url")).thenReturn("ahahaha");
         when(tuple.getValueByField("metadata")).thenReturn(null);
         bolt.execute(tuple);
-
-        boolean acked = output.getAckedTuples().contains(tuple);
-        boolean failed = output.getAckedTuples().contains(tuple);
-
-        // should be acked or failed
-        Assert.assertEquals(true, acked || failed);
-
-        List<List<Object>> statusTuples = output
-                .getEmitted(Constants.StatusStreamName);
-
-        // we should get one tuple on the status stream
-        // to notify that the URL is an error
-        Assert.assertEquals(1, statusTuples.size());
-    }
-
-    @Test
-    public void test304() {
-
-        stubFor(get(urlMatching(".+")).willReturn(aResponse().withStatus(304)));
-
-        TestOutputCollector output = new TestOutputCollector();
-
-        Map config = new HashMap();
-        config.put("http.agent.name", "this is only a test");
-        config.put("http.skip.robots", true);
-
-        bolt.prepare(config, TestUtil.getMockedTopologyContext(),
-                new OutputCollector(output));
-
-        Tuple tuple = mock(Tuple.class);
-        when(tuple.getSourceComponent()).thenReturn("source");
-        when(tuple.getStringByField("url")).thenReturn(
-                "http://localhost:" + port + "/");
-        when(tuple.getValueByField("metadata")).thenReturn(null);
-        bolt.execute(tuple);
-
-        // wait a bit so that the fetcher threads get a chance to process it
-        try {
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-        }
 
         boolean acked = output.getAckedTuples().contains(tuple);
         boolean failed = output.getAckedTuples().contains(tuple);

--- a/core/src/test/java/com/digitalpebble/storm/crawler/bolt/SimpleFetcherBoltTest.java
+++ b/core/src/test/java/com/digitalpebble/storm/crawler/bolt/SimpleFetcherBoltTest.java
@@ -17,13 +17,85 @@
 
 package com.digitalpebble.storm.crawler.bolt;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.digitalpebble.storm.crawler.Constants;
+import com.digitalpebble.storm.crawler.TestOutputCollector;
+import com.digitalpebble.storm.crawler.TestUtil;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import backtype.storm.task.OutputCollector;
+import backtype.storm.tuple.Tuple;
+import backtype.storm.utils.Utils;
 
 public class SimpleFetcherBoltTest extends AbstractFetcherBoltTest {
+
+    private final static int port = 8089;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(port);
 
     @Before
     public void setUpContext() throws Exception {
         bolt = new SimpleFetcherBolt();
+    }
+
+    @Test
+    public void test304() {
+
+        stubFor(get(urlMatching(".+")).willReturn(aResponse().withStatus(304)));
+
+        TestOutputCollector output = new TestOutputCollector();
+
+        Map config = new HashMap();
+        config.put("http.agent.name", "this is only a test");
+
+        bolt.prepare(config, TestUtil.getMockedTopologyContext(),
+                new OutputCollector(output));
+
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getSourceComponent()).thenReturn("source");
+        when(tuple.getStringByField("url")).thenReturn(
+                "http://localhost:" + port + "/");
+        when(tuple.getValueByField("metadata")).thenReturn(null);
+        bolt.execute(tuple);
+
+        try {
+            Thread.sleep(1);
+        } catch (InterruptedException e) {
+        }
+
+        boolean acked = output.getAckedTuples().contains(tuple);
+        boolean failed = output.getAckedTuples().contains(tuple);
+
+        // should be acked or failed
+        Assert.assertEquals(true, acked || failed);
+
+        List<List<Object>> statusTuples = output
+                .getEmitted(Constants.StatusStreamName);
+
+        // we should get one tuple on the status stream
+        // to notify that the URL has been fetched
+        Assert.assertEquals(1, statusTuples.size());
+
+        // and none on the default stream as there is nothing to parse and/or
+        // index
+        Assert.assertEquals(0, output.getEmitted(Utils.DEFAULT_STREAM_ID)
+                .size());
     }
 
 }


### PR DESCRIPTION
see #279 

SimpleFetcherBolt does not emit to default stream when code 304. Added test using Wiremock + http protocol returns empty array when entity is null

The test cannot be used for FetcherBolt yet as the tuples get flushed to the collector based on ticktuples - this will be fixed with #278

