### PR TITLE
Add Flux equivalent of the example topology class #286

### DIFF
--- a/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -22,6 +22,7 @@
       <directory></directory>
       <includes>
         <include>crawler-conf.yaml</include>
+        <include>crawler.flux</include>
         <include>README.md</include>
       </includes>
     </fileSet>

--- a/archetype/src/main/resources/archetype-resources/README.md
+++ b/archetype/src/main/resources/archetype-resources/README.md
@@ -25,3 +25,8 @@ storm jar target/<INSERTJARNAMEHERE>.jar CrawlTopology -conf crawler-conf.yaml
 
 to run it in distributed mode.
 
+Alternatively use Flux 
+
+``` sh
+storm jar target//<INSERTJARNAMEHERE>.jar  org.apache.storm.flux.Flux --local crawler.flux
+```

--- a/archetype/src/main/resources/archetype-resources/README.md
+++ b/archetype/src/main/resources/archetype-resources/README.md
@@ -28,5 +28,5 @@ to run it in distributed mode.
 Alternatively use Flux 
 
 ``` sh
-storm jar target//<INSERTJARNAMEHERE>.jar  org.apache.storm.flux.Flux --local crawler.flux
+storm jar target/<INSERTJARNAMEHERE>.jar  org.apache.storm.flux.Flux --local crawler.flux
 ```

--- a/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -10,6 +10,10 @@ config:
   topology.max.spout.pending: 10
   topology.debug: false
 
+  # mandatory when using Flux
+  topology.kryo.register:
+    - com.digitalpebble.storm.crawler.Metadata
+
   # metadata to transfer to the outlinks
   # used by Fetcher for redirections, sitemapparser, etc...
   # these are also persisted for the parent document (see below)

--- a/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -4,63 +4,65 @@
 # Use this file with the parameter -config when launching your extension of ConfigurableTopology.  
 # This file does not contain all the key values but only the most frequently used ones. See crawler-default.xml for an extensive list.
 
-# metadata to transfer to the outlinks
-# used by Fetcher for redirections, sitemapparser, etc...
-# these are also persisted for the parent document (see below)
-# metadata.transfer:
-# - customMetadataName
+config: 
+  topology.workers: 1
+  topology.message.timeout.secs: 300
+  topology.max.spout.pending: 10
+  topology.debug: false
 
-# lists the metadata to persist to storage
-# these are not transfered to the outlinks
-metadata.persist:
- - _redirTo
- - error.cause
- - isSitemap
- - isFeed
+  # metadata to transfer to the outlinks
+  # used by Fetcher for redirections, sitemapparser, etc...
+  # these are also persisted for the parent document (see below)
+  # metadata.transfer:
+  # - customMetadataName
 
-http.agent.name: "Anonymous Coward"
-http.agent.version: "1.0"
-http.agent.description: "A StormCrawler-based crawler"
-http.agent.url: "http://someorganization.com/"
-http.agent.email: "someone@http://someorganization.com/"
+  # lists the metadata to persist to storage
+  # these are not transfered to the outlinks
+  metadata.persist:
+   - _redirTo
+   - error.cause
+   - isSitemap
+   - isFeed
 
-# FetcherBolt queue dump : comment out to activate
-# if a file exists on the worker machine with the corresponding port number
-# the FetcherBolt will log the content of its internal queues to the logs
-# fetcherbolt.queue.debug.filepath: "/tmp/fetcher-dump-{port}
+  http.agent.name: "Anonymous Coward"
+  http.agent.version: "1.0"
+  http.agent.description: "A StormCrawler-based crawler"
+  http.agent.url: "http://someorganization.com/"
+  http.agent.email: "someone@http://someorganization.com/"
 
-parsefilters.config.file: "parsefilters.json"
-urlfilters.config.file: "urlfilters.json"
+  # FetcherBolt queue dump : comment out to activate
+  # if a file exists on the worker machine with the corresponding port number
+  # the FetcherBolt will log the content of its internal queues to the logs
+  # fetcherbolt.queue.debug.filepath: "/tmp/fetcher-dump-{port}
 
-# revisit a page daily (value in minutes)
-fetchInterval.default: 1440
+  parsefilters.config.file: "parsefilters.json"
+  urlfilters.config.file: "urlfilters.json"
 
-# revisit a page with a fetch error after 2 hours (value in minutes)
-fetchInterval.fetch.error: 120
+  # revisit a page daily (value in minutes)
+  fetchInterval.default: 1440
 
-# revisit a page with an error every month (value in minutes)
-fetchInterval.error: 44640
+  # revisit a page with a fetch error after 2 hours (value in minutes)
+  fetchInterval.fetch.error: 120
 
-# custom fetch interval to be used when a document has the key/value in its metadata
-# and has been fetched succesfully (value in minutes)
-# fetchInterval.isFeed=true: 10
+  # revisit a page with an error every month (value in minutes)
+  fetchInterval.error: 44640
 
-# configuration for the classes extending AbstractIndexerBolt
-# indexer.md.filter: "someKey=aValue"
-indexer.url.fieldname: "url"
-indexer.text.fieldname: "content"
-indexer.canonical.name: "canonical"
-indexer.md.mapping:
-- parse.title=title
-- parse.keywords=keywords
-- parse.description=description
+  # custom fetch interval to be used when a document has the key/value in its metadata
+  # and has been fetched succesfully (value in minutes)
+  # fetchInterval.isFeed=true: 10
 
-topology.workers: 1
-topology.message.timeout.secs: 300
-topology.max.spout.pending: 10
-topology.debug: false
+  # configuration for the classes extending AbstractIndexerBolt
+  # indexer.md.filter: "someKey=aValue"
+  indexer.url.fieldname: "url"
+  indexer.text.fieldname: "content"
+  indexer.canonical.name: "canonical"
+  indexer.md.mapping:
+  - parse.title=title
+  - parse.keywords=keywords
+  - parse.description=description
 
-# Metrics consumers:
-topology.metrics.consumer.register:
-   - class: "org.apache.storm.metric.LoggingMetricsConsumer"
-     parallelism.hint: 1
+  # Metrics consumers:
+  topology.metrics.consumer.register:
+     - class: "org.apache.storm.metric.LoggingMetricsConsumer"
+       parallelism.hint: 1
+

--- a/archetype/src/main/resources/archetype-resources/crawler.flux
+++ b/archetype/src/main/resources/archetype-resources/crawler.flux
@@ -1,6 +1,10 @@
 name: "crawler"
 
 includes:
+    - resource: true
+      file: "/crawler-default.yaml"
+      override: false
+
     - resource: false
       file: "crawler-conf.yaml"
       override: false

--- a/archetype/src/main/resources/archetype-resources/crawler.flux
+++ b/archetype/src/main/resources/archetype-resources/crawler.flux
@@ -1,0 +1,85 @@
+name: "crawler"
+
+includes:
+    - resource: false
+      file: "crawler-conf.yaml"
+      override: false
+
+spouts:
+  - id: "spout"
+    className: "com.digitalpebble.storm.crawler.spout.MemorySpout"
+    parallelism: 1
+    constructorArgs:
+      - ["http://www.lequipe.fr/", "http://www.lemonde.fr/", "http://www.bbc.co.uk/", "http://storm.apache.org/", "http://digitalpebble.com/"]
+
+bolts:
+  - id: "partitioner"
+    className: "com.digitalpebble.storm.crawler.bolt.URLPartitionerBolt"
+    parallelism: 1
+  - id: "fetcher"
+    className: "com.digitalpebble.storm.crawler.bolt.FetcherBolt"
+    parallelism: 1
+  - id: "sitemap"
+    className: "com.digitalpebble.storm.crawler.bolt.SiteMapParserBolt"
+    parallelism: 1
+  - id: "parse"
+    className: "com.digitalpebble.storm.crawler.bolt.JSoupParserBolt"
+    parallelism: 1
+  - id: "index"
+    className: "com.digitalpebble.storm.crawler.indexing.StdOutIndexer"
+    parallelism: 1
+  - id: "status"
+    className: "com.digitalpebble.storm.crawler.persistence.StdOutStatusUpdater"
+    parallelism: 1
+
+streams:
+  - from: "spout"
+    to: "partitioner"
+    grouping:
+      type: SHUFFLE
+
+  - from: "partitioner"
+    to: "fetcher"
+    grouping:
+      type: FIELDS
+      args: ["key"]
+
+  - from: "fetcher"
+    to: "sitemap"
+    grouping:
+      type: LOCAL_OR_SHUFFLE
+
+  - from: "sitemap"
+    to: "parse"
+    grouping:
+      type: LOCAL_OR_SHUFFLE
+
+  - from: "parse"
+    to: "index"
+    grouping:
+      type: LOCAL_OR_SHUFFLE
+
+  - from: "fetch"
+    to: "status"
+    grouping:
+      type: LOCAL_OR_SHUFFLE
+      streamId: "status"
+
+  - from: "sitemap"
+    to: "status"
+    grouping:
+      type: LOCAL_OR_SHUFFLE
+      streamId: "status"
+
+  - from: "parse"
+    to: "status"
+    grouping:
+      type: LOCAL_OR_SHUFFLE
+      streamId: "status"
+
+  - from: "index"
+    to: "status"
+    grouping:
+      type: LOCAL_OR_SHUFFLE
+      streamId: "status"
+

--- a/archetype/src/main/resources/archetype-resources/crawler.flux
+++ b/archetype/src/main/resources/archetype-resources/crawler.flux
@@ -59,7 +59,7 @@ streams:
     grouping:
       type: LOCAL_OR_SHUFFLE
 
-  - from: "fetch"
+  - from: "fetcher"
     to: "status"
     grouping:
       type: LOCAL_OR_SHUFFLE
@@ -82,4 +82,3 @@ streams:
     grouping:
       type: LOCAL_OR_SHUFFLE
       streamId: "status"
-

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -55,6 +55,10 @@
 							<transformers>
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+								<transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+								  <mainClass>org.apache.storm.flux.Flux</mainClass>
+								</transformer>
 							</transformers>
 							<!-- The filters below are necessary if you want to include the Tika
 								module -->
@@ -81,6 +85,11 @@
 			<artifactId>storm-core</artifactId>
 			<version>1.0.1</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.storm</groupId>
+			<artifactId>flux-core</artifactId>
+			<version>1.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.digitalpebble.stormcrawler</groupId>

--- a/core/src/main/java/com/digitalpebble/storm/crawler/ConfigurableTopology.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/ConfigurableTopology.java
@@ -44,7 +44,7 @@ public abstract class ConfigurableTopology {
         // loads the default configuration file
         Map defaultSCConfig = Utils.findAndReadConfigFile(
                 "crawler-default.yaml", false);
-        topology.conf.putAll(defaultSCConfig);
+        topology.conf.putAll(ConfUtils.extractConfigElement(defaultSCConfig));
 
         String[] remainingArgs = topology.parse(args);
         topology.run(remainingArgs);

--- a/core/src/main/java/com/digitalpebble/storm/crawler/util/ConfUtils.java
+++ b/core/src/main/java/com/digitalpebble/storm/crawler/util/ConfUtils.java
@@ -77,7 +77,25 @@ public class ConfUtils {
         if (ret == null) {
             ret = new HashMap();
         }
+        // contains a single config element ?
+        else {
+            ret = extractConfigElement(ret);
+        }
         conf.putAll(ret);
+        return conf;
+    }
+
+    /**
+     * If the config consists of a single key 'config', its values are used
+     * instead
+     **/
+    public static Map extractConfigElement(Map conf) {
+        if (conf.size() == 1) {
+            Object confNode = conf.get("config");
+            if (confNode != null && confNode instanceof Map) {
+                conf = (Map) confNode;
+            }
+        }
         return conf;
     }
 }

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -3,104 +3,105 @@
 # Do not modify this file but instead provide a custom one with the parameter -config
 # when launching your extension of ConfigurableTopology.  
 
-fetcher.server.delay: 1.0
-fetcher.server.min.delay: 0.0
-fetcher.queue.mode: "byHost"
-fetcher.threads.per.queue: 1
-fetcher.threads.number: 10
+config: 
+  fetcher.server.delay: 1.0
+  fetcher.server.min.delay: 0.0
+  fetcher.queue.mode: "byHost"
+  fetcher.threads.per.queue: 1
+  fetcher.threads.number: 10
 
-# time bucket to use for the metrics sent by the Fetcher
-fetcher.metrics.time.bucket.secs: 10
+  # time bucket to use for the metrics sent by the Fetcher
+  fetcher.metrics.time.bucket.secs: 10
 
-partition.url.mode: "byHost"
+  partition.url.mode: "byHost"
 
-# metadata to transfer to the outlinks
-# used by Fetcher for redirections, sitemapparser, etc...
-# these are also persisted for the parent document (see below)
-# metadata.transfer:
-# - customMetadataName
+  # metadata to transfer to the outlinks
+  # used by Fetcher for redirections, sitemapparser, etc...
+  # these are also persisted for the parent document (see below)
+  # metadata.transfer:
+  # - customMetadataName
 
-# lists the metadata to persist to storage
-# these are not transfered to the outlinks
-metadata.persist:
- - _redirTo
- - error.cause
- - isSitemap
- - isFeed
+  # lists the metadata to persist to storage
+  # these are not transfered to the outlinks
+  metadata.persist:
+   - _redirTo
+   - error.cause
+   - isSitemap
+   - isFeed
 
-http.agent.name: "Anonymous Coward"
-http.agent.version: "1.0"
-http.agent.description: "A StormCrawler-based crawler"
-http.agent.url: "http://someorganization.com/"
-http.agent.email: "someone@someorganization.com"
+  http.agent.name: "Anonymous Coward"
+  http.agent.version: "1.0"
+  http.agent.description: "A StormCrawler-based crawler"
+  http.agent.url: "http://someorganization.com/"
+  http.agent.email: "someone@someorganization.com"
 
-http.accept.language: "en-us,en-gb,en;q=0.7,*;q=0.3"
-http.accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-http.content.limit: 65536
-http.store.responsetime: true
-http.timeout: 10000
+  http.accept.language: "en-us,en-gb,en;q=0.7,*;q=0.3"
+  http.accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+  http.content.limit: 65536
+  http.store.responsetime: true
+  http.timeout: 10000
 
-http.robots.403.allow: true
+  http.robots.403.allow: true
 
-# should the URLs be removed when a page is marked as noFollow
-robots.noFollow.strict: true
+  # should the URLs be removed when a page is marked as noFollow
+  robots.noFollow.strict: true
 
-protocols: "http,https"
-http.protocol.implementation: "com.digitalpebble.storm.crawler.protocol.httpclient.HttpProtocol"
-https.protocol.implementation: "com.digitalpebble.storm.crawler.protocol.httpclient.HttpProtocol"
+  protocols: "http,https"
+  http.protocol.implementation: "com.digitalpebble.storm.crawler.protocol.httpclient.HttpProtocol"
+  https.protocol.implementation: "com.digitalpebble.storm.crawler.protocol.httpclient.HttpProtocol"
 
-# no url or parsefilters by default
-# parsefilters.config.file: "parsefilters.json"
-# urlfilters.config.file: "urlfilters.json"
+  # no url or parsefilters by default
+  # parsefilters.config.file: "parsefilters.json"
+  # urlfilters.config.file: "urlfilters.json"
 
-# JSoupParserBolt
-jsoup.treat.non.html.as.error: true
-parser.emitOutlinks: true
-track.anchors: true
+  # JSoupParserBolt
+  jsoup.treat.non.html.as.error: true
+  parser.emitOutlinks: true
+  track.anchors: true
 
-# whether the sitemap parser should try to 
-# determine whether a page is a sitemap based
-# on its content if it is missing the K/V in the metadata
-sitemap.sniffContent: false
+  # whether the sitemap parser should try to 
+  # determine whether a page is a sitemap based
+  # on its content if it is missing the K/V in the metadata
+  sitemap.sniffContent: false
 
-# filters URLs in sitemaps based on their modified Date (if any)
-sitemap.filter.hours.since.modified: -1
+  # filters URLs in sitemaps based on their modified Date (if any)
+  sitemap.filter.hours.since.modified: -1
 
-# whether to add any sitemaps found in the robots.txt to the status stream
-# used by fetcher bolts. sitemap.sniffContent must be set to true if the 
-# discovery is enabled
-sitemap.discovery: false
+  # whether to add any sitemaps found in the robots.txt to the status stream
+  # used by fetcher bolts. sitemap.sniffContent must be set to true if the 
+  # discovery is enabled
+  sitemap.discovery: false
 
-# Default implementation of Scheduler
-scheduler.class: "com.digitalpebble.storm.crawler.persistence.DefaultScheduler"
+  # Default implementation of Scheduler
+  scheduler.class: "com.digitalpebble.storm.crawler.persistence.DefaultScheduler"
 
-# revisit a page daily (value in minutes)
-fetchInterval.default: 1440
+  # revisit a page daily (value in minutes)
+  fetchInterval.default: 1440
 
-# revisit a page with a fetch error after 2 hours (value in minutes)
-fetchInterval.fetch.error: 120
+  # revisit a page with a fetch error after 2 hours (value in minutes)
+  fetchInterval.fetch.error: 120
 
-# revisit a page with an error every month (value in minutes)
-fetchInterval.error: 44640
+  # revisit a page with an error every month (value in minutes)
+  fetchInterval.error: 44640
 
-# custom fetch interval to be used when a document has the key/value in its metadata
-# and has been fetched succesfully (value in minutes)
-# fetchInterval.isFeed=true: 10
+  # custom fetch interval to be used when a document has the key/value in its metadata
+  # and has been fetched succesfully (value in minutes)
+  # fetchInterval.isFeed=true: 10
 
-# max number of successive fetch errors before changing status to ERROR
-max.fetch.errors: 3
+  # max number of successive fetch errors before changing status to ERROR
+  max.fetch.errors: 3
 
-# Guava cache use by AbstractStatusUpdaterBolt for DISCOVERED URLs
-status.updater.use.cache: true
-status.updater.cache.spec: "maximumSize=10000,expireAfterAccess=1h"
+  # Guava cache use by AbstractStatusUpdaterBolt for DISCOVERED URLs
+  status.updater.use.cache: true
+  status.updater.cache.spec: "maximumSize=10000,expireAfterAccess=1h"
 
-# configuration for the classes extending AbstractIndexerBolt
-# indexer.md.filter: "someKey=aValue"
-indexer.url.fieldname: "url"
-indexer.text.fieldname: "content"
-indexer.canonical.name: "canonical"
-indexer.md.mapping:
-- parse.title=title
-- parse.keywords=keywords
-- parse.description=description
-
+  # configuration for the classes extending AbstractIndexerBolt
+  # indexer.md.filter: "someKey=aValue"
+  indexer.url.fieldname: "url"
+  indexer.text.fieldname: "content"
+  indexer.canonical.name: "canonical"
+  indexer.md.mapping:
+  - parse.title=title
+  - parse.keywords=keywords
+  - parse.description=description
+  


### PR DESCRIPTION
The crawl is defined in a file `crawler.flux` and the topology can get started with 

``` sh
storm jar target/<INSERTJARNAMEHERE>.jar  org.apache.storm.flux.Flux --local crawler.flux
```

The configuration (both custom and default) are now put in a root _config_ element so that the files can be used by both the ConfigurableTopology and Flux. The old format still works for the ConfigurableTopology.