### PR TITLE
ES SamplerAggregationSpout

### DIFF
--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/AggregationSpout.java
@@ -105,45 +105,45 @@ public class AggregationSpout extends BaseRichSpout {
      **/
     private static final String ESStatusMinDelayParamName = "es.status.min.delay.queries";
 
-    private String indexName;
-    private String docType;
+    protected String indexName;
+    protected String docType;
 
     private SpoutOutputCollector _collector;
 
-    private static Client client;
+    protected static Client client;
 
-    private Set<String> beingProcessed = new HashSet<>();
+    protected Set<String> beingProcessed = new HashSet<>();
 
-    private Queue<Values> buffer = new LinkedList<>();
+    protected Queue<Values> buffer = new LinkedList<>();
 
     /** Field name used for field collapsing e.g. metadata.hostname **/
-    private String partitionField;
+    protected String partitionField;
 
-    private int maxURLsPerBucket = 10;
+    protected int maxURLsPerBucket = 10;
 
-    private int maxBucketNum = 10;
+    protected int maxBucketNum = 10;
 
-    private MultiCountMetric eventCounter;
+    protected MultiCountMetric eventCounter;
 
     private boolean active = true;
 
-    private long minDelayBetweenQueries = 2000;
+    protected long minDelayBetweenQueries = 2000;
 
     /**
      * when using multiple instances - each one is in charge of a specific shard
      * useful when sharding based on host or domain to guarantee a good mix of
      * URLs
      */
-    private int shardID = -1;
+    protected int shardID = -1;
 
     private String bucketSortField = "";
 
     private String totalSortField = "";
 
-    private Date timePreviousQuery = null;
+    protected Date timePreviousQuery = null;
 
     /** Used to distinguish between instances in the logs **/
-    private String logIdprefix = "";
+    protected String logIdprefix = "";
 
     @Override
     public void open(Map stormConf, TopologyContext context,
@@ -256,7 +256,7 @@ public class AggregationSpout extends BaseRichSpout {
     }
 
     /** run a query on ES to populate the internal buffer **/
-    private void populateBuffer() {
+    protected void populateBuffer() {
 
         Date now = new Date();
 
@@ -388,7 +388,7 @@ public class AggregationSpout extends BaseRichSpout {
         eventCounter.scope("ES_docs").incrBy(numhits);
     }
 
-    private final Metadata fromKeyValues(Map<String, Object> keyValues) {
+    protected final Metadata fromKeyValues(Map<String, Object> keyValues) {
         Map<String, List<String>> mdAsMap = (Map<String, List<String>>) keyValues
                 .get("metadata");
         Metadata metadata = new Metadata();

--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/SamplerAggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/SamplerAggregationSpout.java
@@ -1,0 +1,129 @@
+package com.digitalpebble.storm.crawler.elasticsearch.persistence;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.storm.tuple.Values;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.sampler.SamplerAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.tophits.TopHits;
+import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.storm.crawler.Metadata;
+
+public class SamplerAggregationSpout extends AggregationSpout {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(SamplerAggregationSpout.class);
+
+    @Override
+    protected void populateBuffer() {
+
+        Date now = new Date();
+
+        // check that we allowed some time between queries
+        if (timePreviousQuery != null) {
+            long difference = now.getTime() - timePreviousQuery.getTime();
+            if (difference < minDelayBetweenQueries) {
+                long sleepTime = minDelayBetweenQueries - difference;
+                LOG.info(
+                        "{} Not enough time elapsed since {} - sleeping for {}",
+                        logIdprefix, timePreviousQuery, sleepTime);
+                try {
+                    Thread.sleep(sleepTime);
+                } catch (InterruptedException e) {
+                    LOG.error("{} InterruptedException caught while waiting",
+                            logIdprefix);
+                }
+                return;
+            }
+        }
+
+        timePreviousQuery = now;
+
+        LOG.info("{} Populating buffer with nextFetchDate <= {}", logIdprefix,
+                now);
+
+        QueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(
+                "nextFetchDate").lte(now);
+
+        SearchRequestBuilder srb = client.prepareSearch(indexName)
+                .setTypes(docType).setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setQuery(rangeQueryBuilder).setFrom(0).setSize(0)
+                .setExplain(false);
+
+        SamplerAggregationBuilder sab = AggregationBuilders.sampler("sample")
+                .field("metadata." + partitionField)
+                .maxDocsPerValue(maxURLsPerBucket)
+                .shardSize(maxURLsPerBucket * maxBucketNum);
+
+        TopHitsBuilder tophits = AggregationBuilders.topHits("docs")
+                .setSize(maxURLsPerBucket * maxBucketNum).setExplain(false);
+
+        sab.subAggregation(tophits);
+        srb.addAggregation(sab);
+
+        // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-preference.html
+        // _shards:2,3
+        if (shardID != -1) {
+            srb.setPreference("_shards:" + shardID);
+        }
+
+        // dump query to log
+        LOG.debug("{} ES query {}", logIdprefix, srb.toString());
+
+        long start = System.currentTimeMillis();
+        SearchResponse response = srb.execute().actionGet();
+        long end = System.currentTimeMillis();
+
+        eventCounter.scope("ES_query_time_msec").incrBy(end - start);
+
+        SingleBucketAggregation agg = response.getAggregations().get("sample");
+
+        int numhits = 0;
+        int alreadyprocessed = 0;
+
+        // filter results so that we don't include URLs we are already
+        // being processed
+        TopHits topHits = agg.getAggregations().get("docs");
+        for (SearchHit hit : topHits.getHits().getHits()) {
+
+            Map<String, Object> keyValues = hit.sourceAsMap();
+            String url = (String) keyValues.get("url");
+
+            LOG.debug("{} -> id [{}], _source [{}]", logIdprefix, hit.getId(),
+                    hit.getSourceAsString());
+
+            // is already being processed - skip it!
+            if (beingProcessed.contains(url)) {
+                alreadyprocessed++;
+                continue;
+            }
+            Metadata metadata = fromKeyValues(keyValues);
+            buffer.add(new Values(url, metadata));
+        }
+
+        // Shuffle the URLs so that we don't get blocks of URLs from the same
+        // host or domain
+        Collections.shuffle((List) buffer);
+
+        LOG.info(
+                "{} ES query returned {} hits in {} msec with {} already being processed",
+                logIdprefix, numhits, end - start, alreadyprocessed);
+
+        eventCounter.scope("already_being_processed").incrBy(alreadyprocessed);
+        eventCounter.scope("ES_queries").incrBy(1);
+        eventCounter.scope("ES_docs").incrBy(numhits);
+    }
+}

--- a/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/SamplerAggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/storm/crawler/elasticsearch/persistence/SamplerAggregationSpout.java
@@ -98,7 +98,7 @@ public class SamplerAggregationSpout extends AggregationSpout {
         // being processed
         TopHits topHits = agg.getAggregations().get("docs");
         for (SearchHit hit : topHits.getHits().getHits()) {
-
+            numhits++;
             Map<String, Object> keyValues = hit.sourceAsMap();
             String url = (String) keyValues.get("url");
 


### PR DESCRIPTION
See #299 

This introduces a new SamplerAggregationSpout which uses the Sampler aggregation from ES 2.x
Unlike the existing AggregationSpout there is no guarantee that the URLs returned will be the oldest available. This spout greatly reduces the average query time (by up to 50% in some cases) which improves the overall performance of the crawler. 

This new class extends AggregationSpout.
