### PR TITLE
ES Cache URLs post ack/fail

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/MetadataTransfer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/MetadataTransfer.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 
+import com.digitalpebble.stormcrawler.Constants;
 import com.digitalpebble.stormcrawler.Metadata;
 
 import clojure.lang.PersistentVector;
@@ -148,6 +149,9 @@ public class MetadataTransfer {
             else {
                 mdToPersistOnly.add(obj.toString());
             }
+
+            // always add the fetch error count
+            mdToPersistOnly.add(Constants.fetchErrorCountParamName);
         }
     }
 

--- a/external/elasticsearch/es-conf.yaml
+++ b/external/elasticsearch/es-conf.yaml
@@ -39,6 +39,9 @@ es.status.routing.fieldname: "hostname"
 es.status.bulkActions: 500
 es.status.flushInterval: "5s"
 
+# used by spouts - time in secs for which the URLs will be considered for fetching after a ack of fail
+es.status.ttl.purgatory: 30
+
 # ElasticSearchSpout
 # ES Spout throttling. Uses configuration of URLPartitionerBolt for the bucket key.
 es.status.max.inflight.urls.per.bucket: -1

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/SamplerAggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/SamplerAggregationSpout.java
@@ -106,7 +106,7 @@ public class SamplerAggregationSpout extends AggregationSpout {
                     hit.getSourceAsString());
 
             // is already being processed - skip it!
-            if (beingProcessed.contains(url)) {
+            if (beingProcessed.containsKey(url)) {
                 alreadyprocessed++;
                 continue;
             }


### PR DESCRIPTION
Fixes #340 

The abstract class contains an extension of Map for the URLs in process, this extension also contains a Guava cache which gets populated when entries are removed from the map.

The time during which the entries remain in the cache is configurable. We also report 2 separate metrics for the # of entries in the map and in the cache.

Not yet tested but reviews welcome as usual

FYI @sebastian-nagel