### PR TITLE
Use min.delay.queries for all types of spouts 

### DIFF
--- a/external/elasticsearch/es-conf.yaml
+++ b/external/elasticsearch/es-conf.yaml
@@ -42,6 +42,9 @@ es.status.flushInterval: "5s"
 # used by spouts - time in secs for which the URLs will be considered for fetching after a ack of fail
 es.status.ttl.purgatory: 30
 
+# Min time (in msecs) to allow between 2 successive queries to ES
+es.status.min.delay.queries: 2000
+
 # ElasticSearchSpout
 # ES Spout throttling. Uses configuration of URLPartitionerBolt for the bucket key.
 es.status.max.inflight.urls.per.bucket: -1

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ElasticSearchSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ElasticSearchSpout.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.Utils;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
@@ -112,6 +113,14 @@ public class ElasticSearchSpout extends AbstractSpout {
         // inactive?
         if (active == false)
             return;
+
+        // check that we allowed some time between queries
+        if (throttleESQueries()) {
+            // sleep for a bit but not too much in order to give ack/fail a
+            // chance
+            Utils.sleep(10);
+            return;
+        }
 
         // have anything in the buffer?
         if (!buffer.isEmpty()) {

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/SamplerAggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/SamplerAggregationSpout.java
@@ -32,26 +32,6 @@ public class SamplerAggregationSpout extends AggregationSpout {
 
         Date now = new Date();
 
-        // check that we allowed some time between queries
-        if (timePreviousQuery != null) {
-            long difference = now.getTime() - timePreviousQuery.getTime();
-            if (difference < minDelayBetweenQueries) {
-                long sleepTime = minDelayBetweenQueries - difference;
-                LOG.info(
-                        "{} Not enough time elapsed since {} - sleeping for {}",
-                        logIdprefix, timePreviousQuery, sleepTime);
-                try {
-                    Thread.sleep(sleepTime);
-                } catch (InterruptedException e) {
-                    LOG.error("{} InterruptedException caught while waiting",
-                            logIdprefix);
-                }
-                return;
-            }
-        }
-
-        timePreviousQuery = now;
-
         LOG.info("{} Populating buffer with nextFetchDate <= {}", logIdprefix,
                 now);
 


### PR DESCRIPTION
- don't sleep for the whole delay as this would block ack/fails
