### PR TITLE
Non-blocking calls to ES for AggregationSpouts

### DIFF
--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
@@ -99,7 +99,7 @@ public abstract class AbstractSpout extends BaseRichSpout {
      */
     protected InProcessMap<String, String> beingProcessed;
 
-    private Date timePreviousQuery;
+    protected long timeStartESQuery = 0;
 
     private long minDelayBetweenQueries = 2000;
 
@@ -218,18 +218,17 @@ public abstract class AbstractSpout extends BaseRichSpout {
     /** Returns true if ES was queried too recently and needs throttling **/
     protected boolean throttleESQueries() {
         Date now = new Date();
-        if (timePreviousQuery != null) {
+        if (timeStartESQuery != 0) {
             // check that we allowed some time between queries
-            long difference = now.getTime() - timePreviousQuery.getTime();
+            long difference = now.getTime() - timeStartESQuery;
             if (difference < minDelayBetweenQueries) {
                 long sleepTime = minDelayBetweenQueries - difference;
                 LOG.debug(
                         "{} Not enough time elapsed since {} - should try again in {}",
-                        logIdprefix, timePreviousQuery, sleepTime);
+                        logIdprefix, timeStartESQuery, sleepTime);
                 return true;
             }
         }
-        timePreviousQuery = now;
         return false;
     }
 

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
@@ -91,8 +91,6 @@ public class AggregationSpout extends AbstractSpout implements
 
     private String totalSortField = "";
 
-    private long timeStartESQuery = 0;
-
     private AtomicBoolean isInESQuery = new AtomicBoolean(false);
 
     @Override
@@ -123,14 +121,6 @@ public class AggregationSpout extends AbstractSpout implements
         if (active == false)
             return;
 
-        // check that we allowed some time between queries
-        if (throttleESQueries()) {
-            // sleep for a bit but not too much in order to give ack/fail a
-            // chance
-            Utils.sleep(10);
-            return;
-        }
-
         synchronized (buffer) {
             // have anything in the buffer?
             if (!buffer.isEmpty()) {
@@ -144,6 +134,14 @@ public class AggregationSpout extends AbstractSpout implements
 
                 return;
             }
+        }
+
+        // check that we allowed some time between queries
+        if (throttleESQueries()) {
+            // sleep for a bit but not too much in order to give ack/fail a
+            // chance
+            Utils.sleep(10);
+            return;
         }
 
         // re-populate the buffer

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
@@ -21,12 +21,14 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Values;
 import org.apache.storm.utils.Utils;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
@@ -57,7 +59,8 @@ import com.digitalpebble.stormcrawler.util.ConfUtils;
  * metadata.hostname.
  **/
 @SuppressWarnings("serial")
-public class AggregationSpout extends AbstractSpout {
+public class AggregationSpout extends AbstractSpout implements
+        ActionListener<SearchResponse> {
 
     private static final Logger LOG = LoggerFactory
             .getLogger(AggregationSpout.class);
@@ -87,6 +90,10 @@ public class AggregationSpout extends AbstractSpout {
     private String bucketSortField = "";
 
     private String totalSortField = "";
+
+    private long timeStartESQuery = 0;
+
+    private AtomicBoolean isInESQuery = new AtomicBoolean(false);
 
     @Override
     public void open(Map stormConf, TopologyContext context,
@@ -124,20 +131,25 @@ public class AggregationSpout extends AbstractSpout {
             return;
         }
 
-        // have anything in the buffer?
-        if (!buffer.isEmpty()) {
-            Values fields = buffer.remove();
+        synchronized (buffer) {
+            // have anything in the buffer?
+            if (!buffer.isEmpty()) {
+                Values fields = buffer.remove();
 
-            String url = fields.get(0).toString();
-            beingProcessed.put(url, null);
+                String url = fields.get(0).toString();
+                beingProcessed.put(url, null);
 
-            _collector.emit(fields, url);
-            eventCounter.scope("emitted").incrBy(1);
+                _collector.emit(fields, url);
+                eventCounter.scope("emitted").incrBy(1);
 
-            return;
+                return;
+            }
         }
+
         // re-populate the buffer
-        populateBuffer();
+        if (!isInESQuery.get()) {
+            populateBuffer();
+        }
     }
 
     /** run a query on ES to populate the internal buffer **/
@@ -189,11 +201,23 @@ public class AggregationSpout extends AbstractSpout {
         // dump query to log
         LOG.debug("{} ES query {}", logIdprefix, srb.toString());
 
-        long start = System.currentTimeMillis();
-        SearchResponse response = srb.execute().actionGet();
+        timeStartESQuery = System.currentTimeMillis();
+        isInESQuery.set(true);
+        srb.execute(this);
+    }
+
+    @Override
+    public void onFailure(Throwable arg0) {
+        LOG.error("Exception with ES query", arg0);
+        isInESQuery.set(false);
+    }
+
+    @Override
+    public void onResponse(SearchResponse response) {
+
         long end = System.currentTimeMillis();
 
-        eventCounter.scope("ES_query_time_msec").incrBy(end - start);
+        eventCounter.scope("ES_query_time_msec").incrBy(end - timeStartESQuery);
 
         Aggregations aggregs = response.getAggregations();
 
@@ -203,54 +227,61 @@ public class AggregationSpout extends AbstractSpout {
         int numBuckets = 0;
         int alreadyprocessed = 0;
 
-        // For each entry
-        for (Terms.Bucket entry : agg.getBuckets()) {
-            String key = (String) entry.getKey(); // bucket key
-            long docCount = entry.getDocCount(); // Doc count
+        synchronized (buffer) {
+            // For each entry
+            for (Terms.Bucket entry : agg.getBuckets()) {
+                String key = (String) entry.getKey(); // bucket key
+                long docCount = entry.getDocCount(); // Doc count
 
-            int hitsForThisBucket = 0;
+                int hitsForThisBucket = 0;
 
-            // filter results so that we don't include URLs we are already
-            // being processed
-            TopHits topHits = entry.getAggregations().get("docs");
-            for (SearchHit hit : topHits.getHits().getHits()) {
-                hitsForThisBucket++;
+                // filter results so that we don't include URLs we are already
+                // being processed
+                TopHits topHits = entry.getAggregations().get("docs");
+                for (SearchHit hit : topHits.getHits().getHits()) {
+                    hitsForThisBucket++;
 
-                Map<String, Object> keyValues = hit.sourceAsMap();
-                String url = (String) keyValues.get("url");
+                    Map<String, Object> keyValues = hit.sourceAsMap();
+                    String url = (String) keyValues.get("url");
 
-                LOG.debug("{} -> id [{}], _source [{}]", logIdprefix,
-                        hit.getId(), hit.getSourceAsString());
+                    LOG.debug("{} -> id [{}], _source [{}]", logIdprefix,
+                            hit.getId(), hit.getSourceAsString());
 
-                // is already being processed - skip it!
-                if (beingProcessed.containsKey(url)) {
-                    alreadyprocessed++;
-                    continue;
+                    // is already being processed - skip it!
+                    if (beingProcessed.containsKey(url)) {
+                        alreadyprocessed++;
+                        continue;
+                    }
+                    Metadata metadata = fromKeyValues(keyValues);
+                    buffer.add(new Values(url, metadata));
                 }
-                Metadata metadata = fromKeyValues(keyValues);
-                buffer.add(new Values(url, metadata));
+
+                if (hitsForThisBucket > 0)
+                    numBuckets++;
+
+                numhits += hitsForThisBucket;
+
+                LOG.debug("{} key [{}], hits[{}], doc_count [{}]", logIdprefix,
+                        key, hitsForThisBucket, docCount, alreadyprocessed);
             }
 
-            if (hitsForThisBucket > 0)
-                numBuckets++;
-
-            numhits += hitsForThisBucket;
-
-            LOG.debug("{} key [{}], hits[{}], doc_count [{}]", logIdprefix,
-                    key, hitsForThisBucket, docCount, alreadyprocessed);
+            // Shuffle the URLs so that we don't get blocks of URLs from the
+            // same
+            // host or domain
+            Collections.shuffle((List) buffer);
         }
-
-        // Shuffle the URLs so that we don't get blocks of URLs from the same
-        // host or domain
-        Collections.shuffle((List) buffer);
 
         LOG.info(
                 "{} ES query returned {} hits from {} buckets in {} msec with {} already being processed",
-                logIdprefix, numhits, numBuckets, end - start, alreadyprocessed);
+                logIdprefix, numhits, numBuckets, end - timeStartESQuery,
+                alreadyprocessed);
 
         eventCounter.scope("already_being_processed").incrBy(alreadyprocessed);
         eventCounter.scope("ES_queries").incrBy(1);
         eventCounter.scope("ES_docs").incrBy(numhits);
+
+        // remove lock
+        isInESQuery.set(false);
     }
 
 }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
@@ -91,7 +91,7 @@ public class AggregationSpout extends AbstractSpout implements
 
     private String totalSortField = "";
 
-    private AtomicBoolean isInESQuery = new AtomicBoolean(false);
+    protected AtomicBoolean isInESQuery = new AtomicBoolean(false);
 
     @Override
     public void open(Map stormConf, TopologyContext context,

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/SamplerAggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/SamplerAggregationSpout.java
@@ -63,47 +63,60 @@ public class SamplerAggregationSpout extends AggregationSpout {
         // dump query to log
         LOG.debug("{} ES query {}", logIdprefix, srb.toString());
 
-        long start = System.currentTimeMillis();
-        SearchResponse response = srb.execute().actionGet();
+        timeStartESQuery = System.currentTimeMillis();
+
+        isInESQuery.set(true);
+        srb.execute(this);
+    }
+
+    @Override
+    public void onResponse(SearchResponse response) {
         long end = System.currentTimeMillis();
 
-        eventCounter.scope("ES_query_time_msec").incrBy(end - start);
+        eventCounter.scope("ES_query_time_msec").incrBy(end - timeStartESQuery);
 
         SingleBucketAggregation agg = response.getAggregations().get("sample");
 
         int numhits = 0;
         int alreadyprocessed = 0;
 
-        // filter results so that we don't include URLs we are already
-        // being processed
-        TopHits topHits = agg.getAggregations().get("docs");
-        for (SearchHit hit : topHits.getHits().getHits()) {
-            numhits++;
-            Map<String, Object> keyValues = hit.sourceAsMap();
-            String url = (String) keyValues.get("url");
+        synchronized (buffer) {
+            // filter results so that we don't include URLs we are already
+            // being processed
+            TopHits topHits = agg.getAggregations().get("docs");
+            for (SearchHit hit : topHits.getHits().getHits()) {
+                numhits++;
+                Map<String, Object> keyValues = hit.sourceAsMap();
+                String url = (String) keyValues.get("url");
 
-            LOG.debug("{} -> id [{}], _source [{}]", logIdprefix, hit.getId(),
-                    hit.getSourceAsString());
+                LOG.debug("{} -> id [{}], _source [{}]", logIdprefix,
+                        hit.getId(), hit.getSourceAsString());
 
-            // is already being processed - skip it!
-            if (beingProcessed.containsKey(url)) {
-                alreadyprocessed++;
-                continue;
+                // is already being processed - skip it!
+                if (beingProcessed.containsKey(url)) {
+                    alreadyprocessed++;
+                    continue;
+                }
+                Metadata metadata = fromKeyValues(keyValues);
+                buffer.add(new Values(url, metadata));
             }
-            Metadata metadata = fromKeyValues(keyValues);
-            buffer.add(new Values(url, metadata));
-        }
 
-        // Shuffle the URLs so that we don't get blocks of URLs from the same
-        // host or domain
-        Collections.shuffle((List) buffer);
+            // Shuffle the URLs so that we don't get blocks of URLs from the
+            // same
+            // host or domain
+            Collections.shuffle((List) buffer);
+        }
 
         LOG.info(
                 "{} ES query returned {} hits in {} msec with {} already being processed",
-                logIdprefix, numhits, end - start, alreadyprocessed);
+                logIdprefix, numhits, end - timeStartESQuery, alreadyprocessed);
 
         eventCounter.scope("already_being_processed").incrBy(alreadyprocessed);
         eventCounter.scope("ES_queries").incrBy(1);
         eventCounter.scope("ES_docs").incrBy(numhits);
+
+        // remove lock
+        isInESQuery.set(false);
     }
+
 }


### PR DESCRIPTION
Implements #371 and fixes a bug introduced in #370 
Not implemented in the non-aggregation spout for now.

This should improve the performance a bit as slow queries to ES should not block ack and fail. 
