### PR TITLE
Add adaptive fetch scheduler

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/MD5SignatureParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/MD5SignatureParseFilter.java
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  * <dt>keyNameCopy</dt>
  * <dd>name of the metadata field to hold a temporary copy of the signature used
  * to decide by signature comparison whether the document has changed. If not
- * defined, the signature is not copied.</dd>
+ * defined or empty, the signature is not copied.</dd>
  * </dl>
  *
  */
@@ -63,8 +63,9 @@ public class MD5SignatureParseFilter extends ParseFilter {
         Metadata metadata = parseData.getMetadata();
         if (copyKeyName != null) {
             String signature = metadata.getFirstValue(key_name);
-            if (signature != null)
+            if (signature != null) {
                 metadata.setValue(copyKeyName, signature);
+            }
         }
         byte[] data = null;
         if (useText) {
@@ -94,9 +95,9 @@ public class MD5SignatureParseFilter extends ParseFilter {
             key_name = node.asText("signature");
         }
         node = filterParams.get("keyNameCopy");
-        if (node != null && node.isTextual()) {
+        if (node != null && node.isTextual()
+                && StringUtils.isNotBlank(node.asText(""))) {
             copyKeyName = node.asText("signatureOld");
-            System.out.println("HERE: signatureOld" + copyKeyName);
         }
     }
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/MD5SignatureParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/MD5SignatureParseFilter.java
@@ -33,6 +33,20 @@ import com.fasterxml.jackson.databind.JsonNode;
 /**
  * Computes a signature for a page, based on the binary content or text. If the
  * content is empty, the URL is used.
+ *
+ * Configuration properties:
+ * <dl>
+ * <dt>useText</dt>
+ * <dd>compute signature on plain text, instead of binary content</dd>
+ * <dt>keyName</dt>
+ * <dd>name of the metadata field to hold the signature (default:
+ * &quot;signature&quot;)</dd>
+ * <dt>keyNameCopy</dt>
+ * <dd>name of the metadata field to hold a temporary copy of the signature used
+ * to decide by signature comparison whether the document has changed. If not
+ * defined, the signature is not copied.</dd>
+ * </dl>
+ *
  */
 public class MD5SignatureParseFilter extends ParseFilter {
 
@@ -40,11 +54,18 @@ public class MD5SignatureParseFilter extends ParseFilter {
 
     private boolean useText = false;
 
+    private String copyKeyName = null;
+
     @Override
     public void filter(String URL, byte[] content, DocumentFragment doc,
             ParseResult parse) {
         ParseData parseData = parse.get(URL);
         Metadata metadata = parseData.getMetadata();
+        if (copyKeyName != null) {
+            String signature = metadata.getFirstValue(key_name);
+            if (signature != null)
+                metadata.setValue(copyKeyName, signature);
+        }
         byte[] data = null;
         if (useText) {
             String text = parseData.getText();
@@ -71,6 +92,11 @@ public class MD5SignatureParseFilter extends ParseFilter {
         node = filterParams.get("keyName");
         if (node != null && node.isTextual()) {
             key_name = node.asText("signature");
+        }
+        node = filterParams.get("keyNameCopy");
+        if (node != null && node.isTextual()) {
+            copyKeyName = node.asText("signatureOld");
+            System.out.println("HERE: signatureOld" + copyKeyName);
         }
     }
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
@@ -140,8 +140,6 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
             metadata.setValue("lastProcessedDate", nowAsString);
         }
 
-        metadata = mdTransfer.filter(metadata);
-
         // too many fetch errors?
         if (status.equals(Status.FETCH_ERROR)) {
             String errorCount = metadata
@@ -170,6 +168,10 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
 
         // determine the value of the next fetch based on the status
         Date nextFetch = scheduler.schedule(status, metadata);
+
+        // filter metadata just before storing it, so that non-persisted
+        // metadata is available to fetch schedulers
+        metadata = mdTransfer.filter(metadata);
 
         // extensions of this class will handle the storage
         // on a per document basis

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AdaptiveScheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AdaptiveScheduler.java
@@ -1,0 +1,322 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.persistence;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.stormcrawler.Constants;
+import com.digitalpebble.stormcrawler.Metadata;
+import com.digitalpebble.stormcrawler.parse.filter.MD5SignatureParseFilter;
+import com.digitalpebble.stormcrawler.persistence.DefaultScheduler;
+import com.digitalpebble.stormcrawler.persistence.Status;
+import com.digitalpebble.stormcrawler.protocol.HttpHeaders;
+import com.digitalpebble.stormcrawler.util.ConfUtils;
+
+/**
+ * Adaptive fetch scheduler, checks by signature comparison whether a re-fetched
+ * page has changed:
+ * <ul>
+ * <li>if yes, shrink the fetch interval up to a minimum fetch interval</li>
+ * <li>if not, increase the fetch interval up to a maximum</li>
+ * </ul>
+ * 
+ * <p>
+ * The rate how the fetch interval is incremented or decremented is
+ * configurable.
+ * </p>
+ * 
+ * <p>
+ * Note, that this scheduler requires the following metadata:
+ * <dl>
+ * <dt>signature</dt>
+ * <dd>page signature, filled by {@link MD5SignatureParseFilter}</dd>
+ * <dt>signatureOld</dt>
+ * <dd>(temporary) copy of the previous signature, optionally copied by
+ * {@link MD5SignatureParseFilter}</dd>
+ * <dt>fetch.statusCode
+ * <dt>
+ * <dd>HTTP response status code, required to handle &quot;HTTP 304 Not
+ * Modified&quot; responses</dd>
+ * </dl>
+ * and writes the following metadata fields:
+ * <dl>
+ * <dt>fetchInterval</dt>
+ * <dd>current fetch interval</dd>
+ * <dt>signatureChangeDate</dt>
+ * <dd>date when the signature has changed</dd>
+ * <dt>last-modified</dt>
+ * <dd>last-modified time used to send If-Modified-Since HTTP requests, only
+ * written if <code>scheduler.adaptive.setLastModified</code> is true)</dd>
+ * </p>
+ * 
+ * <h2>Configuration</h2>
+ * <p>
+ * The following lines show how to configure the adaptive scheduler in the
+ * configuration file (crawler-conf.yaml):
+ * 
+ * <pre>
+ * scheduler.class: "com.digitalpebble.stormcrawler.persistence.AdaptiveScheduler"
+ * # set last-modified time ({@link HttpHeaders.LAST_MODIFIED}) used in HTTP If-Modified-Since request header field
+ * scheduler.adaptive.setLastModified: true
+ * # min. interval in minutes (default: 1h)
+ * scheduler.adaptive.fetchInterval.min: 60
+ * # max. interval in minutes (default: 2 weeks)
+ * scheduler.adaptive.fetchInterval.max: 20160
+ * # increment and decrement rates (0.0 < rate <= 1.0)
+ * scheduler.adaptive.fetchInterval.rate.incr: .5
+ * scheduler.adaptive.fetchInterval.rate.decr: .5
+ * 
+ * # (additionally) required persisted metadata:
+ * metadata.persist:
+ *  - ...
+ *  - signature
+ *  - signatureOld
+ *  - fetch.statusCode
+ *  - fetchInterval
+ *  - signatureChangeDate
+ *  - last-modified
+ * </pre>
+ * </p>
+ * 
+ * <p>
+ * To generate the signature and keep a copy of the last signature, the parse
+ * filters should be configured accordingly:
+ * 
+ * <pre>
+ * "com.digitalpebble.stormcrawler.parse.ParseFilters": [
+ *   ...,
+ *   {
+ *     "class": "com.digitalpebble.stormcrawler.parse.filter.MD5SignatureParseFilter",
+ *     "name": "MD5Digest",
+ *     "params": {
+ *       "useText": "false",
+ *       "keyName": "signature",
+ *       "keyNameCopy": "signatureOld"
+ *     }
+ *   }
+ * </pre>
+ * 
+ * The order is mandatory: first copy the old signature, than generate the
+ * current one.
+ * </p>
+ */
+public class AdaptiveScheduler extends DefaultScheduler {
+
+    /**
+     * Configuration property (boolean) whether or not to set the
+     * &quot;last-modified&quot; metadata field when a page change was detected
+     * by signature comparison.
+     */
+    public static final String SET_LAST_MODIFIED = "scheduler.adaptive.setLastModified";
+
+    /**
+     * Configuration property (int) to set the minimum fetch interval in
+     * minutes.
+     */
+    public static final String INTERVAL_MIN = "scheduler.adaptive.fetchInterval.min";
+
+    /**
+     * Configuration property (int) to set the maximum fetch interval in
+     * minutes.
+     */
+    public static final String INTERVAL_MAX = "scheduler.adaptive.fetchInterval.max";
+
+    /**
+     * Configuration property (float) to set the increment rate. If a page
+     * hasn't changed when refetched, the fetch interval is multiplied by
+     * (1.0 + incr_rate) until the max. fetch interval is reached.
+     */
+    public static final String INTERVAL_INC_RATE = "scheduler.adaptive.fetchInterval.rate.incr";
+
+    /**
+     * Configuration property (float) to set the decrement rate. If a page
+     * has changed when refetched, the fetch interval is multiplied by
+     * (1.0 - decr_rate). If the fetch interval comes closer to the
+     * minimum interval, the decrementing is slowed down.
+     */
+    public static final String INTERVAL_DEC_RATE = "scheduler.adaptive.fetchInterval.rate.decr";
+
+    /**
+     * Name of the signature key in metadata, must be defined as
+     * &quot;keyName&quot; in the configuration of
+     * {@link com.digitalpebble.stormcrawler.parse.filter.MD5SignatureParseFilter}.
+     * This key must be listed in &quot;metadata.persist&quot;.
+     */
+    public static final String SIGNATURE_KEY = "signature";
+
+    /**
+     * Name of key to hold previous signature: a copy, not overwritten by
+     * {@link MD5SignatureParseFilter}, is added by
+     * {@link com.digitalpebble.stormcrawler.parse.filter.SignatureCopyParseFilter}.
+     * This key is a temporary copy, not necessarily persisted in metadata.
+     */
+    public static final String SIGNATURE_OLD_KEY = "signatureOld";
+
+    /**
+     * Key to store the current fetch interval value,
+     * must be listed in &quot;metadata.persist&quot;.
+     */
+    public static final String FETCH_INTERVAL_KEY = "fetchInterval";
+
+    /**
+     * Key to store the date when the signature has been changed,
+     * must be listed in &quot;metadata.persist&quot;.
+     */
+    public static final String SIGNATURE_MODIFIED_KEY = "signatureChangeDate";
+
+
+    private static final org.slf4j.Logger LOG = LoggerFactory
+            .getLogger(AdaptiveScheduler.class);
+
+    protected int defaultfetchInterval;
+    protected int minFetchInterval = 60;
+    protected int maxFetchInterval = 60 * 24 * 14;
+    protected float fetchIntervalDecRate = .5f;
+    protected float fetchIntervalIncRate = .5f;
+
+    protected boolean setLastModified = false;
+    protected boolean overwriteLastModified = false;
+
+    /**
+     * Format dates in HTTP headers, cf. <a href=
+     * "https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3">sec3.3 in
+     * RFC 2616</a>. Used to fill the last-modified metadata field.
+     */
+    protected SimpleDateFormat httpDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
+
+    @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void init(Map stormConf) {
+        defaultfetchInterval = ConfUtils.getInt(stormConf,
+                Constants.defaultFetchIntervalParamName, 1440);
+        setLastModified = ConfUtils.getBoolean(stormConf, SET_LAST_MODIFIED,
+                false);
+        minFetchInterval = ConfUtils.getInt(stormConf, INTERVAL_MIN,
+                minFetchInterval);
+        maxFetchInterval = ConfUtils.getInt(stormConf, INTERVAL_MAX,
+                maxFetchInterval);
+        fetchIntervalDecRate = ConfUtils.getFloat(stormConf, INTERVAL_DEC_RATE,
+                fetchIntervalDecRate);
+        fetchIntervalIncRate = ConfUtils.getFloat(stormConf, INTERVAL_INC_RATE,
+                fetchIntervalIncRate);
+        super.init(stormConf);
+    }
+
+    @Override
+    public Date schedule(Status status, Metadata metadata) {
+        LOG.debug("Scheduling status: {}, metadata: {}", status, metadata);
+
+        String signature = metadata.getFirstValue(SIGNATURE_KEY);
+        String oldSignature = metadata.getFirstValue(SIGNATURE_OLD_KEY); 
+
+        if (status != Status.FETCHED) {
+
+            // reset all metadata
+            metadata.remove(SIGNATURE_MODIFIED_KEY);
+            metadata.remove(FETCH_INTERVAL_KEY);
+            metadata.remove(SIGNATURE_KEY);
+            metadata.remove(SIGNATURE_OLD_KEY);
+
+            // fall-back to DefaultScheduler
+            return super.schedule(status, metadata);
+        }
+
+        Calendar now = Calendar.getInstance(Locale.ROOT);
+
+        String signatureModified = metadata
+                .getFirstValue(SIGNATURE_MODIFIED_KEY);
+
+        boolean changed = false;
+
+        final String modifiedTimeString = httpDateFormat.format(now.getTime());
+
+        if (signature == null || oldSignature == null) {
+            // no decision possible by signature comparison if
+            // - document not parsed (intentionally or not) or
+            // - signature not generated or
+            // - old signature not copied
+
+            if (metadata.getFirstValue("fetch.statusCode").equals("304")) {
+                // HTTP 304 Not Modified
+            } else {
+                // fall-back to DefaultScheduler
+                LOG.debug("No signature for FETCHED page: {}", metadata);
+                return super.schedule(status, metadata);
+            }
+
+        } else if (signature.equals(oldSignature)) {
+            // unchanged, remove old signature (do not keep same signature twice)
+            metadata.remove(SIGNATURE_OLD_KEY);
+            if (signatureModified == null)
+                signatureModified = modifiedTimeString;
+        } else {
+            // change detected by signature comparison
+            changed = true;
+            signatureModified = modifiedTimeString;
+            if (setLastModified)
+                metadata.setValue(HttpHeaders.LAST_MODIFIED, modifiedTimeString);
+        }
+
+        String fetchInterval = metadata.getFirstValue(FETCH_INTERVAL_KEY);
+        int interval = defaultfetchInterval;
+        if (fetchInterval != null) {
+            interval = Integer.parseInt(fetchInterval);
+        } else {
+            // initialize from DefaultScheduler
+            Optional<Integer> customInterval = super.checkCustomInterval(metadata, status);
+            if (customInterval.isPresent())
+                interval = customInterval.get();
+            else
+                interval = defaultfetchInterval;
+            fetchInterval = Integer.toString(interval);
+        }
+
+        if (changed) {
+            // shrink fetch interval (slow down decrementing if already close to
+            // the minimum interval)
+            interval = (int) ((1.0f - fetchIntervalDecRate) * interval
+                    + fetchIntervalDecRate * minFetchInterval);
+            LOG.debug("Signature has changed, fetchInterval decreased from {} to {}",
+                    fetchInterval, interval);
+
+        } else {
+            // no change or not modified, increase fetch interval
+            interval = (int) (interval * (1.0f + fetchIntervalIncRate));
+            if (interval > maxFetchInterval)
+                interval = maxFetchInterval;
+            LOG.debug(
+                    "Unchanged, fetchInterval increased from {} to {}",
+                    fetchInterval, interval);
+        }
+
+        metadata.setValue(FETCH_INTERVAL_KEY, Integer.toString(interval));
+        metadata.setValue(SIGNATURE_MODIFIED_KEY, signatureModified);
+
+        now.add(Calendar.MINUTE, interval);
+
+        return now.getTime();
+    }
+
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AdaptiveScheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AdaptiveScheduler.java
@@ -68,7 +68,8 @@ import com.digitalpebble.stormcrawler.util.ConfUtils;
  * <dd>date when the signature has changed</dd>
  * <dt>last-modified</dt>
  * <dd>last-modified time used to send If-Modified-Since HTTP requests, only
- * written if <code>scheduler.adaptive.setLastModified</code> is true)</dd>
+ * written if <code>scheduler.adaptive.setLastModified</code> is true. Same date
+ * string as set in &quot;signatureChangeDate&quot;.</dd>
  * </p>
  * 
  * <h2>Configuration</h2>
@@ -88,15 +89,17 @@ import com.digitalpebble.stormcrawler.util.ConfUtils;
  * scheduler.adaptive.fetchInterval.rate.incr: .5
  * scheduler.adaptive.fetchInterval.rate.decr: .5
  * 
- * # (additionally) required persisted metadata:
+ * # required persisted metadata (in addition to other persisted metadata):
  * metadata.persist:
  *  - ...
  *  - signature
- *  - signatureOld
  *  - fetch.statusCode
  *  - fetchInterval
- *  - signatureChangeDate
  *  - last-modified
+ * # - signatureOld
+ * # - signatureChangeDate
+ * # Note: "signatureOld" and "signatureChangeDate" are optional, the adaptive
+ * # scheduler will also work if both are temporarily passed and not persisted.
  * </pre>
  * </p>
  * 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/DefaultScheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/DefaultScheduler.java
@@ -144,7 +144,7 @@ public class DefaultScheduler extends Scheduler {
     /**
      * Returns the first matching custom interval
      **/
-    private final Optional<Integer> checkCustomInterval(Metadata metadata,
+    protected final Optional<Integer> checkCustomInterval(Metadata metadata,
             Status s) {
         if (customIntervals == null)
             return Optional.empty();


### PR DESCRIPTION
Add implementation of Scheduler which 
- checks fetch status (304 not modified) or compares previous and current signature
  to decide whether a page has changed since the previous fetch
- if changed, decreases the fetch interval
- otherwise increases it up to a configurable limit

See also commoncrawl/news-crawl#15.

Possible TODOs:
- add unit tests
- simplify configuration
  - interaction with parse filters to provide signatures (old and new)
  - reduce amount of persisted metadata (need metadata to be kept in the topology but not necessarily persisted in storage)