### PR TITLE
HTTP Proxy over Basic Authentication

### DIFF
--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -45,6 +45,13 @@ config:
   http.store.headers: false
   http.timeout: 10000
 
+  # for crawling through a proxy:
+  # http.proxy.host:
+  # http.proxy.port:
+  # for crawling through a proxy with Basic authentication:
+  # http.proxy.user:
+  # http.proxy.pass:
+
   http.robots.403.allow: true
 
   # should the URLs be removed when a page is marked as noFollow


### PR DESCRIPTION
Modified HttpProtocol to optionally accept a proxy username, password and auth scheme. It currently only supports basic authentication because that's the only one I can test against.

Additional configuration parameters to leverage this functionality are:
```
http.proxy.user: [proxy username, if not present authentication is not used]
http.proxy.pass: [proxy password, if not present authentication is not used]
```
Also removed a throws Exception because it never throws that exception, and cleaned up the builder usage code.