### PR TITLE
Abstract Selenium protocol, NavigationFilters and RemoteDriverProtocol

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@
 		<!-- dependency versions -->
 		<mockito-all.version>1.10.8</mockito-all.version>
 		<crawler-commons.version>0.7</crawler-commons.version>
-		<guava.version>18.0</guava.version>
+		<guava.version>21.0</guava.version>
 		<jsoup.version>1.10.1</jsoup.version>
 		<icu4j.version>58.2</icu4j.version>
 		<xerces.version>2.11.0</xerces.version>
@@ -159,5 +159,12 @@
 			<artifactId>commons-lang</artifactId>
 			<version>${commons.lang.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-remote-driver</artifactId>
+			<version>3.3.1</version>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/NavigationFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/NavigationFilter.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.protocol.selenium;
+
+import java.util.Map;
+
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import com.digitalpebble.stormcrawler.Metadata;
+import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public abstract class NavigationFilter {
+    /**
+     * Called when this filter is being initialised
+     * 
+     * @param stormConf
+     *            The Storm configuration used for the parsing bolt
+     * @param filterParams
+     *            the filter specific configuration. Never null
+     */
+    public abstract void configure(@SuppressWarnings("rawtypes") Map stormConf,
+            JsonNode filterParams);
+
+    /** The end result comes from the first filter to return non-null **/
+    public abstract ProtocolResponse filter(RemoteWebDriver driver,
+            Metadata metadata);
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/NavigationFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/NavigationFilter.java
@@ -34,8 +34,9 @@ public abstract class NavigationFilter {
      * @param filterParams
      *            the filter specific configuration. Never null
      */
-    public abstract void configure(@SuppressWarnings("rawtypes") Map stormConf,
-            JsonNode filterParams);
+    public void configure(@SuppressWarnings("rawtypes") Map stormConf,
+            JsonNode filterParams) {
+    }
 
     /** The end result comes from the first filter to return non-null **/
     public abstract ProtocolResponse filter(RemoteWebDriver driver,

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/NavigationFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/NavigationFilters.java
@@ -29,7 +29,6 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.Metadata;
-import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -41,7 +40,7 @@ import com.fasterxml.jackson.databind.node.NullNode;
  */
 public class NavigationFilters extends NavigationFilter {
 
-    public static final NavigationFilters emptyParseFilter = new NavigationFilters();
+    public static final NavigationFilters emptyNavigationFilters = new NavigationFilters();
 
     private static final org.slf4j.Logger LOG = LoggerFactory
             .getLogger(NavigationFilters.class);
@@ -62,8 +61,8 @@ public class NavigationFilters extends NavigationFilter {
     }
 
     /**
-     * Loads and configure the ParseFilters based on the storm config if there
-     * is one otherwise returns an emptyParseFilter.
+     * Loads and configure the NavigationFilters based on the storm config if
+     * there is one otherwise returns an emptyNavigationFilters.
      **/
     @SuppressWarnings("rawtypes")
     public static NavigationFilters fromConf(Map stormConf) {
@@ -80,7 +79,7 @@ public class NavigationFilters extends NavigationFilter {
             }
         }
 
-        return NavigationFilters.emptyParseFilter;
+        return NavigationFilters.emptyNavigationFilters;
     }
 
     /**
@@ -146,13 +145,13 @@ public class NavigationFilters extends NavigationFilter {
             String className = classNode.textValue().trim();
             filterName += '[' + className + ']';
             // check that it is available and implements the interface
-            // ParseFilter
+            // NavigationFilter
             try {
                 Class<?> filterClass = Class.forName(className);
-                boolean subClassOK = ParseFilter.class
+                boolean subClassOK = NavigationFilter.class
                         .isAssignableFrom(filterClass);
                 if (!subClassOK) {
-                    LOG.error("Filter {} does not extend ParseFilter",
+                    LOG.error("Filter {} does not extend NavigationFilter",
                             filterName);
                     continue;
                 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/NavigationFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/NavigationFilters.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.protocol.selenium;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.stormcrawler.Metadata;
+import com.digitalpebble.stormcrawler.parse.ParseFilter;
+import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
+import com.digitalpebble.stormcrawler.util.ConfUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+
+/**
+ * Wrapper for the NavigationFilter defined in a JSON configuration
+ */
+public class NavigationFilters extends NavigationFilter {
+
+    public static final NavigationFilters emptyParseFilter = new NavigationFilters();
+
+    private static final org.slf4j.Logger LOG = LoggerFactory
+            .getLogger(NavigationFilters.class);
+
+    private NavigationFilter[] filters;
+
+    private NavigationFilters() {
+        filters = new NavigationFilter[0];
+    }
+
+    public ProtocolResponse filter(RemoteWebDriver driver, Metadata metadata) {
+        for (NavigationFilter filter : filters) {
+            ProtocolResponse response = filter.filter(driver, metadata);
+            if (response != null)
+                return response;
+        }
+        return null;
+    }
+
+    /**
+     * Loads and configure the ParseFilters based on the storm config if there
+     * is one otherwise returns an emptyParseFilter.
+     **/
+    @SuppressWarnings("rawtypes")
+    public static NavigationFilters fromConf(Map stormConf) {
+        String configfile = ConfUtils.getString(stormConf,
+                "navigationfilters.config.file");
+        if (StringUtils.isNotBlank(configfile)) {
+            try {
+                return new NavigationFilters(stormConf, configfile);
+            } catch (IOException e) {
+                String message = "Exception caught while loading the NavigationFilters from "
+                        + configfile;
+                LOG.error(message);
+                throw new RuntimeException(message, e);
+            }
+        }
+
+        return NavigationFilters.emptyParseFilter;
+    }
+
+    /**
+     * loads the filters from a JSON configuration file
+     * 
+     * @throws IOException
+     */
+    @SuppressWarnings("rawtypes")
+    public NavigationFilters(Map stormConf, String configFile)
+            throws IOException {
+        // load the JSON configFile
+        // build a JSON object out of it
+        JsonNode confNode = null;
+        InputStream confStream = null;
+        try {
+            confStream = getClass().getClassLoader().getResourceAsStream(
+                    configFile);
+
+            ObjectMapper mapper = new ObjectMapper();
+            confNode = mapper.readValue(confStream, JsonNode.class);
+        } catch (Exception e) {
+            throw new IOException("Unable to build JSON object from file", e);
+        } finally {
+            if (confStream != null) {
+                confStream.close();
+            }
+        }
+
+        configure(stormConf, confNode);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public void configure(Map stormConf, JsonNode filtersConf) {
+        // initialises the filters
+        List<NavigationFilter> filterLists = new ArrayList<>();
+
+        // get the filters part
+        String name = getClass().getCanonicalName();
+        filtersConf = filtersConf.get(name);
+
+        if (filtersConf == null) {
+            LOG.info("No field {} in JSON config. Skipping", name);
+            filters = new NavigationFilter[0];
+            return;
+        }
+
+        // conf node contains a list of objects
+        Iterator<JsonNode> filterIter = filtersConf.elements();
+        while (filterIter.hasNext()) {
+            JsonNode afilterConf = filterIter.next();
+            String filterName = "<unnamed>";
+            JsonNode nameNode = afilterConf.get("name");
+            if (nameNode != null) {
+                filterName = nameNode.textValue();
+            }
+            JsonNode classNode = afilterConf.get("class");
+            if (classNode == null) {
+                LOG.error("Filter {} doesn't specified a 'class' attribute",
+                        filterName);
+                continue;
+            }
+            String className = classNode.textValue().trim();
+            filterName += '[' + className + ']';
+            // check that it is available and implements the interface
+            // ParseFilter
+            try {
+                Class<?> filterClass = Class.forName(className);
+                boolean subClassOK = ParseFilter.class
+                        .isAssignableFrom(filterClass);
+                if (!subClassOK) {
+                    LOG.error("Filter {} does not extend ParseFilter",
+                            filterName);
+                    continue;
+                }
+                NavigationFilter filterInstance = (NavigationFilter) filterClass
+                        .newInstance();
+
+                JsonNode paramNode = afilterConf.get("params");
+                if (paramNode != null) {
+                    filterInstance.configure(stormConf, paramNode);
+                } else {
+                    // Pass in a nullNode if missing
+                    filterInstance.configure(stormConf, NullNode.getInstance());
+                }
+
+                filterLists.add(filterInstance);
+                LOG.info("Setup {}", filterName);
+            } catch (Exception e) {
+                LOG.error("Can't setup {}: {}", filterName, e);
+                throw new RuntimeException("Can't setup " + filterName, e);
+            }
+        }
+
+        filters = filterLists.toArray(new NavigationFilter[filterLists.size()]);
+    }
+
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/RemoteDriverProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/RemoteDriverProtocol.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.protocol.selenium;
+
+import java.net.URL;
+import java.util.List;
+
+import org.apache.storm.Config;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import com.digitalpebble.stormcrawler.util.ConfUtils;
+
+/**
+ * Delegates the requests to one or more remote selenium servers. The processes
+ * must be started / stopped separately. The URLs to connect to are specified
+ * with the config 'selenium.addresses'.
+ **/
+
+public class RemoteDriverProtocol extends SeleniumProtocol {
+
+    @Override
+    public void configure(Config conf) {
+        super.configure(conf);
+
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        capabilities.setJavascriptEnabled(true);
+
+        String userAgentString = getAgentString(conf);
+        capabilities.setBrowserName(userAgentString);
+
+        // TODO set capabilities via config
+        // e.g. timeout? disable redirects? etc...
+
+        // load adresses from config
+        List<String> addresses = ConfUtils.loadListFromConf(
+                "selenium.addresses", conf);
+        if (addresses.size() == 0) {
+            throw new RuntimeException("No value found for selenium.addresses");
+        }
+        try {
+            for (String cdaddress : addresses) {
+                RemoteWebDriver driver = new RemoteWebDriver(
+                        new URL(cdaddress), capabilities);
+                drivers.add(driver);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        RemoteDriverProtocol.main(new RemoteDriverProtocol(), args);
+    }
+
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/SeleniumProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/SeleniumProtocol.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.protocol.selenium;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.storm.Config;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.stormcrawler.Metadata;
+import com.digitalpebble.stormcrawler.protocol.AbstractHttpProtocol;
+import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
+
+public abstract class SeleniumProtocol extends AbstractHttpProtocol {
+
+    protected static final org.slf4j.Logger LOG = LoggerFactory
+            .getLogger(SeleniumProtocol.class);
+
+    protected LinkedBlockingQueue<RemoteWebDriver> drivers;
+
+    private NavigationFilters filters;
+
+    @Override
+    public void configure(Config conf) {
+        super.configure(conf);
+        drivers = new LinkedBlockingQueue<>();
+        filters = NavigationFilters.fromConf(conf);
+    }
+
+    public ProtocolResponse getProtocolOutput(String url, Metadata metadata)
+            throws Exception {
+        // TODO check that the driver is not null
+        RemoteWebDriver driver = getDriver();
+        try {
+            // This will block for the page load and any
+            // associated AJAX requests
+            driver.get(url);
+
+            // call the filters
+            ProtocolResponse response = filters.filter(driver, metadata);
+            if (response == null) {
+                // if no filters got triggered
+                byte[] content = driver.getPageSource().getBytes();
+                response = new ProtocolResponse(content, 200, metadata);
+            }
+            return response;
+        } finally {
+            // finished with this driver - return it to the queue
+            drivers.put(driver);
+        }
+    }
+
+    /** Returns the first available driver **/
+    private final RemoteWebDriver getDriver() {
+        RemoteWebDriver d = null;
+        try {
+            d = drivers.take();
+        } catch (InterruptedException e) {
+        }
+        return d;
+    }
+
+}


### PR DESCRIPTION
This PR contains much of the code from the jBrowserDriver branch and implements #144. Instead to being tied to a particular library, it provides a neutral RemoteDriverProtocol which can be configured to connect to one or more endpoints.

The code in JBrowserDriver could be refactored later on to be based on this.

There is a lot more work to do on this e.g. pass configuration, setup timeouts etc... but at least this would be a good starting point.

To run with phantomjs on Linux

```
sudo apt install phantomjs
phantomjs --webdriver 9515
```
then set in the config\:

`selenium.addresses: "http://localhost:9515"`

