### PR TITLE
Optimise nextFetchDate to speed up queries to Elasticsearch

### DIFF
--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
@@ -139,6 +139,8 @@ public abstract class AbstractSpout extends BaseRichSpout {
 
     protected CollectionMetric esQueryTimes;
 
+    protected Date lastDate;
+
     /** Map which holds elements some additional time after the removal. */
     public class InProcessMap<K, V> extends HashMap<K, V> {
 

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
@@ -63,7 +63,6 @@ public class CollapsingSpout extends AbstractSpout implements
     private static final String ESMaxStartOffsetParamName = "es.status.max.start.offset";
 
     private int lastStartOffset = 0;
-    private Date lastDate;
     private int maxStartOffset = -1;
 
     @Override
@@ -87,11 +86,13 @@ public class CollapsingSpout extends AbstractSpout implements
             lastStartOffset = 0;
         }
 
+        String formattedLastDate = String.format(DATEFORMAT, lastDate);
+
         LOG.info("{} Populating buffer with nextFetchDate <= {}", logIdprefix,
-                lastDate);
+                formattedLastDate);
 
         QueryBuilder queryBuilder = QueryBuilders.rangeQuery("nextFetchDate")
-                .lte(String.format(DATEFORMAT, lastDate));
+                .lte(formattedLastDate);
 
         SearchRequestBuilder srb = client.prepareSearch(indexName)
                 .setTypes(docType).setSearchType(SearchType.QUERY_THEN_FETCH)


### PR DESCRIPTION
implements #452 for the AggregationSpout

Introduces 2 new parameters which set the nextFetchDate to query on based on the most recent date returned by the latest query. A duration in minutes is added to this date and will be used for querying unless the previous date was within N minutes of the new one. This way we can hit the caches.