### PR TITLE
Fixing max fetch error count comparison so it can cope with configura…

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
@@ -159,7 +159,7 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
             } catch (NumberFormatException e) {
             }
             count++;
-            if (count == maxFetchErrors) {
+            if (count >= maxFetchErrors) {
                 status = Status.ERROR;
                 metadata.setValue(Constants.STATUS_ERROR_CAUSE,
                         "maxFetchErrors");


### PR DESCRIPTION
…tion changes to max fetch errors, and not miss counts that have gone above the threshold.

It is currently possible with configuration changes to get scenarios where the fetch error count against a URL exceeds the _maxFetchErrors_ configuration parameter. This is due to the current comparator using _exactly equal to_.

This fix just uses _greater than or equal_ instead, so you can never skip over the threshold and get _bad_ documents cycling through the crawl.


