### PR TITLE
Upgrade WARC module to latest version of storm-hdfs, fixes #590

### DIFF
--- a/external/warc/pom.xml
+++ b/external/warc/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.apache.storm</groupId>
 			<artifactId>storm-hdfs</artifactId>
-			<version>1.0.3</version>
+			<version>1.1.0</version>
 		</dependency>
 
 	</dependencies>

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/FileTimeSizeRotationPolicy.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/FileTimeSizeRotationPolicy.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Rotates a file based on size or optionally time, whichever occurs first **/
+@SuppressWarnings("serial")
 public class FileTimeSizeRotationPolicy implements FileRotationPolicy {
 
     private static final Logger LOG = LoggerFactory
@@ -111,4 +112,12 @@ public class FileTimeSizeRotationPolicy implements FileRotationPolicy {
         this.timeStarted = System.currentTimeMillis();
     }
 
+    @Override
+    public FileRotationPolicy copy() {
+        FileTimeSizeRotationPolicy copy = new FileTimeSizeRotationPolicy(1.0f,
+                Units.GB);
+        copy.maxBytes = this.maxBytes;
+        copy.interval = this.interval;
+        return copy;
+    }
 }


### PR DESCRIPTION
Tested so far in small scale:
  - WARC files validate
  - file rotation by size works
A large scale test will follow during the next days.

A first trial to implement a class GzipHdfsWriter extending AbstractHDFSWriter (AbstractHDFSWriter needs to be returned by `AbstractHdfsBolt.makeNewWriter(path, tuple)`) wasn't successful:
- the field `offset` in AbstractHDFSWriter is only visible in the package `org.apache.storm.hdfs.common`, it cannot be used in a Storm-crawler package
-  the method `write(tuple)` which accesses the package-internal `offset` is final:
```
abstract public class AbstractHDFSWriter {

    long offset;

    final public long write(Tuple tuple) throws IOException{
        doWrite(tuple);
        this.needsRotation = rotationPolicy.mark(tuple, offset);

        return this.offset;
    }
}
```

I didn't find a way to operate directly on the output stream and offset while still extending the classes in `org.apache.storm.hdfs.common`. That's why compression is moved to a GzipRecordFormat. As a consequence, the option to do the rotation on uncompressed offsets (content length) is dropped.
