### PR TITLE
BasicURLNormalizer to optionally convert IDN host names to ASCII/Punycode

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLNormalizer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLNormalizer.java
@@ -17,6 +17,7 @@
 
 package com.digitalpebble.stormcrawler.filtering.basic;
 
+import java.net.IDN;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -91,6 +92,7 @@ public class BasicURLNormalizer implements URLFilter {
     boolean unmangleQueryString = true;
     boolean checkValidURI = true;
     boolean removeHashes = false;
+    private boolean hostIDNtoASCII = false;
     final Set<String> queryElementsToRemove = new TreeSet<>();
 
     @Override
@@ -134,6 +136,9 @@ public class BasicURLNormalizer implements URLFilter {
 
             if (host != null) {
                 String newHost = host.toLowerCase(Locale.ROOT);
+                if (hostIDNtoASCII && !isAscii(newHost)) {
+                    newHost = IDN.toASCII(newHost);
+                }
                 if (!host.equals(newHost)) {
                     host = newHost;
                     hasChanged = true;
@@ -201,6 +206,11 @@ public class BasicURLNormalizer implements URLFilter {
         node = paramNode.get("removeHashes");
         if (node != null) {
             removeHashes = node.booleanValue();
+        }
+
+        node = paramNode.get("hostIDNtoASCII");
+        if (node != null) {
+            hostIDNtoASCII = node.booleanValue();
         }
     }
 
@@ -417,4 +427,15 @@ public class BasicURLNormalizer implements URLFilter {
 
         return sb.toString();
     }
+
+    private boolean isAscii(String str) {
+        char[] chars = str.toCharArray();
+        for (char c : chars) {
+            if (c > 127) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/core/src/test/java/com/digitalpebble/stormcrawler/filtering/BasicURLNormalizerTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/filtering/BasicURLNormalizerTest.java
@@ -333,6 +333,30 @@ public class BasicURLNormalizerTest {
                 normalizedUrl);
     }
 
+    @Test
+    public void testHostIDNtoASCII() throws MalformedURLException {
+        ObjectNode filterParams = new ObjectNode(JsonNodeFactory.instance);
+        filterParams.put("hostIDNtoASCII", true);
+        URLFilter urlFilter = createFilter(filterParams);
+        URL testSourceUrl = new URL("http://www.example.com/");
+
+        String inputURL = "http://señal6.com.ar/";
+        String expectedURL = "http://xn--seal6-pta.com.ar/";
+        String normalizedUrl = urlFilter.filter(testSourceUrl, new Metadata(),
+                inputURL);
+
+        assertEquals("Failed to filter query string", expectedURL,
+                normalizedUrl);
+
+        inputURL = "http://сфера.укр/";
+        expectedURL = "http://xn--80aj7acp.xn--j1amh/";
+        normalizedUrl = urlFilter.filter(testSourceUrl, new Metadata(),
+                inputURL);
+
+        assertEquals("Failed to filter query string", expectedURL,
+                normalizedUrl);
+    }
+
     private JsonNode getArrayNode(List<String> queryElementsToRemove) {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.valueToTree(queryElementsToRemove);


### PR DESCRIPTION
- conversion of IDN host names to their ASCII/Punycode equivalent is triggered if param "hostIDNtoASCII" is true
- avoids duplicate page content
- get clean ASCII keys if sharding/routing is done by host or domain
