### PR TITLE
Store content-length as field value and allow to use inner classes of FetchBolt

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/FetcherBolt.java
@@ -101,7 +101,7 @@ public class FetcherBolt extends StatusEmitterBolt {
     /**
      * This class described the item to be fetched.
      */
-    private static class FetchItem {
+    public static class FetchItem {
 
         String queueID;
         String url;
@@ -178,7 +178,7 @@ public class FetcherBolt extends StatusEmitterBolt {
      * proto/hostname or proto/IP pair). It also keeps track of requests in
      * progress and elapsed time between requests.
      */
-    private static class FetchItemQueue {
+    public static class FetchItemQueue {
         Deque<FetchItem> queue = new LinkedBlockingDeque<>();
 
         AtomicInteger inProgress = new AtomicInteger();
@@ -254,7 +254,7 @@ public class FetcherBolt extends StatusEmitterBolt {
      * Convenience class - a collection of queues that keeps track of the total
      * number of items, and provides items eligible for fetching from any queue.
      */
-    private static class FetchItemQueues {
+    public static class FetchItemQueues {
         Map<String, FetchItemQueue> queues = Collections
                 .synchronizedMap(new LinkedHashMap<String, FetchItemQueue>());
 
@@ -390,7 +390,7 @@ public class FetcherBolt extends StatusEmitterBolt {
     /**
      * This class picks items from queues and fetches the pages.
      */
-    private class FetcherThread extends Thread {
+    protected class FetcherThread extends Thread {
 
         // longest delay accepted from robots.txt
         private final long maxCrawlDelay;
@@ -540,6 +540,8 @@ public class FetcherBolt extends StatusEmitterBolt {
                     long timeFetching = System.currentTimeMillis() - start;
 
                     final int byteLength = response.getContent().length;
+
+                    metadata.setValue("fetch_content_length", String.format("%s", byteLength));
 
                     averagedMetrics.scope("fetch_time").update(timeFetching);
                     averagedMetrics.scope("bytes_fetched").update(byteLength);

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -144,4 +144,5 @@ config:
   - parse.title=title
   - parse.keywords=keywords
   - parse.description=description
+  - fetch_content_length=size
   


### PR DESCRIPTION
Extra line in FetchBolt like discussed in
https://stackoverflow.com/questions/48013771/store-content-length-as-field-value-aka-in-metadata-of-indexed-docs

Switch from private to public inner classes in FetchBold because we need nearly the same function to crawle extra xml-sites with metadate for each pdf. So why not allow to use the same code?