### PR TITLE
http.content.limit inconsistent default to -1 #533

### DIFF
--- a/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -40,6 +40,11 @@ config:
   http.agent.url: "http://someorganization.com/"
   http.agent.email: "someone@someorganization.com"
 
+  # The maximum number of bytes for returned HTTP response bodies.
+  # The fetched page will be trimmed to 65KB in this case
+  # Set -1 to disable the limit.
+  http.content.limit: 65536
+
   # FetcherBolt queue dump : comment out to activate
   # if a file exists on the worker machine with the corresponding port number
   # the FetcherBolt will log the content of its internal queues to the logs

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -44,7 +44,7 @@ config:
 
   http.accept.language: "en-us,en-gb,en;q=0.7,*;q=0.3"
   http.accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-  http.content.limit: 65536
+  http.content.limit: -1
   http.store.responsetime: true
   http.store.headers: false
   http.timeout: 10000


### PR DESCRIPTION
Based on the discussion here https://github.com/DigitalPebble/storm-crawler/issues/533

We are setting the default  `http.content.limit` to `-1` in the default config, whereas in the archetype to `65536`, a more clear approach for the user.

