### PR TITLE
Use UTF-8 for input encoding of seeds (FileSpout)

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLNormalizer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLNormalizer.java
@@ -137,7 +137,15 @@ public class BasicURLNormalizer implements URLFilter {
             if (host != null) {
                 String newHost = host.toLowerCase(Locale.ROOT);
                 if (hostIDNtoASCII && !isAscii(newHost)) {
-                    newHost = IDN.toASCII(newHost);
+                    try {
+                        newHost = IDN.toASCII(newHost);
+                    } catch (IllegalArgumentException ex) {
+                        // eg. if the input string contains non-convertible
+                        // Unicode codepoints
+                        LOG.error("Failed to convert IDN host {} in {}",
+                                newHost, urlToFilter);
+                        return null;
+                    }
                 }
                 if (!host.equals(newHost)) {
                     host = newHost;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/spout/FileSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/spout/FileSpout.java
@@ -18,8 +18,9 @@
 package com.digitalpebble.stormcrawler.spout;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
@@ -98,8 +99,9 @@ public class FileSpout extends BaseRichSpout {
             if (file == null)
                 return;
             Path inputPath = Paths.get(file);
-            currentBuffer = new BufferedReader(new FileReader(
-                    inputPath.toFile()));
+            currentBuffer = new BufferedReader(new InputStreamReader(
+                    new FileInputStream(inputPath.toFile()),
+                    StandardCharsets.UTF_8));
         }
 
         // no more files to read from


### PR DESCRIPTION
and improve logging of IDN URLs which fail to be converted to ASCII/Punycode

If the system local / default encoding is not UTF-8, non-ASCII seeds may fail to get injected. I've seen this while testing in a Docker container: the seed `https://арктик-тв.рф/rss/arctic-tv.xml` caused the error:
```
2018-03-06 11:09:11.273 c.d.s.f.URLFilters Thread-14-filter-executor[5 5] [ERROR] URL filtering threw exception
java.lang.IllegalArgumentException: java.text.ParseException: A prohibited code point was found in the input????????????-????
        at java.net.IDN.toASCIIInternal(IDN.java:274) ~[?:1.8.0_151]
        at java.net.IDN.toASCII(IDN.java:122) ~[?:1.8.0_151]
        at java.net.IDN.toASCII(IDN.java:151) ~[?:1.8.0_151]
        at com.digitalpebble.stormcrawler.filtering.basic.BasicURLNormalizer.filter(BasicURLNormalizer.java:140) ~[stormjar.jar:?]
        at com.digitalpebble.stormcrawler.filtering.URLFilters.filter(URLFilters.java:102) [stormjar.jar:?]
        at com.digitalpebble.stormcrawler.bolt.URLFilterBolt.execute(URLFilterBolt.java:53) [stormjar.jar:?]
```

The logged part of the URL `????????????-????` is not really helpful, the improved log message adds more context from the URL:
``` 
2018-03-06 10:59:55.551 c.d.s.f.b.BasicURLNormalizer Thread-14-filter-executor[5 5] [ERROR] Failed to convert IDN host ????????????-????.???? in https://????????????-????.????/rss/arctic-tv.xml
```
