### PR TITLE
Default URL filter: exclude localhost and private address spaces

### DIFF
--- a/archetype/src/main/resources/archetype-resources/src/main/resources/default-regex-filters.txt
+++ b/archetype/src/main/resources/archetype-resources/src/main/resources/default-regex-filters.txt
@@ -9,5 +9,24 @@
 # very time-consuming : use BasicURLFilter instead
 # -.*(/[^/]+)/[^/]+\1/[^/]+\1/
 
+# exclude localhost and equivalents to avoid that information
+# can be leaked by placing faked links pointing to web interfaces
+# of services running on the crawling machine (e.g., Elasticsearch,
+# Storm)
+#
+# - exclude localhost and loop-back addresses
+#     http://localhost:8080
+#     http://127.0.0.1/ .. http://127.255.255.255/
+#     http://[::1]/
+-^https?://(?:localhost|127(?:\.(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))){3}|\[::1\])(?::\d+)?(?:/|$)
+#
+# - exclude private IP address spaces
+#     10.0.0.0/8
+-^https?://(?:10(?:\.(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))){3})(?::\d+)?(?:/|$)
+#     192.168.0.0/16
+-^https?://(?:192\.168(?:\.(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))){2})(?::\d+)?(?:/|$)
+#     172.16.0.0/12
+-^https?://(?:172\.(?:1[6789]|2[0-9]|3[01])(?:\.(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))){2})(?::\d+)?(?:/|$)
+
 # accept anything else
 +.


### PR DESCRIPTION
To avoid that information is leaked and exposed in a public search interface, a web crawler should never follow links to localhost, loop-back addresses and private address spaces, see commoncrawl/news-crawl#21. These are excluded by regular expressions for http/https URLs.

Of course, could comment out the rules to enable test crawls of the local Apache web server.