### PR TITLE
Add simple basic auth system

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/regex/FastURLFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/regex/FastURLFilter.java
@@ -153,8 +153,8 @@ public class FastURLFilter implements URLFilter, JSONResource {
 
             JsonNode patternsNode = current.get("patterns");
             if (patternsNode == null)
-                throw new RuntimeException(
-                        "Missing patterns for scope" + scopeval);
+                throw new RuntimeException("Missing patterns for scope"
+                        + scopeval);
 
             List<Rule> rlist = new LinkedList<>();
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -54,7 +55,6 @@ import org.apache.http.message.BasicHeader;
 import org.apache.http.util.Args;
 import org.apache.http.util.ByteArrayBuffer;
 import org.apache.storm.Config;
-import java.util.Base64.Encoder;
 import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.Metadata;
@@ -63,7 +63,6 @@ import com.digitalpebble.stormcrawler.protocol.AbstractHttpProtocol;
 import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 import com.digitalpebble.stormcrawler.util.CookieConverter;
-import com.rometools.rome.io.impl.Base64;
 
 /**
  * Uses Apache httpclient to handle http and https
@@ -121,10 +120,10 @@ public class HttpProtocol extends AbstractHttpProtocol implements
         if (StringUtils.isNotBlank(basicAuthUser)) {
             String basicAuthPass = ConfUtils.getString(conf,
                     "http.basicauth.password", "");
-            byte[] encoding = Base64.encode(new String(basicAuthUser + ":"
-                    + basicAuthPass).getBytes());
+            String encoding = Base64.getEncoder().encodeToString(
+                    (basicAuthUser + ":" + basicAuthPass).getBytes());
             defaultHeaders.add(new BasicHeader("Authorization", "Basic "
-                    + new String(encoding)));
+                    + encoding));
         }
 
         String acceptLanguage = ConfUtils.getString(conf,

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
@@ -54,7 +54,7 @@ import org.apache.http.message.BasicHeader;
 import org.apache.http.util.Args;
 import org.apache.http.util.ByteArrayBuffer;
 import org.apache.storm.Config;
-import org.apache.storm.shade.org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
+import java.util.Base64.Encoder;
 import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.Metadata;
@@ -63,6 +63,7 @@ import com.digitalpebble.stormcrawler.protocol.AbstractHttpProtocol;
 import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 import com.digitalpebble.stormcrawler.util.CookieConverter;
+import com.rometools.rome.io.impl.Base64;
 
 /**
  * Uses Apache httpclient to handle http and https
@@ -113,28 +114,17 @@ public class HttpProtocol extends AbstractHttpProtocol implements
             defaultHeaders.add(new BasicHeader("Accept", accept));
         }
 
-        boolean useBasicAuth = ConfUtils.getBoolean(conf,
-                "http.basicauth.enabled", false);
+        String basicAuthUser = ConfUtils.getString(conf, "http.basicauth.user",
+                null);
 
         // use a basic auth?
-        if (useBasicAuth) {
-
-            String basicAuthUser = ConfUtils.getString(conf,
-                    "http.basicauth.user", null);
+        if (StringUtils.isNotBlank(basicAuthUser)) {
             String basicAuthPass = ConfUtils.getString(conf,
-                    "http.basicauth.password", null);
-
-            if (StringUtils.isNotBlank(basicAuthUser)
-                    && StringUtils.isNotBlank(basicAuthPass)) {
-                char[] encoding = Base64Coder.encode(new String(basicAuthUser
-                        + ":" + basicAuthPass).getBytes());
-                defaultHeaders.add(new BasicHeader("Authorization", "Basic "
-                        + String.valueOf(encoding)));
-            } else {
-                LOG.warn("Basic Auth has been disabled, credentials are empty. Please set "
-                        + "'http.basicauth.user' and 'http.basicauth.pass'.");
-            }
-
+                    "http.basicauth.password", "");
+            byte[] encoding = Base64.encode(new String(basicAuthUser + ":"
+                    + basicAuthPass).getBytes());
+            defaultHeaders.add(new BasicHeader("Authorization", "Basic "
+                    + new String(encoding)));
         }
 
         String acceptLanguage = ConfUtils.getString(conf,


### PR DESCRIPTION
Hello,

This is a simple basic auth system that allow user to add these parameters into the yaml configuration :

-   http.basicauth.enabled: true
-   http.basicauth.user: "root"
-   http.basicauth.password: "root"

This way it allows stormcrawler to be used in most of the intranets.

If this PR is accepted I'll produce the documentation associated.

Thanks