### PR TITLE
Added ability to implement custom indexes names based on metadata information, fixes #591

### DIFF
--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/DeletionBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/DeletionBolt.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.LoggerFactory;
 
+import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.elasticsearch.ElasticSearchConnection;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 
@@ -71,11 +72,14 @@ public class DeletionBolt extends BaseRichBolt {
     @Override
     public void execute(Tuple tuple) {
         String url = tuple.getStringByField("url");
+        Metadata metadata = (Metadata) tuple.getValueByField("metadata");
+
         // keep it simple for now and ignore cases where the canonical URL was
         // used
         String sha256hex = org.apache.commons.codec.digest.DigestUtils
                 .sha256Hex(url);
-        DeleteRequest dr = new DeleteRequest(indexName, docType, sha256hex);
+        DeleteRequest dr = new DeleteRequest(getIndexName(metadata), docType,
+                sha256hex);
         try {
             client.delete(dr);
         } catch (IOException e) {
@@ -89,6 +93,14 @@ public class DeletionBolt extends BaseRichBolt {
     @Override
     public void declareOutputFields(OutputFieldsDeclarer arg0) {
         // none
+    }
+
+    /**
+     * Must be overridden for implementing custom index names based on some
+     * metadata information By Default, indexName coming from config is used
+     */
+    protected String getIndexName(Metadata m) {
+        return indexName;
     }
 
 }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/IndexerBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/IndexerBolt.java
@@ -172,8 +172,8 @@ public class IndexerBolt extends AbstractIndexerBolt {
             String sha256hex = org.apache.commons.codec.digest.DigestUtils
                     .sha256Hex(normalisedurl);
 
-            IndexRequest indexRequest = new IndexRequest(indexName, docType,
-                    sha256hex).source(builder);
+            IndexRequest indexRequest = new IndexRequest(
+                    getIndexName(metadata), docType, sha256hex).source(builder);
 
             DocWriteRequest.OpType optype = DocWriteRequest.OpType.INDEX;
 
@@ -200,6 +200,14 @@ public class IndexerBolt extends AbstractIndexerBolt {
             // do not send to status stream so that it gets replayed
             _collector.fail(tuple);
         }
+    }
+
+    /**
+     * Must be overridden for implementing custom index names based on some
+     * metadata information By Default, indexName coming from config is used
+     */
+    protected String getIndexName(Metadata m) {
+        return indexName;
     }
 
 }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/StatusUpdaterBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/StatusUpdaterBolt.java
@@ -231,7 +231,8 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt implements
 
         builder.endObject();
 
-        IndexRequest request = new IndexRequest(indexName).type(docType);
+        IndexRequest request = new IndexRequest(getIndexName(metadata))
+                .type(docType);
         request.source(builder).id(sha256hex).create(create);
 
         if (StringUtils.isNotBlank(partitionKey)) {
@@ -378,4 +379,11 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt implements
         eventCounter.scope("bulks_received").incrBy(1);
     }
 
+    /**
+     * Must be overridden for implementing custom index names based on some
+     * metadata information By Default, indexName coming from config is used
+     */
+    protected String getIndexName(Metadata m) {
+        return indexName;
+    }
 }


### PR DESCRIPTION
Added `getIndexName(Metadata m)` method in bolts responsible for interacting with ES indexes. This allow implementing custom indexes names based on some metadata information.

