### PR TITLE
Allow to connect all threads to a single domain

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
@@ -95,7 +95,8 @@ public class HttpProtocol extends AbstractHttpProtocol implements
                 200);
         CONNECTION_MANAGER.setMaxTotal(maxFetchThreads);
 
-        CONNECTION_MANAGER.setDefaultMaxPerRoute(20);
+	// allow to connect all threads to a single domain
+        CONNECTION_MANAGER.setDefaultMaxPerRoute(maxFetchThreads);
 
         this.maxContent = ConfUtils.getInt(conf, "http.content.limit", -1);
 


### PR DESCRIPTION
So far in HttpProtocol.java there was an hard limit of 20 threads allowed per route:
`CONNECTION_MANAGER.setDefaultMaxPerRoute(20);`

This was creating problems while crawling on very limited number of domains and having set large numbers for configuration parameters `fetcher.threads.per.queue` and `fetcher.threads.number` (e.g. several hundreds of threads for both). Problem observed was of type:
```
org.apache.http.conn.ConnectionPoolTimeoutException: Timeout waiting for connection from pool
        at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.leaseConnection(PoolingHttpClientConnectionManager.java:292) 
```
With the proposed solution we potentially allow all threads to connect to a single domain.
