### PR TITLE
Added byteLength to Metadata

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/FetcherBolt.java
@@ -584,6 +584,9 @@ public class FetcherBolt extends StatusEmitterBolt {
                     response.getMetadata().setValue("fetch.statusCode",
                             Integer.toString(response.getStatusCode()));
 
+                    response.getMetadata().setValue("fetch.byteLength",
+                            Integer.toString(byteLength));
+
                     response.getMetadata().setValue("fetch.loadingTime",
                             Long.toString(timeFetching));
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/SimpleFetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/SimpleFetcherBolt.java
@@ -440,6 +440,9 @@ public class SimpleFetcherBolt extends StatusEmitterBolt {
             response.getMetadata().setValue("fetch.loadingTime",
                     Long.toString(timeFetching));
 
+            response.getMetadata().setValue("fetch.byteLength",
+                    Integer.toString(byteLength));
+
             // determine the status based on the status code
             final Status status = Status.fromHTTPCode(response.getStatusCode());
 


### PR DESCRIPTION
FetcherBolt already read the byteLength from the response, but didn't add it to Metadata.
(This could be helpful if you want to index the document size)

