### PR TITLE
Batch PreparedStatements in SQL status updater bolt, fixes #610

### DIFF
--- a/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/Constants.java
+++ b/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/Constants.java
@@ -26,6 +26,7 @@ public class Constants {
     public static final String MYSQL_BUFFERSIZE_PARAM_NAME = "mysql.buffer.size";
     public static final String MYSQL_MAX_DOCS_BUCKET_PARAM_NAME = "mysql.max.urls.per.bucket";
     public static final String MYSQL_MIN_QUERY_INTERVAL_PARAM_NAME = "mysql.min.query.interval";
+    public static final String SQL_UPDATE_BATCH_SIZE_PARAM_NAME = "sql.update.batch.size";
 
     private Constants() {
     }

--- a/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/SQLUtil.java
+++ b/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/SQLUtil.java
@@ -21,6 +21,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.Properties;
 
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 
@@ -30,7 +31,7 @@ public class SQLUtil {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    static Connection getConnection(Map stormConf) throws SQLException {
+    public static Connection getConnection(Map stormConf) throws SQLException {
         // SQL connection details
         String url = ConfUtils.getString(stormConf,
                 Constants.MYSQL_URL_PARAM_NAME,
@@ -39,7 +40,12 @@ public class SQLUtil {
                 Constants.MYSQL_USER_PARAM_NAME);
         String password = ConfUtils.getString(stormConf,
                 Constants.MYSQL_PASSWORD_PARAM_NAME);
-        return DriverManager.getConnection(url, user, password);
+        Properties props = new Properties();
+        props.setProperty("user", user);
+        props.setProperty("password", password);
+        props.setProperty("rewriteBatchedStatements", "true");
+        props.setProperty("useBatchMultiSend", "true");
+        return DriverManager.getConnection(url, props);
     }
 
 }

--- a/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/StatusUpdaterBolt.java
+++ b/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/StatusUpdaterBolt.java
@@ -21,16 +21,20 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.apache.storm.metric.api.MeanReducer;
 import org.apache.storm.metric.api.MultiCountMetric;
-import org.apache.storm.metric.api.MultiReducedMetric;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.persistence.AbstractStatusUpdaterBolt;
@@ -38,13 +42,17 @@ import com.digitalpebble.stormcrawler.persistence.Status;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 import com.digitalpebble.stormcrawler.util.URLPartitioner;
 
+/**
+ * Status updater for SQL backend. Discovered URLs are sent as a batch, whereas
+ * updates are atomic.
+ **/
+
 @SuppressWarnings("serial")
 public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
     public static final Logger LOG = LoggerFactory
             .getLogger(StatusUpdaterBolt.class);
 
-    private MultiReducedMetric averagedMetrics;
     private MultiCountMetric eventCounter;
 
     private Connection connection;
@@ -52,6 +60,20 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
     private URLPartitioner partitioner;
     private int maxNumBuckets = -1;
+
+    private int batchMaxSize = 1000;
+    private float batchMaxIdleMsec = 2000;
+
+    private int currentBatchSize = 0;
+
+    private PreparedStatement insertPreparedStmt = null;
+
+    private long lastInsertBatchTime = 0;
+
+    private String updateQuery;
+    private String insertQuery;
+
+    private final Map<String, List<Tuple>> waitingAck = new HashMap<>();
 
     public StatusUpdaterBolt(int maxNumBuckets) {
         this.maxNumBuckets = maxNumBuckets;
@@ -63,21 +85,15 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public void prepare(Map stormConf, TopologyContext context,
-            OutputCollector collector) {
+    public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
         super.prepare(stormConf, context, collector);
 
         partitioner = new URLPartitioner();
         partitioner.configure(stormConf);
 
-        this.averagedMetrics = context.registerMetric("SQLStatusUpdater",
-                new MultiReducedMetric(new MeanReducer()), 10);
+        this.eventCounter = context.registerMetric("counter", new MultiCountMetric(), 10);
 
-        this.eventCounter = context.registerMetric("counter",
-                new MultiCountMetric(), 10);
-
-        tableName = ConfUtils.getString(stormConf,
-                Constants.MYSQL_TABLE_PARAM_NAME);
+        tableName = ConfUtils.getString(stormConf, Constants.MYSQL_TABLE_PARAM_NAME);
 
         try {
             connection = SQLUtil.getConnection(stormConf);
@@ -86,53 +102,141 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
             throw new RuntimeException(ex);
         }
 
+        String query = tableName + " (url, status, nextfetchdate, metadata, bucket, host)"
+                + " values (?, ?, ?, ?, ?, ?)";
+
+        updateQuery = "REPLACE INTO " + query;
+        insertQuery = "INSERT IGNORE INTO " + query;
+
+        try {
+            insertPreparedStmt = connection.prepareStatement(insertQuery);
+        } catch (SQLException e) {
+            LOG.error(e.getMessage(), e);
+        }
+
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        long delay = 5000L;
+        long period = 1000L;
+        executor.scheduleAtFixedRate(() -> sendInsertBatch(), delay, period, TimeUnit.MILLISECONDS);
     }
 
     @Override
     public void store(String url, Status status, Metadata metadata,
             Date nextFetch) throws Exception {
 
-        // the mysql insert statement
-        String query = tableName
-                + " (url, status, nextfetchdate, metadata, bucket, host)"
-                + " values (?, ?, ?, ?, ?, ?)";
+        synchronized (this) {
+            StringBuilder mdAsString = new StringBuilder();
+            for (String mdKey : metadata.keySet()) {
+                String[] vals = metadata.getValues(mdKey);
+                for (String v : vals) {
+                    mdAsString.append("\t").append(mdKey).append("=").append(v);
+                }
+            }
 
-        StringBuffer mdAsString = new StringBuffer();
-        for (String mdKey : metadata.keySet()) {
-            String[] vals = metadata.getValues(mdKey);
-            for (String v : vals) {
-                mdAsString.append("\t").append(mdKey).append("=").append(v);
+            int partition = 0;
+            String partitionKey = partitioner.getPartition(url, metadata);
+            if (maxNumBuckets > 1) {
+                // determine which shard to send to based on the host / domain /
+                // IP
+                partition = Math.abs(partitionKey.hashCode() % maxNumBuckets);
+            }
+
+            PreparedStatement preparedStmt = this.insertPreparedStmt;
+
+            // create in table if does not already exist
+            if (!status.equals(Status.DISCOVERED)) {
+                preparedStmt = connection.prepareStatement(updateQuery);
+            }
+
+            preparedStmt.setString(1, url);
+            preparedStmt.setString(2, status.toString());
+            preparedStmt.setObject(3, nextFetch);
+            preparedStmt.setString(4, mdAsString.toString());
+            preparedStmt.setInt(5, partition);
+            preparedStmt.setString(6, partitionKey);
+
+            // updates are not batched
+            if (!status.equals(Status.DISCOVERED)) {
+                preparedStmt.executeUpdate();
+                preparedStmt.close();
+                eventCounter.scope("sql_updates_number").incrBy(1);
+                return;
+            }
+
+            // code below is for inserts i.e. DISCOVERED URLs
+            preparedStmt.addBatch();
+
+            // keep track of URL to ack the tuples later
+            waitingAck.put(url, new LinkedList<Tuple>());
+
+            // check the batch size
+            currentBatchSize++;
+
+            eventCounter.scope("sql_inserts_number").incrBy(1);
+
+            if (currentBatchSize == batchMaxSize) {
+                sendInsertBatch();
             }
         }
+    }
 
-        int partition = 0;
-        String partitionKey = partitioner.getPartition(url, metadata);
-        if (maxNumBuckets > 1) {
-            // determine which shard to send to based on the host / domain / IP
-            partition = Math.abs(partitionKey.hashCode() % maxNumBuckets);
+    private synchronized void sendInsertBatch() {
+        // check whether the insert batches need flushing
+        // useful when triggered by time
+        if (currentBatchSize == 0 || lastInsertBatchTime + batchMaxIdleMsec > System.currentTimeMillis()) {
+            return;
         }
 
-        // create in table if does not already exist
-        if (status.equals(Status.DISCOVERED)) {
-            query = "INSERT IGNORE INTO " + query;
-        } else
-            query = "REPLACE INTO " + query;
+        try {
+            insertPreparedStmt.executeBatch();
+            waitingAck.forEach((k, v) -> {
+                for (Tuple t : v) {
+                    super.ack(t, k);
+                }
+            });
+        } catch (SQLException e) {
+            LOG.error(e.getMessage(), e);
+            // fail the entire batch
+            waitingAck.forEach((k, v) -> {
+                for (Tuple t : v) {
+                    super._collector.fail(t);
+                }
+            });
+        } finally {
+            try {
+                lastInsertBatchTime = System.currentTimeMillis();
+                currentBatchSize = 0;
+                waitingAck.clear();
+                insertPreparedStmt.close();
+                insertPreparedStmt = connection.prepareStatement(insertQuery);
+            } catch (SQLException e) {
+            }
 
-        PreparedStatement preparedStmt = connection.prepareStatement(query);
-        preparedStmt.setString(1, url);
-        preparedStmt.setString(2, status.toString());
-        preparedStmt.setObject(3, nextFetch);
-        preparedStmt.setString(4, mdAsString.toString());
-        preparedStmt.setInt(5, partition);
-        preparedStmt.setString(6, partitionKey);
-
-        long start = System.currentTimeMillis();
-
-        // execute the preparedstatement
-        preparedStmt.execute();
-        eventCounter.scope("sql_query_number").incrBy(1);
-        averagedMetrics.scope("sql_execute_time").update(
-                System.currentTimeMillis() - start);
-        preparedStmt.close();
+        }
     }
+
+    @Override
+    public void cleanup() {
+        if (connection != null)
+            try {
+                connection.close();
+            } catch (SQLException e) {
+            }
+    }
+
+    /**
+     * Do not ack the tuple straight away! wait to get the confirmation that it
+     * worked.
+     **/
+    public void ack(Tuple t, String url) {
+        // not sent via batch - ack straight away
+        if (!waitingAck.containsKey(url)) {
+            super.ack(t, url);
+            return;
+        }
+        // add the tuple to the list for that url
+        List<Tuple> list = waitingAck.get(url);
+        list.add(t);
+    }
+
 }


### PR DESCRIPTION
This PR changes the behaviour of the SQL StatusUpdaterBolt by batching the INSERTs, i.e. the discovered URLs which are far more frequent than updates.
 
@cruftex plz let me know what you think. we can make it SQL agnostic in a separate step.