### PR TITLE
Abstract functionalities of spout implementations

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
@@ -1,0 +1,231 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.persistence;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.storm.metric.api.IMetric;
+import org.apache.storm.metric.api.MultiCountMetric;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichSpout;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.Utils;
+
+import com.digitalpebble.stormcrawler.util.ConfUtils;
+import com.google.common.base.Optional;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+/**
+ * Common features of spouts which query a backend to generate tuples. Tracks
+ * the URLs being processes, with an optional delay before they are removed from
+ * the cache. Throttles the rate a which queries are emitted and provides a
+ * buffer to store the URLs waiting to be sent.
+ * 
+ * @since 1.11
+ **/
+
+public abstract class AbstractQueryingSpout extends BaseRichSpout {
+
+    /**
+     * Time in seconds for which acked or failed URLs will be considered for
+     * fetching again, default 30 secs.
+     **/
+    protected static final String StatusTTLPurgatory = "spout.ttl.purgatory";
+    /**
+     * Min time to allow between 2 successive queries to the backend. Value in
+     * msecs, default 2000.
+     **/
+    protected static final String StatusMinDelayParamName = "spout.min.delay.queries";
+    protected long minDelayBetweenQueries = 2000;
+
+    protected long timeLastQuery = 0;
+
+    protected MultiCountMetric eventCounter;
+
+    protected Queue<Values> buffer = new LinkedList<>();
+    private SpoutOutputCollector _collector;
+
+    /** Required for implementations doing asynchronous calls **/
+    protected AtomicBoolean isInQuery = new AtomicBoolean(false);
+
+    @Override
+    public void open(Map stormConf, TopologyContext context,
+            SpoutOutputCollector collector) {
+
+        int ttlPurgatory = ConfUtils.getInt(stormConf, StatusTTLPurgatory, 30);
+
+        minDelayBetweenQueries = ConfUtils.getLong(stormConf,
+                StatusMinDelayParamName, 2000);
+
+        beingProcessed = new InProcessMap<>(ttlPurgatory, TimeUnit.SECONDS);
+
+        eventCounter = context.registerMetric("counters",
+                new MultiCountMetric(), 10);
+
+        context.registerMetric("buffer_size", new IMetric() {
+            @Override
+            public Object getValueAndReset() {
+                return buffer.size();
+            }
+        }, 10);
+
+        context.registerMetric("beingProcessed", new IMetric() {
+            @Override
+            public Object getValueAndReset() {
+                return beingProcessed.size();
+            }
+        }, 10);
+
+        context.registerMetric("inPurgatory", new IMetric() {
+            @Override
+            public Object getValueAndReset() {
+                return beingProcessed.inCache();
+            }
+        }, 10);
+
+        _collector = collector;
+    }
+
+    /** Method where specific implementations query the storage **/
+    protected abstract void populateBuffer();
+
+    /**
+     * Map to keep in-process URLs, ev. with additional information for URL /
+     * politeness bucket (hostname / domain etc.). The entries are kept in a
+     * cache for a configurable amount of time to avoid that some items are
+     * fetched a second time if new items are queried shortly after they have
+     * been acked.
+     */
+    protected InProcessMap<String, String> beingProcessed;
+    private boolean active;
+
+    /** Map which holds elements some additional time after the removal. */
+    public class InProcessMap<K, V> extends HashMap<K, V> {
+
+        private Cache<K, Optional<V>> deletionCache;
+
+        public InProcessMap(long maxDuration, TimeUnit timeUnit) {
+            deletionCache = CacheBuilder.newBuilder()
+                    .expireAfterWrite(maxDuration, timeUnit).build();
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            boolean incache = super.containsKey(key);
+            if (!incache) {
+                incache = (deletionCache.getIfPresent(key) != null);
+            }
+            return incache;
+        }
+
+        @Override
+        public V remove(Object key) {
+            deletionCache.put((K) key, Optional.absent());
+            return super.remove(key);
+        }
+
+        public long inCache() {
+            return deletionCache.size();
+        }
+    }
+
+    @Override
+    public void nextTuple() {
+        if (!active)
+            return;
+
+        // synchronize access to buffer needed in case of asynchronous
+        // queries to the backend
+        synchronized (buffer) {
+            if (!buffer.isEmpty()) {
+                List<Object> fields = buffer.remove();
+                String url = fields.get(0).toString();
+                this._collector.emit(fields, url);
+                beingProcessed.put(url, null);
+                eventCounter.scope("emitted").incrBy(1);
+                return;
+            }
+        }
+
+        if (isInQuery.get() || throttleQueries() > 0) {
+            // sleep for a bit but not too much in order to give ack/fail a
+            // chance
+            Utils.sleep(10);
+            return;
+        }
+
+        // re-populate the buffer
+        populateBuffer();
+    }
+
+    /**
+     * Returns the amount of time to wait if the backend was queried too
+     * recently and needs throttling or -1 if the backend can be queried
+     * straight away.
+     **/
+    private long throttleQueries() {
+        Date now = new Date();
+        if (timeLastQuery != 0) {
+            // check that we allowed some time between queries
+            long difference = now.getTime() - timeLastQuery;
+            if (difference < minDelayBetweenQueries) {
+                return minDelayBetweenQueries - difference;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public void activate() {
+        active = true;
+    }
+
+    @Override
+    public void deactivate() {
+        active = false;
+    }
+
+    @Override
+    public void ack(Object msgId) {
+        beingProcessed.remove(msgId);
+        eventCounter.scope("acked").incrBy(1);
+    }
+
+    @Override
+    public void fail(Object msgId) {
+        beingProcessed.remove(msgId);
+        eventCounter.scope("failed").incrBy(1);
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        declarer.declare(new Fields("url", "metadata"));
+    }
+
+}

--- a/external/elasticsearch/es-conf.yaml
+++ b/external/elasticsearch/es-conf.yaml
@@ -44,10 +44,10 @@ config:
   # es.status.filterQuery: "-(metadata.hostname:stormcrawler.net)"
 
   # time in secs for which the URLs will be considered for fetching after a ack of fail
-  es.status.ttl.purgatory: 30
+  spout.ttl.purgatory: 30
   
   # Min time (in msecs) to allow between 2 successive queries to ES
-  es.status.min.delay.queries: 2000
+  spout.min.delay.queries: 2000
 
   es.status.max.buckets: 50
   es.status.max.urls.per.bucket: 2

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
@@ -122,6 +122,8 @@ public abstract class AbstractSpout extends AbstractQueryingSpout {
     public void open(Map stormConf, TopologyContext context,
             SpoutOutputCollector collector) {
 
+        super.open(stormConf, context, collector);
+
         indexName = ConfUtils.getString(stormConf, ESStatusIndexNameParamName,
                 "status");
         docType = ConfUtils.getString(stormConf, ESStatusDocTypeParamName,

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
@@ -19,42 +19,24 @@ package com.digitalpebble.stormcrawler.elasticsearch.persistence;
 
 import java.io.IOException;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Queue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.storm.metric.api.IMetric;
-import org.apache.storm.metric.api.MultiCountMetric;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
-import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.topology.base.BaseRichSpout;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Values;
-import org.apache.storm.utils.Utils;
-import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsGroup;
-import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
-import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.elasticsearch.ElasticSearchConnection;
+import com.digitalpebble.stormcrawler.persistence.AbstractQueryingSpout;
 import com.digitalpebble.stormcrawler.util.CollectionMetric;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
-import com.google.common.base.Optional;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
-public abstract class AbstractSpout extends BaseRichSpout {
+public abstract class AbstractSpout extends AbstractQueryingSpout {
 
     private static final Logger LOG = LoggerFactory
             .getLogger(AbstractSpout.class);
@@ -66,6 +48,9 @@ public abstract class AbstractSpout extends BaseRichSpout {
     /**
      * Time in seconds for which acked or failed URLs will be considered for
      * fetching again, default 30 secs.
+     * 
+     * @deprecated replaced by
+     *             {@link com.digitalpebble.stormcrawler.persistence.AbstractQueryingSpout.StatusTTLPurgatory}
      **/
     protected static final String ESStatusTTLPurgatory = "es.status.ttl.purgatory";
 
@@ -88,6 +73,10 @@ public abstract class AbstractSpout extends BaseRichSpout {
     /**
      * Min time to allow between 2 successive queries to ES. Value in msecs,
      * default 2000.
+     * 
+     * @deprecated replaced by
+     *             {@link com.digitalpebble.stormcrawler.persistence.AbstractQueryingSpout.StatusMinDelayParamName}
+     * 
      **/
     private static final String ESStatusMinDelayParamName = "es.status.min.delay.queries";
 
@@ -99,9 +88,6 @@ public abstract class AbstractSpout extends BaseRichSpout {
 
     protected String indexName;
     protected String docType;
-    protected boolean active = true;
-    protected SpoutOutputCollector _collector;
-    protected MultiCountMetric eventCounter;
 
     protected static RestHighLevelClient client;
 
@@ -114,23 +100,6 @@ public abstract class AbstractSpout extends BaseRichSpout {
 
     /** Used to distinguish between instances in the logs **/
     protected String logIdprefix = "";
-
-    protected Queue<Values> buffer = new LinkedList<>();
-
-    /**
-     * Map to keep in-process URLs, ev. with additional information for URL /
-     * politeness bucket (hostname / domain etc.). The entries are kept in a
-     * cache for a configurable amount of time to avoid that some items are
-     * fetched a second time if new items are queried shortly after they have
-     * been acked.
-     */
-    protected InProcessMap<String, String> beingProcessed;
-
-    protected long timeStartESQuery = 0;
-
-    private long minDelayBetweenQueries = 2000;
-
-    protected AtomicBoolean isInESQuery = new AtomicBoolean(false);
 
     /** Field name used for field collapsing e.g. metadata.hostname **/
     protected String partitionField;
@@ -148,36 +117,6 @@ public abstract class AbstractSpout extends BaseRichSpout {
     protected Date lastDate;
 
     protected int resetFetchDateAfterNSecs = 120;
-
-    /** Map which holds elements some additional time after the removal. */
-    public class InProcessMap<K, V> extends HashMap<K, V> {
-
-        private Cache<K, Optional<V>> deletionCache;
-
-        public InProcessMap(long maxDuration, TimeUnit timeUnit) {
-            deletionCache = CacheBuilder.newBuilder()
-                    .expireAfterWrite(maxDuration, timeUnit).build();
-        }
-
-        @Override
-        public boolean containsKey(Object key) {
-            boolean incache = super.containsKey(key);
-            if (!incache) {
-                incache = (deletionCache.getIfPresent(key) != null);
-            }
-            return incache;
-        }
-
-        @Override
-        public V remove(Object key) {
-            deletionCache.put((K) key, Optional.absent());
-            return super.remove(key);
-        }
-
-        public long inCache() {
-            return deletionCache.size();
-        }
-    }
 
     @Override
     public void open(Map stormConf, TopologyContext context,
@@ -238,14 +177,6 @@ public abstract class AbstractSpout extends BaseRichSpout {
             LOG.info("{} assigned shard ID {}", logIdprefix, shardID);
         }
 
-        _collector = collector;
-
-        int ttlPurgatory = ConfUtils
-                .getInt(stormConf, ESStatusTTLPurgatory, 30);
-
-        minDelayBetweenQueries = ConfUtils.getLong(stormConf,
-                ESStatusMinDelayParamName, 2000);
-
         partitionField = ConfUtils.getString(stormConf,
                 ESStatusBucketFieldParamName, "metadata.hostname");
 
@@ -263,90 +194,10 @@ public abstract class AbstractSpout extends BaseRichSpout {
         resetFetchDateAfterNSecs = ConfUtils.getInt(stormConf,
                 ESStatusResetFetchDateParamName, resetFetchDateAfterNSecs);
 
-        beingProcessed = new InProcessMap<>(ttlPurgatory, TimeUnit.SECONDS);
-
         filterQuery = ConfUtils.getString(stormConf, ESStatusFilterParamName);
-
-        eventCounter = context.registerMetric("counters",
-                new MultiCountMetric(), 10);
-
-        context.registerMetric("buffer_size", new IMetric() {
-            @Override
-            public Object getValueAndReset() {
-                return buffer.size();
-            }
-        }, 10);
-
-        context.registerMetric("beingProcessed", new IMetric() {
-            @Override
-            public Object getValueAndReset() {
-                return beingProcessed.size();
-            }
-        }, 10);
-
-        context.registerMetric("inPurgatory", new IMetric() {
-            @Override
-            public Object getValueAndReset() {
-                return beingProcessed.inCache();
-            }
-        }, 10);
 
         esQueryTimes = new CollectionMetric();
         context.registerMetric("ES_query_time_msec", esQueryTimes, 10);
-    }
-
-    /** Returns true if ES was queried too recently and needs throttling **/
-    protected boolean throttleESQueries() {
-        Date now = new Date();
-        if (timeStartESQuery != 0) {
-            // check that we allowed some time between queries
-            long difference = now.getTime() - timeStartESQuery;
-            if (difference < minDelayBetweenQueries) {
-                long sleepTime = minDelayBetweenQueries - difference;
-                LOG.debug(
-                        "{} Not enough time elapsed since {} - should try again in {}",
-                        logIdprefix, timeStartESQuery, sleepTime);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public void declareOutputFields(OutputFieldsDeclarer declarer) {
-        declarer.declare(new Fields("url", "metadata"));
-    }
-
-    @Override
-    public void nextTuple() {
-
-        // inactive?
-        if (active == false)
-            return;
-
-        synchronized (buffer) {
-            // have anything in the buffer?
-            if (!buffer.isEmpty()) {
-                Values fields = buffer.remove();
-                String url = fields.get(0).toString();
-                beingProcessed.put(url, null);
-                _collector.emit(fields, url);
-                eventCounter.scope("emitted").incrBy(1);
-                return;
-            }
-        }
-
-        // check that we allowed some time between queries
-        // and not in middle of querying ES
-        if (isInESQuery.get() || throttleESQueries()) {
-            // sleep for a bit but not too much in order to give ack/fail a
-            // chance
-            Utils.sleep(10);
-            return;
-        }
-
-        // re-populate the buffer
-        populateBuffer();
     }
 
     /** Builds a query and use it retrieve the results from ES **/
@@ -381,25 +232,13 @@ public abstract class AbstractSpout extends BaseRichSpout {
     @Override
     public void ack(Object msgId) {
         LOG.debug("{}  Ack for {}", logIdprefix, msgId);
-        beingProcessed.remove(msgId);
-        eventCounter.scope("acked").incrBy(1);
+        super.ack(msgId);
     }
 
     @Override
     public void fail(Object msgId) {
         LOG.info("{}  Fail for {}", logIdprefix, msgId);
-        beingProcessed.remove(msgId);
-        eventCounter.scope("failed").incrBy(1);
-    }
-
-    @Override
-    public void activate() {
-        active = true;
-    }
-
-    @Override
-    public void deactivate() {
-        active = false;
+        super.fail(msgId);
     }
 
     @Override

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
@@ -171,25 +171,25 @@ public class AggregationSpout extends AbstractSpout implements
         // dump query to log
         LOG.debug("{} ES query {}", logIdprefix, request.toString());
 
-        timeStartESQuery = System.currentTimeMillis();
-        isInESQuery.set(true);
+        timeLastQuery = System.currentTimeMillis();
+        isInQuery.set(true);
         client.searchAsync(request, this);
     }
 
     @Override
     public void onFailure(Exception arg0) {
         LOG.error("Exception with ES query", arg0);
-        isInESQuery.set(false);
+        isInQuery.set(false);
     }
 
     @Override
     public void onResponse(SearchResponse response) {
-        long timeTaken = System.currentTimeMillis() - timeStartESQuery;
+        long timeTaken = System.currentTimeMillis() - timeLastQuery;
 
         Aggregations aggregs = response.getAggregations();
 
         if (aggregs == null) {
-            isInESQuery.set(false);
+            isInQuery.set(false);
             return;
         }
 
@@ -333,7 +333,7 @@ public class AggregationSpout extends AbstractSpout implements
         }
 
         // remove lock
-        isInESQuery.set(false);
+        isInQuery.set(false);
     }
 
 }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
@@ -151,20 +151,20 @@ public class CollapsingSpout extends AbstractSpout implements
         // dump query to log
         LOG.debug("{} ES query {}", logIdprefix, request.toString());
 
-        timeStartESQuery = System.currentTimeMillis();
-        isInESQuery.set(true);
+        timeLastQuery = System.currentTimeMillis();
+        isInQuery.set(true);
         client.searchAsync(request, this);
     }
 
     @Override
     public void onFailure(Exception e) {
         LOG.error("{} Exception with ES query", logIdprefix, e);
-        isInESQuery.set(false);
+        isInQuery.set(false);
     }
 
     @Override
     public void onResponse(SearchResponse response) {
-        long timeTaken = System.currentTimeMillis() - timeStartESQuery;
+        long timeTaken = System.currentTimeMillis() - timeLastQuery;
 
         SearchHit[] hits = response.getHits().getHits();
         int numBuckets = hits.length;
@@ -238,7 +238,7 @@ public class CollapsingSpout extends AbstractSpout implements
         }
 
         // remove lock
-        isInESQuery.set(false);
+        isInQuery.set(false);
     }
 
     private final boolean addHitToBuffer(SearchHit hit) {

--- a/external/solr/solr-conf.yaml
+++ b/external/solr/solr-conf.yaml
@@ -8,6 +8,13 @@ config:
   solr.status.bucket.field: host
   solr.status.bucket.maxsize: 100
   solr.status.metadata.prefix: metadata
+  solr.status.max.results: 
+  
+  # time in secs for which the URLs will be considered for fetching after a ack of fail
+  spout.ttl.purgatory: 30
+  
+  # Min time (in msecs) to allow between 2 successive queries to SOLR
+  spout.min.delay.queries: 2000
   
   # Solr MetricsConsumer
   solr.metrics.url: "http://localhost:8983/solr/metrics"

--- a/external/solr/solr-conf.yaml
+++ b/external/solr/solr-conf.yaml
@@ -8,7 +8,7 @@ config:
   solr.status.bucket.field: host
   solr.status.bucket.maxsize: 100
   solr.status.metadata.prefix: metadata
-  solr.status.max.results: 
+  solr.status.max.results: 100
   
   # time in secs for which the URLs will be considered for fetching after a ack of fail
   spout.ttl.purgatory: 30

--- a/external/sql/sql-conf.yaml
+++ b/external/sql/sql-conf.yaml
@@ -6,8 +6,14 @@ config:
   mysql.table: "urls"
   mysql.user: "myuser"
   mysql.password: "mypassword"
-  mysql.buffer.size: 100
-  mysql.min.query.interval: 5000
+  
+  mysql.spout.max.results: 100
+  
+    # time in secs for which the URLs will be considered for fetching after a ack of fail
+  spout.ttl.purgatory: 30
+  
+  # Min time (in msecs) to allow between 2 successive queries to SQL
+  spout.min.delay.queries: 2000
 
   mysql.metrics.table: "metrics"
   

--- a/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/Constants.java
+++ b/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/Constants.java
@@ -23,10 +23,16 @@ public class Constants {
     public static final String MYSQL_USER_PARAM_NAME = "mysql.user";
     public static final String MYSQL_PASSWORD_PARAM_NAME = "mysql.password";
     public static final String MYSQL_TABLE_PARAM_NAME = "mysql.table";
-    public static final String MYSQL_BUFFERSIZE_PARAM_NAME = "mysql.buffer.size";
     public static final String MYSQL_MAX_DOCS_BUCKET_PARAM_NAME = "mysql.max.urls.per.bucket";
-    public static final String MYSQL_MIN_QUERY_INTERVAL_PARAM_NAME = "mysql.min.query.interval";
     public static final String MYSQL_METRICS_TABLE_PARAM_NAME = "mysql.metrics.table";
+
+    public static final String MYSQL_MAXRESULTS_PARAM_NAME = "mysql.spout.max.results";
+
+    /**
+     * @deprecated replaced by
+     *             {@link com.digitalpebble.stormcrawler.persistence.AbstractQueryingSpout.StatusMinDelayParamName}
+     */
+    public static final String MYSQL_MIN_QUERY_INTERVAL_PARAM_NAME = "mysql.min.query.interval";
 
     private Constants() {
     }

--- a/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/SQLSpout.java
+++ b/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/SQLSpout.java
@@ -25,58 +25,32 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.digitalpebble.stormcrawler.util.CollectionMetric;
-import com.digitalpebble.stormcrawler.util.ConfUtils;
-import com.digitalpebble.stormcrawler.util.StringTabScheme;
-
-import org.apache.storm.metric.api.MultiCountMetric;
 import org.apache.storm.spout.Scheme;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.topology.base.BaseRichSpout;
-import org.apache.storm.utils.Utils;
+import org.apache.storm.tuple.Values;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.stormcrawler.persistence.AbstractQueryingSpout;
+import com.digitalpebble.stormcrawler.util.CollectionMetric;
+import com.digitalpebble.stormcrawler.util.ConfUtils;
+import com.digitalpebble.stormcrawler.util.StringTabScheme;
 
 @SuppressWarnings("serial")
-public class SQLSpout extends BaseRichSpout {
+public class SQLSpout extends AbstractQueryingSpout {
 
     public static final Logger LOG = LoggerFactory.getLogger(SQLSpout.class);
 
     private static final Scheme SCHEME = new StringTabScheme();
 
-    private SpoutOutputCollector _collector;
-
     private String tableName;
 
     private Connection connection;
-
-    private int bufferSize = 100;
-
-    private Queue<List<Object>> buffer = new LinkedList<>();
-
-    /**
-     * Keeps track of the URLs in flight so that we don't add them more than
-     * once when the table contains just a few URLs
-     **/
-    private Set<String> beingProcessed = new HashSet<>();
-
-    private boolean active;
-
-    private MultiCountMetric eventCounter;
-
-    private int minWaitBetweenQueriesMSec = 5000;
-
-    private long lastQueryTime = System.currentTimeMillis();
 
     /**
      * if more than one instance of the spout exist, each one is in charge of a
@@ -91,25 +65,22 @@ public class SQLSpout extends BaseRichSpout {
 
     private int maxDocsPerBucket;
 
+    private int maxNumResults;
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public void open(Map conf, TopologyContext context,
             SpoutOutputCollector collector) {
-        _collector = collector;
 
-        this.eventCounter = context.registerMetric("spout",
-                new MultiCountMetric(), 10);
-
-        bufferSize = ConfUtils.getInt(conf,
-                Constants.MYSQL_BUFFERSIZE_PARAM_NAME, 100);
+        super.open(conf, context, collector);
 
         maxDocsPerBucket = ConfUtils.getInt(conf,
                 Constants.MYSQL_MAX_DOCS_BUCKET_PARAM_NAME, 5);
 
-        minWaitBetweenQueriesMSec = ConfUtils.getInt(conf,
-                Constants.MYSQL_MIN_QUERY_INTERVAL_PARAM_NAME, 5000);
-
         tableName = ConfUtils.getString(conf, Constants.MYSQL_TABLE_PARAM_NAME);
+
+        maxNumResults = ConfUtils.getInt(conf,
+                Constants.MYSQL_MAXRESULTS_PARAM_NAME, 100);
 
         try {
             connection = SQLUtil.getConnection(conf);
@@ -137,48 +108,9 @@ public class SQLSpout extends BaseRichSpout {
     }
 
     @Override
-    public void nextTuple() {
-        if (!active)
-            return;
+    protected void populateBuffer() {
 
-        if (!buffer.isEmpty()) {
-            List<Object> fields = buffer.remove();
-            String url = fields.get(0).toString();
-            this._collector.emit(fields, url);
-            beingProcessed.add(url);
-            return;
-        }
-
-        if (throttleQueries()) {
-            // sleep for a bit but not too much in order to give ack/fail a
-            // chance
-            Utils.sleep(10);
-            return;
-        }
-
-        // re-populate the buffer
-        populateBuffer();
-    }
-
-    /** Returns true if SQL was queried too recently and needs throttling **/
-    protected boolean throttleQueries() {
-        if (lastQueryTime != 0) {
-            // check that we allowed some time between queries
-            long difference = Instant.now().toEpochMilli() - lastQueryTime;
-            if (difference < minWaitBetweenQueriesMSec) {
-                long sleepTime = minWaitBetweenQueriesMSec - difference;
-                LOG.debug(
-                        "{} Not enough time elapsed since {} - should try again in {}",
-                        logIdprefix, lastQueryTime, sleepTime);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private void populateBuffer() {
-
-        lastQueryTime = Instant.now().toEpochMilli();
+        timeLastQuery = Instant.now().toEpochMilli();
 
         // select entries from mysql
         // https://mariadb.com/kb/en/library/window-functions-overview/
@@ -198,7 +130,7 @@ public class SQLSpout extends BaseRichSpout {
         query += ") as urls_ranks where (urls_ranks.ranking <= "
                 + maxDocsPerBucket + ") order by host, ranking";
 
-        query += " LIMIT " + this.bufferSize;
+        query += " LIMIT " + this.maxNumResults;
 
         int alreadyprocessed = 0;
         int numhits = 0;
@@ -225,7 +157,7 @@ public class SQLSpout extends BaseRichSpout {
                 String url = rs.getString("url");
                 numhits++;
                 // already processed? skip
-                if (beingProcessed.contains(url)) {
+                if (beingProcessed.containsKey(url)) {
                     alreadyprocessed++;
                     continue;
                 }
@@ -238,7 +170,7 @@ public class SQLSpout extends BaseRichSpout {
                 String URLMD = url + metadata;
                 List<Object> v = SCHEME.deserialize(ByteBuffer.wrap(URLMD
                         .getBytes()));
-                buffer.add(v);
+                buffer.add(new Values(v));
             }
 
             eventCounter.scope("already_being_processed").incrBy(
@@ -269,29 +201,15 @@ public class SQLSpout extends BaseRichSpout {
     }
 
     @Override
-    public void activate() {
-        super.activate();
-        active = true;
-    }
-
-    @Override
-    public void deactivate() {
-        super.deactivate();
-        active = false;
-    }
-
-    @Override
     public void ack(Object msgId) {
         LOG.debug("{}  Ack for {}", logIdprefix, msgId);
-        beingProcessed.remove(msgId);
-        eventCounter.scope("acked").incrBy(1);
+        super.ack(msgId);
     }
 
     @Override
     public void fail(Object msgId) {
         LOG.info("{}  Fail for {}", logIdprefix, msgId);
-        beingProcessed.remove(msgId);
-        eventCounter.scope("failed").incrBy(1);
+        super.fail(msgId);
     }
 
     @Override


### PR DESCRIPTION
implements #617

Refactoring of spout implementations. The ones in the external modules have in common that they generate tuples based on queries to a backend (e.g. SOLR, SQL, ES).  The introduction of the class AbstractQueryingSpout simplifies the implementations of these spouts by taking care of the query throttling, caching of URLs in process, instantiation of the metrics etc...

Some of the configuration names have been deprecated as a result. 