### PR TITLE
Override Globally Configured Accepts and Accepts-Language Headers Per-URL

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
@@ -221,8 +221,8 @@ public class HttpProtocol extends AbstractHttpProtocol implements
 
             String acceptLanguage = md.getFirstValue("http.accept.language");
             if (StringUtils.isNotBlank(acceptLanguage)) {
-                headers.put("Accept-Language",
-                        new BasicHeader("Accept-Language", acceptLanguage));
+                headers.put("Accept-Language", new BasicHeader(
+                        "Accept-Language", acceptLanguage));
             }
 
             if (useCookies) {
@@ -235,7 +235,8 @@ public class HttpProtocol extends AbstractHttpProtocol implements
         // no need to release the connection explicitly as this is handled
         // automatically. The client itself must be closed though.
 
-        try (CloseableHttpClient httpclient = builder.setDefaultHeaders(headers.values()).build()) {
+        try (CloseableHttpClient httpclient = builder.setDefaultHeaders(
+                headers.values()).build()) {
             return httpclient.execute(request, this);
         }
     }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
@@ -23,11 +23,9 @@ import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.mutable.MutableBoolean;
@@ -231,7 +229,6 @@ public class HttpProtocol extends AbstractHttpProtocol implements
 
         // no need to release the connection explicitly as this is handled
         // automatically. The client itself must be closed though.
-
         try (CloseableHttpClient httpclient = builder.build()) {
             return httpclient.execute(request, this);
         }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
@@ -20,7 +20,14 @@ package com.digitalpebble.stormcrawler.protocol.httpclient;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.mutable.MutableBoolean;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -206,6 +206,16 @@ public class HttpProtocol extends AbstractHttpProtocol {
                 rb.header("If-None-Match", ifNoneMatch);
             }
 
+            String accept = metadata.getFirstValue("http.accept");
+            if (StringUtils.isNotBlank(accept)) {
+                rb.header("Accept", accept);
+            }
+
+            String acceptLanguage = metadata.getFirstValue("http.accept.language");
+            if (StringUtils.isNotBlank(acceptLanguage)) {
+                rb.header("Accept-Language", acceptLanguage);
+            }
+
             if (useCookies) {
                 addCookiesToRequest(rb, url, metadata);
             }


### PR DESCRIPTION
In this version, the `HttpProtocol` classes have been updated to optionally use `Accept` and `Accept-Language` header values obtained from the `Metadata` object over the globally configured defaults.

This satisfies Feature Request #629 
