### PR TITLE
WARC record format: trailing zero byte causes WARC parser to fail

### DIFF
--- a/external/warc/pom.xml
+++ b/external/warc/pom.xml
@@ -18,6 +18,8 @@
 
 	<properties>
 		<commons-codec.version>1.10</commons-codec.version>
+		<mockito-all.version>1.10.8</mockito-all.version>
+		<wiremock.version>2.19.0</wiremock.version>
 	</properties>
 
 	<dependencies>
@@ -35,5 +37,26 @@
 			<version>1.2.2</version>
 		</dependency>
 
+		<dependency>
+			<groupId>com.digitalpebble.stormcrawler</groupId>
+			<artifactId>storm-crawler-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>${mockito-all.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock</artifactId>
+			<version>${wiremock.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
@@ -204,8 +204,10 @@ public class WARCRecordFormat implements RecordFormat {
 
         byte[] buffasbytes = buffer.toString().getBytes(StandardCharsets.UTF_8);
 
-        // work out the exact length of the bytebuffer with an extra byte
-        int capacity = 7 + buffasbytes.length + httpheaders.length;
+        // work out the *exact* length of the bytebuffer - do not add any extra
+        // bytes which are appended as trailing zero bytes causing invalid WARC
+        // files
+        int capacity = 6 + buffasbytes.length + httpheaders.length;
         if (content != null) {
             capacity += content.length;
         }

--- a/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormatTest.java
+++ b/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormatTest.java
@@ -1,10 +1,16 @@
 package com.digitalpebble.stormcrawler.warc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
 
+import org.apache.storm.tuple.Tuple;
 import org.junit.Test;
+
+import com.digitalpebble.stormcrawler.Metadata;
 
 public class WARCRecordFormatTest {
 
@@ -41,6 +47,44 @@ public class WARCRecordFormatTest {
         String sha1str = "sha1:DHBVNHAJABWFHIYUHNCKYYIB3OBPFX3Y";
         assertEquals("Wrong sha1 digest", sha1str,
                 WARCRecordFormat.getDigestSha1(content));
+    }
+
+    @Test
+    public void testWarcRecord() {
+        // test validity of WARC record
+        String txt = "abcdef";
+        byte[] content = txt.getBytes(StandardCharsets.UTF_8);
+        String sha1str = "sha1:D6FMCDZDYW23YELHXWUEXAZ6LQCXU56S";
+        Metadata metadata = new Metadata();
+        metadata.addValue("_response.headers_",
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html");
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getBinaryByField("content")).thenReturn(content);
+        when(tuple.getStringByField("url")).thenReturn(
+                "https://www.example.org/");
+        when(tuple.getValueByField("metadata")).thenReturn(metadata);
+        WARCRecordFormat format = new WARCRecordFormat();
+        byte[] warcBytes = format.format(tuple);
+        String warcString = new String(warcBytes, StandardCharsets.UTF_8);
+        // the WARC record has the form:
+        // WARC header
+        // \r\n\r\n
+        // HTTP header
+        // \r\n\r\n
+        // payload
+        // \r\n\r\n
+        assertTrue("WARC record: incorrect format of WARC header",
+                warcString.startsWith("WARC/1.0"));
+        assertTrue("WARC record: incorrect format of HTTP header",
+                warcString.contains("\r\n\r\nHTTP/1.1 200 OK\r\n"));
+        assertTrue("WARC record: record is required to end with \\r\\n\\r\\n",
+                warcString.endsWith("\r\n\r\n"));
+        assertTrue("WARC record: payload mangled",
+                warcString.endsWith("\r\n\r\nabcdef\r\n\r\n"));
+        assertTrue(
+                "WARC record: no or incorrect payload digest",
+                warcString.contains("\r\nWARC-Payload-Digest: " + sha1str
+                        + "\r\n"));
     }
 
 }


### PR DESCRIPTION
The WARCRecordFormat adds a trailing zero byte which causes validating WARC parsers to fail, e.g.,
```
warcio index -f offset,length CC-NEWS-20181112133126-00000.warc.gz 
{"offset": "0", "length": "397"}
{"offset": "397", "length": "904"}
Traceback (most recent call last):
  File "...warcio/recordloader.py", line 208, in _detect_type_load_headers
    rec_headers = self.arc_parser.parse(stream, statusline)
  File "...warcio/recordloader.py", line 275, in parse
    raise StatusAndHeadersParserException(msg, parts)
warcio.statusandheaders.StatusAndHeadersParserException: Wrong # of headers, expected arc headers ['WARC-Target-URI', 'WARC-IP-Address', 'WARC-Date', 'Content-Type', 'Content-Length'], Found ['\x00']
```

The pull request
- fixes WARCRecordFormat so that no trailing zero byte is added
- adds a unit test for WARCRecordFormat which does a trivial validation of a return WARC record
