### PR TITLE
 Staggered scheduling of sitemap URLs

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/SiteMapParserBolt.java
@@ -47,6 +47,7 @@ import com.digitalpebble.stormcrawler.parse.Outlink;
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseFilters;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.persistence.DefaultScheduler;
 import com.digitalpebble.stormcrawler.persistence.Status;
 import com.digitalpebble.stormcrawler.protocol.HttpHeaders;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
@@ -87,6 +88,9 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
     private int maxOffsetGuess = 300;
 
     private ReducedMetric averagedMetrics;
+
+    /** Delay in minutes used for scheduling sub-sitemaps **/
+    private int scheduleSitemapsWithDelay = -1;
 
     @Override
     public void execute(Tuple tuple) {
@@ -197,6 +201,12 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
         if (siteMap.isIndex()) {
             SiteMapIndex smi = (SiteMapIndex) siteMap;
             Collection<AbstractSiteMap> subsitemaps = smi.getSitemaps();
+
+            Calendar rightNow = Calendar.getInstance();
+            rightNow.add(Calendar.HOUR, -filterHoursSinceModified);
+
+            int delay = 0;
+
             // keep the subsitemaps as outlinks
             // they will be fetched and parsed in the following steps
             Iterator<AbstractSiteMap> iter = subsitemaps.iterator();
@@ -209,8 +219,6 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
                 if (lastModified != null) {
                     // filter based on the published date
                     if (filterHoursSinceModified != -1) {
-                        Calendar rightNow = Calendar.getInstance();
-                        rightNow.add(Calendar.HOUR, -filterHoursSinceModified);
                         if (lastModified.before(rightNow.getTime())) {
                             LOG.info(
                                     "{} has a modified date {} which is more than {} hours old",
@@ -228,6 +236,14 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
                 if (ol == null) {
                     continue;
                 }
+
+                // add a delay
+                if (this.scheduleSitemapsWithDelay > 0) {
+                    delay += this.scheduleSitemapsWithDelay;
+                    ol.getMetadata().setValue(DefaultScheduler.DELAY_METADATA,
+                            Integer.toString(delay));
+                }
+
                 links.add(ol);
                 LOG.debug("{} : [sitemap] {}", url, target);
             }
@@ -295,6 +311,8 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
         averagedMetrics = context.registerMetric(
                 "sitemap_average_processing_time", new ReducedMetric(
                         new MeanReducer()), 30);
+        scheduleSitemapsWithDelay = ConfUtils.getInt(stormConf,
+                "sitemap.schedule.delay", scheduleSitemapsWithDelay);
     }
 
     @Override

--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/SiteMapParserBolt.java
@@ -239,9 +239,12 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
 
                 // add a delay
                 if (this.scheduleSitemapsWithDelay > 0) {
+                    if (delay > 0) {
+                        ol.getMetadata().setValue(
+                                DefaultScheduler.DELAY_METADATA,
+                                Integer.toString(delay));
+                    }
                     delay += this.scheduleSitemapsWithDelay;
-                    ol.getMetadata().setValue(DefaultScheduler.DELAY_METADATA,
-                            Integer.toString(delay));
                 }
 
                 links.add(ol);

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -138,6 +138,9 @@ config:
   # filters URLs in sitemaps based on their modified Date (if any)
   sitemap.filter.hours.since.modified: -1
 
+  # staggered scheduling of sitemaps
+  sitemap.schedule.delay: -1
+
   # whether to add any sitemaps found in the robots.txt to the status stream
   # used by fetcher bolts. sitemap.sniffContent must be set to true if the 
   # discovery is enabled


### PR DESCRIPTION
Fixed #657

adds a mechanism to the default scheduler for adding a delay based on a value specified in the metadata. Applied prior to the rules set in config