### PR TITLE
669: Implement outlink limit per page

### DIFF
--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -126,6 +126,7 @@ config:
   # JSoupParserBolt
   jsoup.treat.non.html.as.error: true
   parser.emitOutlinks: true
+  parser.emitOutlinks.max.per.page: -1
   track.anchors: true
   detect.mimetype: true
   detect.charset.maxlength: 10000


### PR DESCRIPTION
Added a new property called `parser.emitOutlinks.max.per.page` in config file, to be used for limiting quantity of outlinks discovered in a page during parsing.
If `parser.emitOutlinks.max.per.page : -1` limit will be disabled. Default value of this property is -1.  
Change is really straight forward .

Thanks 
Juan