### PR TITLE
Upgrades Xerces, Guava & ElasticSearch / Fixes test-failure in non-English timezones

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,10 +19,10 @@
 		<!-- dependency versions -->
 		<mockito-all.version>1.10.8</mockito-all.version>
 		<crawler-commons.version>0.10</crawler-commons.version>
-		<guava.version>21.0</guava.version>
+		<guava.version>27.0.1-jre</guava.version>
 		<jsoup.version>1.11.3</jsoup.version>
 		<icu4j.version>61.1</icu4j.version>
-		<xerces.version>2.11.0</xerces.version>
+		<xerces.version>2.12.0</xerces.version>
 		<httpclient.version>4.5.5</httpclient.version>
 		<snakeyaml.version>1.16</snakeyaml.version>
 		<commons.lang.version>2.6</commons.lang.version>

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/CookieConverter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/CookieConverter.java
@@ -23,6 +23,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
+
 import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.cookie.BasicClientCookie;
 
@@ -33,14 +35,14 @@ import org.apache.http.impl.cookie.BasicClientCookie;
 public class CookieConverter {
 
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(
-            "EEE, dd MMM yyyy HH:mm:ss zzz");
+            "EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
 
     /**
      * Get a list of cookies based on the cookies string taken from response
      * header and the target url.
      * 
-     * @param cookiesString
-     *            the value of the http header for "Cookie" in the http
+     * @param cookiesStrings
+     *            the values of the http header for "Cookie" in the http
      *            response.
      * @param targetURL
      *            the url for which we wish to pass the cookies in the request.

--- a/external/elasticsearch/pom.xml
+++ b/external/elasticsearch/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>
 			<artifactId>elasticsearch-rest-high-level-client</artifactId>
-			<version>6.5.0</version>
+			<version>6.5.2</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
- upgrades guava to 27.0.1.jre (was 21.0) to mitigate https://nvd.nist.gov/vuln/detail/CVE-2018-10237
- upgrades xerces to 2.12.0 (was 2.11.0) to mitigate https://nvd.nist.gov/vuln/detail/CVE-2012-0881
- upgrades elasticsearch to 6.5.2 (was 6.5.0), fixes #667

- adds the English locale to DATE_FORMAT in CookieConverter to avoid test failures in different build environments (i.e. German time zone) and adjusts javadoc