### PR TITLE
Date format used for HTTP if-modified-since requests must follow RFC 7231

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpHeaders.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpHeaders.java
@@ -16,8 +16,14 @@
  */
 package com.digitalpebble.stormcrawler.protocol;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
 /**
- * A collection of HTTP header names.
+ * A collection of HTTP header names and utilities around header values.
  * 
  * @see <a href="http://rfc-ref.org/RFC-TEXTS/2616/">Hypertext Transfer Protocol
  *      -- HTTP/1.1 (RFC 2616)</a>
@@ -44,4 +50,47 @@ public interface HttpHeaders {
 
     public static final String LOCATION = "location";
 
+    /**
+     * Formatter for dates in HTTP headers, used to fill the
+     * &quot;If-Modified-Since&quot; request header field, e.g.
+     * 
+     * <pre>
+     * Sun, 06 Nov 1994 08:49:37 GMT
+     * </pre>
+     * 
+     * See <a href=
+     * "https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1">sec.
+     * 3.3.1 in RFC 2616</a> and <a
+     * href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">sec. 7.1.1.1
+     * in RFC 7231</a>. The latter specifies the format defined in RFC 1123 as
+     * the &quot;preferred&quot; format.
+     */
+    public static final DateTimeFormatter HTTP_DATE_FORMATTER = DateTimeFormatter.RFC_1123_DATE_TIME
+            .withZone(ZoneId.of(ZoneOffset.UTC.toString()));
+
+    /**
+     * Format an ISO date string as HTTP date used in HTTP headers, e.g.,
+     * 
+     * <pre>
+     * 1994-11-06T08:49:37.000Z
+     * </pre>
+     * 
+     * is formatted to
+     * 
+     * <pre>
+     * Sun, 06 Nov 1994 08:49:37 GMT
+     * </pre>
+     * 
+     * See {@link #HTTP_DATE_FORMATTER.}
+     */
+    public static String formatHttpDate(String isoDate) {
+        try {
+            ZonedDateTime date = DateTimeFormatter.ISO_INSTANT.parse(isoDate,
+                    ZonedDateTime::from);
+            return HTTP_DATE_FORMATTER.format(date);
+        } catch (DateTimeParseException e) {
+            // not an ISO date
+            return "";
+        }
+    }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
@@ -60,6 +60,7 @@ import org.slf4j.LoggerFactory;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.persistence.Status;
 import com.digitalpebble.stormcrawler.protocol.AbstractHttpProtocol;
+import com.digitalpebble.stormcrawler.protocol.HttpHeaders;
 import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 import com.digitalpebble.stormcrawler.util.CookieConverter;
@@ -201,7 +202,8 @@ public class HttpProtocol extends AbstractHttpProtocol implements
 
             String lastModified = md.getFirstValue("last-modified");
             if (StringUtils.isNotBlank(lastModified)) {
-                request.addHeader("If-Modified-Since", lastModified);
+                request.addHeader("If-Modified-Since",
+                        HttpHeaders.formatHttpDate(lastModified));
             }
 
             String ifNoneMatch = md.getFirstValue("etag");

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.protocol.AbstractHttpProtocol;
+import com.digitalpebble.stormcrawler.protocol.HttpHeaders;
 import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 import com.digitalpebble.stormcrawler.util.CookieConverter;
@@ -203,7 +204,8 @@ public class HttpProtocol extends AbstractHttpProtocol {
         if (metadata != null) {
             String lastModified = metadata.getFirstValue("last-modified");
             if (StringUtils.isNotBlank(lastModified)) {
-                rb.header("If-Modified-Since", lastModified);
+                rb.header("If-Modified-Since",
+                        HttpHeaders.formatHttpDate(lastModified));
             }
 
             String ifNoneMatch = metadata.getFirstValue("etag");


### PR DESCRIPTION
Format the last-modified ISO date persisted in metadata as HTTP-Date when sending If-Modified-Since requests. Fixes #673.