### PR TITLE
Optional timeout configurations for elasticsearch's RestClient

### DIFF
--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/ElasticSearchConnection.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/ElasticSearchConnection.java
@@ -41,6 +41,10 @@ import org.elasticsearch.common.unit.TimeValue;
 
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 
+import static org.elasticsearch.client.RestClientBuilder.DEFAULT_CONNECT_TIMEOUT_MILLIS;
+import static org.elasticsearch.client.RestClientBuilder.DEFAULT_MAX_RETRY_TIMEOUT_MILLIS;
+import static org.elasticsearch.client.RestClientBuilder.DEFAULT_SOCKET_TIMEOUT_MILLIS;
+
 /**
  * Utility class to instantiate an ES client and bulkprocessor based on the
  * configuration.

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/ElasticSearchConnection.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/ElasticSearchConnection.java
@@ -115,6 +115,17 @@ public class ElasticSearchConnection {
             });
         }
 
+        int connectTimeout = ConfUtils.getInt(stormConf, "es." + boltType
+                + ".connect.timeout", DEFAULT_CONNECT_TIMEOUT_MILLIS);
+        int socketTimeout = ConfUtils.getInt(stormConf, "es." + boltType
+                + ".socket.timeout", DEFAULT_SOCKET_TIMEOUT_MILLIS);
+        int maxRetryTimeout = ConfUtils.getInt(stormConf, "es." + boltType
+                + ".max.retry.timeout", DEFAULT_MAX_RETRY_TIMEOUT_MILLIS);
+        builder.setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder
+                .setConnectTimeout(connectTimeout)  //Timeout until connection is established
+                .setSocketTimeout(socketTimeout)    //Timeout when waiting for data
+        ).setMaxRetryTimeoutMillis(maxRetryTimeout);
+
         // TODO configure headers etc...
         // Map<String, String> configSettings = (Map) stormConf
         // .get("es." + boltType + ".settings");


### PR DESCRIPTION
In this version it is possible to optionally configure overrides for elasticsearch's default RestClient timeouts.

Options are:
```
es.[BOLT TYPE].connect.timeout: // Timeout for establishing a connection (if the value is 0, the timeout is considered "infinity")
es.[BOLT TYPE].socket.timeout: // Timeout for receiving data (if the value is 0, the timeout is considered "infinity")
es.[BOLT TYPE].max.retry.timeout: // The time before a connection retry is considered to have timed out (must be > 0)
```

All values should be in millis.

If no values are supplied, the elasticsearch defaults are used.

Thanks for contributing to StormCrawler, your efforts are appreciated!