### PR TITLE
Add a ScrollSpout to read all the documents from a shard

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
@@ -92,7 +92,7 @@ public abstract class AbstractQueryingSpout extends BaseRichSpout {
     protected Queue<Values> buffer = new LinkedList<>();
     protected HashSet<String> in_buffer = new HashSet<>();
 
-    private SpoutOutputCollector _collector;
+    protected SpoutOutputCollector _collector;
 
     /** Required for implementations doing asynchronous calls **/
     protected AtomicBoolean isInQuery = new AtomicBoolean(false);
@@ -136,13 +136,12 @@ public abstract class AbstractQueryingSpout extends BaseRichSpout {
     protected abstract void populateBuffer();
 
     /**
-     * Map to keep in-process URLs, ev. with additional information for URL /
-     * politeness bucket (hostname / domain etc.). The entries are kept in a
-     * cache for a configurable amount of time to avoid that some items are
-     * fetched a second time if new items are queried shortly after they have
-     * been acked.
+     * Map to keep in-process URLs, with the URL as key and optional value
+     * depending on the spout implementation. The entries are kept in a cache
+     * for a configurable amount of time to avoid that some items are fetched a
+     * second time if new items are queried shortly after they have been acked.
      */
-    protected InProcessMap<String, String> beingProcessed;
+    protected InProcessMap<String, Object> beingProcessed;
     private boolean active;
 
     /** Map which holds elements some additional time after the removal. */

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
@@ -177,6 +177,7 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
             try {
                 store(url, status, metadata, nextFetch);
                 ack(tuple, url);
+                return;
             } catch (Exception e) {
                 LOG.error("Exception caught when storing", e);
                 _collector.fail(tuple);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
@@ -175,7 +175,7 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
         if (dateInMetadata != null) {
             Date nextFetch = Date.from(Instant.parse(dateInMetadata));
             try {
-                store(url, status, metadata, nextFetch);
+                store(url, status, mdTransfer.filter(metadata), nextFetch);
                 ack(tuple, url);
                 return;
             } catch (Exception e) {

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
@@ -17,6 +17,7 @@
 package com.digitalpebble.stormcrawler.persistence;
 
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -74,6 +75,14 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
      * latter is the default value.
      **/
     public static String roundDateParamName = "status.updater.unit.round.date";
+
+    /**
+     * Key used to pass a preset Date to use as nextFetchDate. The value must
+     * represent a valid instant in UTC and be parsable using
+     * {@link DateTimeFormatter#ISO_INSTANT}. This also indicates that the
+     * storage can be done directly on the metadata as-is.
+     **/
+    public static final String AS_IS_NEXTFETCHDATE_METADATA = "status.store.as.is.with.nextfetchdate";
 
     protected OutputCollector _collector;
 
@@ -158,6 +167,22 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
         }
 
         Metadata metadata = (Metadata) tuple.getValueByField("metadata");
+
+        // store directly with the date specified in the metadata without
+        // changing the status or scheduling.
+        String dateInMetadata = metadata
+                .getFirstValue(AS_IS_NEXTFETCHDATE_METADATA);
+        if (dateInMetadata != null) {
+            Date nextFetch = Date.from(Instant.parse(dateInMetadata));
+            try {
+                store(url, status, metadata, nextFetch);
+                ack(tuple, url);
+            } catch (Exception e) {
+                LOG.error("Exception caught when storing", e);
+                _collector.fail(tuple);
+                return;
+            }
+        }
 
         // store last processed or discovery date in UTC
         final String nowAsString = Instant.now().toString();

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/DefaultScheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/DefaultScheduler.java
@@ -26,8 +26,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.storm.testing.OpaqueMemoryTransactionalSpout;
-
 import com.digitalpebble.stormcrawler.Constants;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.util.ConfUtils;

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ScrollSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ScrollSpout.java
@@ -111,7 +111,7 @@ public class ScrollSpout extends AbstractSpout implements
         }
 
         SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
-        scrollRequest.scroll(TimeValue.timeValueSeconds(30));
+        scrollRequest.scroll(TimeValue.timeValueMinutes(5L));
 
         isInQuery.set(true);
         client.scrollAsync(scrollRequest, RequestOptions.DEFAULT, this);

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ScrollSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ScrollSpout.java
@@ -61,16 +61,11 @@ public class ScrollSpout extends AbstractSpout implements
     // map of things being processed
     public void nextTuple() {
         synchronized (buffer) {
-            if (!isInQuery.get()) {
-                populateBuffer();
-            }
-
             if (!buffer.isEmpty()) {
                 List<Object> fields = buffer.remove();
                 String url = fields.get(0).toString();
                 _collector.emit(Constants.StatusStreamName, fields, url);
                 beingProcessed.put(url, fields);
-                in_buffer.remove(url);
                 eventCounter.scope("emitted").incrBy(1);
                 LOG.debug("{} emitted {}", logIdprefix, url);
                 return;

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ScrollSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ScrollSpout.java
@@ -51,6 +51,7 @@ public class ScrollSpout extends AbstractSpout implements
         ActionListener<SearchResponse> {
 
     private String scrollId = null;
+    private boolean hasStarted = false;
 
     private static final Logger LOG = LoggerFactory
             .getLogger(ScrollSpout.class);
@@ -86,6 +87,12 @@ public class ScrollSpout extends AbstractSpout implements
     @Override
     protected void populateBuffer() {
         if (scrollId == null) {
+            // scrollID is null because all the documents have been exhausted
+            if (hasStarted) {
+                Utils.sleep(10);
+                return;
+            }
+
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
             searchSourceBuilder.query(QueryBuilders.matchAllQuery());
             searchSourceBuilder.size(maxURLsPerBucket * maxBucketNum);
@@ -119,6 +126,7 @@ public class ScrollSpout extends AbstractSpout implements
         SearchHits hits = response.getHits();
         LOG.info("{} ES query returned {} hits in {} msec", logIdprefix,
                 hits.getHits().length, response.getTook().getMillis());
+        hasStarted = true;
         synchronized (buffer) {
             // Unlike standard spouts, the scroll queries should never return
             // the same

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ScrollSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ScrollSpout.java
@@ -72,6 +72,7 @@ public class ScrollSpout extends AbstractSpout implements
                 beingProcessed.put(url, fields);
                 in_buffer.remove(url);
                 eventCounter.scope("emitted").incrBy(1);
+                LOG.debug("{} emitted {}", logIdprefix, url);
                 return;
             }
         }
@@ -103,6 +104,9 @@ public class ScrollSpout extends AbstractSpout implements
 
             isInQuery.set(true);
             client.searchAsync(searchRequest, RequestOptions.DEFAULT, this);
+
+            // dump query to log
+            LOG.debug("{} ES query {}", logIdprefix, searchRequest.toString());
             return;
         }
 
@@ -111,6 +115,8 @@ public class ScrollSpout extends AbstractSpout implements
 
         isInQuery.set(true);
         client.scrollAsync(scrollRequest, RequestOptions.DEFAULT, this);
+        // dump query to log
+        LOG.debug("{} ES query {}", logIdprefix, scrollRequest.toString());
     }
 
     @Override

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ScrollSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/ScrollSpout.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.elasticsearch.persistence;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.Utils;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.stormcrawler.Constants;
+import com.digitalpebble.stormcrawler.Metadata;
+import com.digitalpebble.stormcrawler.persistence.DefaultScheduler;
+
+/**
+ * Reads all the documents from a shard and emits them on the status stream.
+ * Used for copying an index.
+ **/
+
+public class ScrollSpout extends AbstractSpout implements
+        ActionListener<SearchResponse> {
+
+    private String scrollId = null;
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(ScrollSpout.class);
+
+    @Override
+    // simplified version of the super method so that we can store the fields in
+    // the
+    // map of things being processed
+    public void nextTuple() {
+        synchronized (buffer) {
+            if (!isInQuery.get()) {
+                populateBuffer();
+            }
+
+            if (!buffer.isEmpty()) {
+                List<Object> fields = buffer.remove();
+                String url = fields.get(0).toString();
+                _collector.emit(fields, url);
+                beingProcessed.put(url, fields);
+                in_buffer.remove(url);
+                eventCounter.scope("emitted").incrBy(1);
+                return;
+            }
+        }
+
+        if (isInQuery.get()) {
+            // sleep for a bit but not too much in order to give ack/fail a
+            // chance
+            Utils.sleep(10);
+            return;
+        }
+
+        // re-populate the buffer
+        populateBuffer();
+    }
+
+    @Override
+    protected void populateBuffer() {
+        if (scrollId == null) {
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+            searchSourceBuilder.size(maxURLsPerBucket * maxBucketNum);
+            SearchRequest searchRequest = new SearchRequest(indexName);
+            searchRequest.source(searchSourceBuilder);
+            searchRequest.scroll(TimeValue.timeValueMinutes(5L));
+
+            if (shardID != -1) {
+                searchRequest.preference("_shards:" + shardID);
+            }
+
+            isInQuery.set(true);
+            client.searchAsync(searchRequest, RequestOptions.DEFAULT, this);
+            return;
+        }
+
+        SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
+        scrollRequest.scroll(TimeValue.timeValueSeconds(30));
+
+        isInQuery.set(true);
+        client.scrollAsync(scrollRequest, RequestOptions.DEFAULT, this);
+    }
+
+    @Override
+    public void onResponse(SearchResponse response) {
+        SearchHits hits = response.getHits();
+        LOG.info("{} ES query returned {} hits in {} msec", logIdprefix,
+                hits.getHits().length, response.getTook().getMillis());
+        synchronized (buffer) {
+            // Unlike standard spouts, the scroll queries should never return
+            // the same
+            // document twice -> no need to look in the buffer or cache
+            for (SearchHit hit : hits) {
+                Map<String, Object> keyValues = hit.getSourceAsMap();
+                String url = (String) keyValues.get("url");
+                String status = (String) keyValues.get("status");
+                String nextFetchDate = (String) keyValues.get("nextFetchDate");
+                Metadata metadata = fromKeyValues(keyValues);
+                metadata.setValue(DefaultScheduler.NEXTFETCHDATE_METADATA,
+                        nextFetchDate);
+                buffer.add(new Values(url, metadata, status));
+            }
+        }
+        scrollId = response.getScrollId();
+        // remove lock
+        markQueryReceivedNow();
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+        LOG.error("{} Exception with ES query", logIdprefix, e);
+        markQueryReceivedNow();
+    }
+
+    @Override
+    public void fail(Object msgId) {
+        LOG.info("{}  Fail for {}", logIdprefix, msgId);
+        eventCounter.scope("failed").incrBy(1);
+        // retrieve the values from being processed and send them back to the
+        // queue
+        Values v = (Values) beingProcessed.remove(msgId);
+        buffer.add(v);
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        declarer.declareStream(Constants.StatusStreamName, new Fields("url",
+                "metadata", "status"));
+    }
+
+}


### PR DESCRIPTION
Implements  #688 and fixes #684

This adds a ScrollSpout for ES as well as a mechanism to the AbstractStatusUpdaterBolt so that it stores a tuple without modifying any of its content. 

The following Flux illustrates its use

```
name: "reindexer"

includes:
    - resource: true
      file: "/crawler-default.yaml"
      override: false

    - resource: false
      file: "crawler-conf.yaml"
      override: true

    - resource: false
      file: "es-conf.yaml"
      override: true

config:
  es.status2.addresses: "localhost"
  es.status2.index.name: "status2"
  es.status2.doc.type: "status"
  es.status2.routing: true
  es.status2.routing.fieldname: "key"
  es.status2.bulkActions: 500
  es.status2.flushInterval: "1s"
  es.status2.concurrentRequests: 5
  es.status2.settings:
    cluster.name: "elasticsearch"
  topology.max.spout.pending: 5000
  topology.workers: 1

spouts:
  - id: "spout"
    className: "com.digitalpebble.stormcrawler.elasticsearch.persistence.ScrollSpout"
    parallelism: 10

bolts:
  - id: "status"
    className: "com.digitalpebble.stormcrawler.elasticsearch.persistence.StatusUpdaterBolt"
    parallelism: 4
    constructorArgs:
      - "status2"

streams:
  - from: "spout"
    to: "status"
    grouping:
      streamId: "status"
      type: CUSTOM
      customClass:
        className: "com.digitalpebble.stormcrawler.util.URLStreamGrouping"
        constructorArgs:
          - "byDomain"
```

The target index (here 'status2)' has to be initialised just like the source one. It can of course live on a separate cluster.  

It is a good idea to set `"refresh_interval": "-1"` in the configuration of the target index to speed up the writes. This can be set to any value afterwards when crawling with the new index.

Copying the content of a status index can be useful e.g. when changing the number of shards or the way the documents are assigned to them - for instance if using domains with a different version of crawler-commons, see  #684