### PR TITLE
WARC format improvements

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/ProtocolResponse.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/ProtocolResponse.java
@@ -21,10 +21,36 @@ import com.digitalpebble.stormcrawler.Metadata;
 
 public class ProtocolResponse {
 
-    private final byte[] content;
-    private final int statusCode;
-    private final Metadata metadata;
+    /**
+     * Key which holds the verbatim HTTP request headers in metadata (if
+     * supported by Protocol implementation and if http.store.headers is true).
+     */
+    public final static String REQUEST_HEADERS_KEY = "_request.headers_";
+    /**
+     * Key which holds the verbatim HTTP response headers in metadata.
+     */
+    public final static String RESPONSE_HEADERS_KEY = "_response.headers_";
+    /**
+     * Key which holds the IP address of the server the request was sent to
+     * (response received from) in metadata.
+     */
+    public final static String RESPONSE_IP_KEY = "_response.ip_";
+    /**
+     * Key which holds the request time (begin of request) in metadata.
+     */
+    public final static String REQUEST_TIME_KEY = "_request.time_";
+    /**
+     * Metadata key which holds a boolean value in metadata whether the response
+     * content is trimmed or not.
+     */
+    public static final String TRIMMED_RESPONSE_KEY = "http.trimmed";
+    /**
+     * Metadata key which holds the reason why content has been trimmed, see
+     * {@link TrimmedContentReason}.
+     */
+    public static final String TRIMMED_RESPONSE_REASON_KEY = "http.trimmed.reason";
 
+    /** Enum of reasons which may cause that protocol content is trimmed. */
     public static enum TrimmedContentReason {
         NOT_TRIMMED,
         /** fetch exceeded configured http.content.limit */
@@ -38,6 +64,10 @@ public class ProtocolResponse {
         /** unknown reason */
         UNSPECIFIED
     };
+
+    private final byte[] content;
+    private final int statusCode;
+    private final Metadata metadata;
 
     public ProtocolResponse(byte[] c, int s, Metadata md) {
         content = c;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/ProtocolResponse.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/ProtocolResponse.java
@@ -25,6 +25,20 @@ public class ProtocolResponse {
     private final int statusCode;
     private final Metadata metadata;
 
+    public static enum TrimmedContentReason {
+        NOT_TRIMMED,
+        /** fetch exceeded configured http.content.limit */
+        LENGTH,
+        /** fetch exceeded configured max. time for fetch */
+        TIME,
+        /** network disconnect or timeout during fetch */
+        DISCONNECT,
+        /** implementation internal reason */
+        INTERNAL,
+        /** unknown reason */
+        UNSPECIFIED
+    };
+
     public ProtocolResponse(byte[] c, int s, Metadata md) {
         content = c;
         statusCode = s;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
@@ -283,14 +283,15 @@ public class HttpProtocol extends AbstractHttpProtocol implements
             bytes = HttpProtocol.toByteArray(response.getEntity(), maxContent,
                     trimmed);
             if (trimmed.booleanValue()) {
-                metadata.setValue("http.trimmed", "true");
+                metadata.setValue(ProtocolResponse.TRIMMED_RESPONSE_KEY, "true");
                 LOG.warn("HTTP content trimmed to {}", bytes.length);
             }
         }
 
         if (storeHTTPHeaders) {
             verbatim.append("\r\n");
-            metadata.setValue("_response.headers_", verbatim.toString());
+            metadata.setValue(ProtocolResponse.RESPONSE_HEADERS_KEY,
+                    verbatim.toString());
         }
 
         return new ProtocolResponse(bytes, status, metadata);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -23,8 +23,6 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.security.cert.CertificateException;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.LinkedList;
 import java.util.List;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -18,7 +18,6 @@
 package com.digitalpebble.stormcrawler.protocol.okhttp;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
@@ -38,9 +37,8 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.mutable.MutableBoolean;
+import org.apache.commons.lang.mutable.MutableObject;
 import org.apache.http.cookie.Cookie;
-import org.apache.http.util.ByteArrayBuffer;
 import org.apache.storm.Config;
 import org.slf4j.LoggerFactory;
 
@@ -48,10 +46,12 @@ import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.protocol.AbstractHttpProtocol;
 import com.digitalpebble.stormcrawler.protocol.HttpHeaders;
 import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
+import com.digitalpebble.stormcrawler.protocol.ProtocolResponse.TrimmedContentReason;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 import com.digitalpebble.stormcrawler.util.CookieConverter;
 
 import okhttp3.Call;
+import okhttp3.Connection;
 import okhttp3.Headers;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -61,6 +61,7 @@ import okhttp3.Request.Builder;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okio.BufferedSource;
 
 public class HttpProtocol extends AbstractHttpProtocol {
 
@@ -76,8 +77,12 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
     private int completionTimeout = -1;
 
+    /** Accept partially fetched content as trimmed content */
+    private boolean partialContentAsTrimmed = false;
+
     private final static String VERBATIM_REQUEST_KEY = "_request.headers_";
     private final static String VERBATIM_RESPONSE_KEY = "_response.headers_";
+    private final static String VERBATIM_RESPONSE_IP_KEY = "_response.ip_";
 
     private final List<String[]> customRequestHeaders = new LinkedList<>();
 
@@ -123,6 +128,9 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
         this.completionTimeout = ConfUtils.getInt(conf,
                 "topology.message.timeout.secs", completionTimeout);
+
+        this.partialContentAsTrimmed = ConfUtils.getBoolean(conf,
+                "http.content.partial.as.trimmed", false);
 
         okhttp3.OkHttpClient.Builder builder = new OkHttpClient.Builder()
                 .retryOnConnectionFailure(true).followRedirects(false)
@@ -196,7 +204,6 @@ public class HttpProtocol extends AbstractHttpProtocol {
     @Override
     public ProtocolResponse getProtocolOutput(String url, final Metadata metadata) throws Exception {
         Builder rb = new Request.Builder().url(url);
-
         customRequestHeaders.forEach((k) -> {
             rb.header(k[0], k[1]);
         });
@@ -255,13 +262,15 @@ public class HttpProtocol extends AbstractHttpProtocol {
                 responsemetadata.addValue(key.toLowerCase(Locale.ROOT), value);
             }
 
-            MutableBoolean trimmed = new MutableBoolean();
+            MutableObject trimmed = new MutableObject(TrimmedContentReason.NOT_TRIMMED);
             bytes = toByteArray(response.body(), trimmed);
-            if (trimmed.booleanValue()) {
+            if (trimmed.getValue() != TrimmedContentReason.NOT_TRIMMED) {
                 if (!call.isCanceled()) {
                     call.cancel();
                 }
                 responsemetadata.setValue("http.trimmed", "true");
+                responsemetadata.setValue("http.trimmed.reason",
+                        trimmed.getValue().toString().toLowerCase(Locale.ROOT));
                 LOG.warn("HTTP content trimmed to {}", bytes.length);
             }
 
@@ -270,68 +279,87 @@ public class HttpProtocol extends AbstractHttpProtocol {
     }
 
     private final byte[] toByteArray(final ResponseBody responseBody,
-            MutableBoolean trimmed) throws IOException {
+            MutableObject trimmed) throws IOException {
 
-        if (responseBody == null)
+        if (responseBody == null) {
             return new byte[] {};
+        }
 
-        final InputStream instream = responseBody.byteStream();
-        if (instream == null) {
-            return null;
+        int maxContentBytes = Integer.MAX_VALUE;
+        if (maxContent != -1) {
+            maxContentBytes = Math.min(maxContentBytes, maxContent);
         }
-        if (responseBody.contentLength() > Integer.MAX_VALUE) {
-            throw new IOException(
-                    "Cannot buffer entire body for content length: "
-                            + responseBody.contentLength());
-        }
-        int reportedLength = (int) responseBody.contentLength();
-        // set default size for buffer: 100 KB
-        int bufferInitSize = 102400;
-        if (reportedLength != -1) {
-            bufferInitSize = reportedLength;
-        }
-        // avoid init of too large a buffer when we will trim anyway
-        if (maxContent != -1 && bufferInitSize > maxContent) {
-            bufferInitSize = maxContent;
-        }
+
         long endDueFor = -1;
         if (completionTimeout != -1) {
             endDueFor = System.currentTimeMillis() + (completionTimeout * 1000);
         }
-        final ByteArrayBuffer buffer = new ByteArrayBuffer(bufferInitSize);
-        final byte[] tmp = new byte[4096];
-        int lengthRead;
-        while ((lengthRead = instream.read(tmp)) != -1) {
-            // check whether we need to trim
-            if (maxContent != -1 && buffer.length() + lengthRead > maxContent) {
-                buffer.append(tmp, 0, maxContent - buffer.length());
-                trimmed.setValue(true);
+
+        BufferedSource source = responseBody.source();
+        int bytesRequested = 0;
+        int bufferGrowStepBytes = 8192;
+
+        while (source.buffer().size() < maxContentBytes) {
+            bytesRequested += Math.min(bufferGrowStepBytes,
+                    (maxContentBytes - bytesRequested));
+            boolean success = false;
+            try {
+                success = source.request(bytesRequested);
+            } catch (IOException e) {
+                // requesting more content failed, e.g. by a socket timeout
+                if (partialContentAsTrimmed && source.buffer().size() > 0) {
+                    // treat already fetched content as trimmed
+                    trimmed.setValue(TrimmedContentReason.DISCONNECT);
+                    LOG.debug("Exception while fetching {}", e);
+                } else {
+                    throw e;
+                }
+            }
+            if (!success) {
+                // source exhausted, no more data to read
                 break;
             }
-            buffer.append(tmp, 0, lengthRead);
-            // check whether we hit the completion timeout
+
             if (endDueFor != -1 && endDueFor <= System.currentTimeMillis()) {
-                trimmed.setValue(true);
+                // check whether we hit the completion timeout
+                trimmed.setValue(TrimmedContentReason.TIME);
                 break;
             }
+
+            // okhttp may fetch more content than requested, quickly "increment"
+            // bytes
+            bytesRequested = (int) source.buffer().size();
         }
-        return buffer.toByteArray();
+        int bytesBuffered = (int) source.buffer().size();
+        int bytesToCopy = bytesBuffered;
+        if (maxContent != -1 && bytesToCopy > maxContent) {
+            // okhttp's internal buffer is larger than maxContent
+            trimmed.setValue(TrimmedContentReason.LENGTH);
+            bytesToCopy = maxContentBytes;
+        }
+        byte[] arr = new byte[bytesToCopy];
+        source.buffer().readFully(arr);
+        return arr;
     }
 
     class HTTPHeadersInterceptor implements Interceptor {
 
         @Override
         public Response intercept(Interceptor.Chain chain) throws IOException {
+
+            Connection connection = chain.connection();
+            String ipAddress = connection.socket().getInetAddress()
+                    .getHostAddress();
             Request request = chain.request();
 
-            StringBuilder resquestverbatim = new StringBuilder();
+            StringBuilder requestverbatim = new StringBuilder();
 
             int position = request.url().toString()
                     .indexOf(request.url().host());
             String u = request.url().toString()
                     .substring(position + request.url().host().length());
 
-            resquestverbatim.append(request.method()).append(" ").append(u)
+            requestverbatim.append(request.method()).append(" ").append(u)
                     .append(" ").append("\r\n");
 
             Headers headers = request.headers();
@@ -339,11 +367,11 @@ public class HttpProtocol extends AbstractHttpProtocol {
             for (int i = 0, size = headers.size(); i < size; i++) {
                 String key = headers.name(i);
                 String value = headers.value(i);
-                resquestverbatim.append(key).append(": ").append(value)
+                requestverbatim.append(key).append(": ").append(value)
                         .append("\r\n");
             }
 
-            resquestverbatim.append("\r\n");
+            requestverbatim.append("\r\n");
 
             Response response = chain.proceed(request);
 
@@ -370,7 +398,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
                     responseverbatim.toString().getBytes());
 
             byte[] encodedBytesRequest = Base64.getEncoder().encode(
-                    resquestverbatim.toString().getBytes());
+                    requestverbatim.toString().getBytes());
 
             // returns a modified version of the response
             return response
@@ -378,7 +406,9 @@ public class HttpProtocol extends AbstractHttpProtocol {
                     .header(VERBATIM_REQUEST_KEY,
                             new String(encodedBytesRequest))
                     .header(VERBATIM_RESPONSE_KEY,
-                            new String(encodedBytesResponse)).build();
+                            new String(encodedBytesResponse))
+                    .header(VERBATIM_RESPONSE_IP_KEY,
+                            ipAddress).build();
         }
     }
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -23,6 +23,11 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.security.cert.CertificateException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.LinkedList;
 import java.util.List;
@@ -83,6 +88,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
     private final static String VERBATIM_REQUEST_KEY = "_request.headers_";
     private final static String VERBATIM_RESPONSE_KEY = "_response.headers_";
     private final static String VERBATIM_RESPONSE_IP_KEY = "_response.ip_";
+    private final static String VERBATIM_REQUEST_TIME_KEY = "_request.time_";
 
     private final List<String[]> customRequestHeaders = new LinkedList<>();
 
@@ -344,8 +350,14 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
     class HTTPHeadersInterceptor implements Interceptor {
 
+        final ZoneId TIME_ZONE_UTC = ZoneId.of(ZoneOffset.UTC.toString());
+
         @Override
         public Response intercept(Interceptor.Chain chain) throws IOException {
+
+            String startFetchTime = DateTimeFormatter.ISO_INSTANT
+                    .format(ZonedDateTime.ofInstant(Instant.now(),
+                            TIME_ZONE_UTC));
 
             Connection connection = chain.connection();
             String ipAddress = connection.socket().getInetAddress()
@@ -407,8 +419,8 @@ public class HttpProtocol extends AbstractHttpProtocol {
                             new String(encodedBytesRequest))
                     .header(VERBATIM_RESPONSE_KEY,
                             new String(encodedBytesResponse))
-                    .header(VERBATIM_RESPONSE_IP_KEY,
-                            ipAddress).build();
+                    .header(VERBATIM_RESPONSE_IP_KEY, ipAddress)
+                    .header(VERBATIM_REQUEST_TIME_KEY, startFetchTime).build();
         }
     }
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -345,8 +345,6 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
     class HTTPHeadersInterceptor implements Interceptor {
 
-        final ZoneId TIME_ZONE_UTC = ZoneId.of(ZoneOffset.UTC.toString());
-
         @Override
         public Response intercept(Interceptor.Chain chain) throws IOException {
 

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -74,6 +74,10 @@ config:
   http.store.headers: false
   http.timeout: 10000
 
+  # store partial fetches as trimmed content (some content has been fetched,
+  # but reading more data from socket failed, eg. because of a network timeout)
+  http.content.partial.as.trimmed: false
+
   # for crawling through a proxy:
   # http.proxy.host:
   # http.proxy.port:

--- a/external/warc/README.md
+++ b/external/warc/README.md
@@ -19,12 +19,17 @@ Include the following snippet in your crawl topology
                 .withPath(warcFilePath);
 
         Map<String,String> fields = new HashMap<>();
-        fields.put("software:", "StormCrawler 1.0 http://stormcrawler.net/");
-        fields.put("conformsTo:", "http://www.archive.org/documents/WarcFileFormat-1.0.html");
+        fields.put("software:", "StormCrawler 1.14 http://stormcrawler.net/");
+        fields.put("format", "WARC File Format 1.0");
+        fields.put("conformsTo:",
+                "https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.0/");
         
         WARCHdfsBolt warcbolt = (WARCHdfsBolt) new WARCHdfsBolt()
                 .withFileNameFormat(fileNameFormat);
         warcbolt.withHeader(fields);
+
+        // enable WARC request records
+        warcbolt.withRequestRecords();
 
         // can specify the filesystem - will use the local FS by default
         String fsURL = "hdfs://localhost:9000";
@@ -47,17 +52,36 @@ components:
     configMethods:
       - name: "withPath"
         args:
-          - "/warc"
+          - "/path/to/warc"
+      - name: "withPrefix"
+        args:
+          - "my-warc-prefix"
 
-  - id: "rotationPolicy"
+  - id: "WARCFileRotationPolicy"
     className: "org.apache.storm.hdfs.bolt.rotation.FileSizeRotationPolicy"
     constructorArgs:
       - 50.0
       - MB
 
+  - id: "WARCInfo"
+    className: "java.util.LinkedHashMap"
+    configMethods:
+      - name: "put"
+        args:
+         - "software"
+         - "StormCrawler 1.14 http://stormcrawler.net/"
+      - name: "put"
+        args:
+         - "format"
+         - "WARC File Format 1.0"
+      - name: "put"
+        args:
+         - "conformsTo"
+         - "https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.0/"
+
 [...]
 
- bolts:
+bolts:
  - id: "warc"
     className: "com.digitalpebble.stormcrawler.warc.WARCHdfsBolt"
     parallelism: 1
@@ -67,8 +91,11 @@ components:
           - ref: "WARCFileNameFormat"
       - name: "withRotationPolicy"
         args:
-          - ref: "rotationPolicy"
-
+          - ref: "WARCFileRotationPolicy"
+      - name: "withRequestRecords"
+      - name: "withHeader"
+        args:
+          - ref: "WARCInfo"
 ```
 
 Each instance of the bolt will generate a WARC file and close it once it has reached the required size.
@@ -84,9 +111,33 @@ With the local file system, you need to specify
 ```
   warcbolt.withConfigKey("warc");
   Map<String, Object> hdfsConf = new HashMap<>();
-        hdfsConf.put("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
-        getConf().put("warc", hdfsConf);
- ```
-        
+  hdfsConf.put("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
+  getConf().put("warc", hdfsConf);
+```
+
 This uses the RawLocalFileSystem, which unlike the checksum one used by default does a proper sync of the content to the file.
 
+Using Flux the RawLocalFileSystem is enabled by adding the following statements to `config` and the `warc` bolt:
+
+```
+config:
+  warc: {"fs.file.impl": "org.apache.hadoop.fs.RawLocalFileSystem"}
+
+bolts:
+ - id: "warc"
+    ...
+    configMethods:
+      ...
+      - name: "withConfigKey"
+        args:
+          - "warc"
+```
+
+Writing complete and valid WARC requires that HTTP headers, IP address and capture time are stored by the HTTP protocol implementation in the metadata. Only the okhttp protocol package stores all necessary information. To enable the okhttp protocol implementation and let them save the HTTP headers, you need to add to your configuration:
+
+```
+  http.store.headers: true
+
+  http.protocol.implementation: com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol
+  https.protocol.implementation: com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol
+```

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
@@ -1,7 +1,7 @@
 package com.digitalpebble.stormcrawler.warc;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,7 +45,7 @@ public class WARCHdfsBolt extends GzipHdfsBolt {
             throws IOException {
         AbstractHDFSWriter writer = super.makeNewWriter(path, tuple);
 
-        Date now = new Date();
+        Instant now = Instant.now();
 
         // overrides the filename and creation date in the headers
         header_fields.put("WARC-Date", WARCRecordFormat.WARC_DF.format(now));

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
@@ -35,6 +35,11 @@ public class WARCHdfsBolt extends GzipHdfsBolt {
         return this;
     }
 
+    public WARCHdfsBolt withRequestRecords() {
+        this.addRecordFormat(new WARCRequestRecordFormat(), 0);
+        return this;
+    }
+
     @Override
     protected AbstractHDFSWriter makeNewWriter(Path path, Tuple tuple)
             throws IOException {

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
@@ -149,9 +149,13 @@ public class WARCRecordFormat implements RecordFormat {
         buffer.append("Content-Length").append(": ")
                 .append(Integer.toString(contentLength)).append(CRLF);
 
-        // TODO get actual fetch time from metadata if any
-        Date now = new Date();
-        buffer.append("WARC-Date").append(": ").append(WARC_DF.format(now))
+        // get actual fetch time from metadata if any
+        String captureTime = metadata.getFirstValue("_request.time_");
+        if (captureTime == null) {
+            Date now = new Date();
+            captureTime = WARC_DF.format(now);
+        }
+        buffer.append("WARC-Date").append(": ").append(captureTime)
                 .append(CRLF);
 
         // check if http headers have been stored verbatim
@@ -166,9 +170,9 @@ public class WARCRecordFormat implements RecordFormat {
                 .append(CRLF);
 
         // "WARC-IP-Address" if present
-        String IP = metadata.getFirstValue("_ip_");
+        String IP = metadata.getFirstValue("_response.ip_");
         if (StringUtils.isNotBlank(IP)) {
-            buffer.append("WARC-IP-Address").append(": ").append("IP")
+            buffer.append("WARC-IP-Address").append(": ").append(IP)
                     .append(CRLF);
         }
 

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
@@ -27,9 +27,9 @@ import com.digitalpebble.stormcrawler.protocol.HttpHeaders;
 @SuppressWarnings("serial")
 public class WARCRecordFormat implements RecordFormat {
 
-    private static final String WARC_VERSION = "WARC/1.0";
-    private static final String CRLF = "\r\n";
-    private static final byte[] CRLF_BYTES = { 13, 10 };
+    protected static final String WARC_VERSION = "WARC/1.0";
+    protected static final String CRLF = "\r\n";
+    protected static final byte[] CRLF_BYTES = { 13, 10 };
 
     private static final Logger LOG = LoggerFactory
             .getLogger(WARCRecordFormat.class);
@@ -131,6 +131,14 @@ public class WARCRecordFormat implements RecordFormat {
 
         buffer.append("WARC-Record-ID").append(": ").append("<urn:uuid:")
                 .append(mainID).append(">").append(CRLF);
+
+        String warcRequestId = metadata
+                .getFirstValue("_request.warc_record_id_");
+        if (warcRequestId != null) {
+            buffer.append("WARC-Concurrent-To").append(": ")
+                    .append("<urn:uuid:").append(warcRequestId).append(">")
+                    .append(CRLF);
+        }
 
         int contentLength = 0;
         String payloadDigest = digestNoContent;

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
@@ -117,8 +117,8 @@ public class WARCRecordFormat implements RecordFormat {
         byte[] httpheaders = new byte[0];
         if (StringUtils.isNotBlank(headersVerbatim)) {
             // check that ends with an empty line
-            if (!headersVerbatim.endsWith(CRLF + CRLF)) {
-                headersVerbatim += CRLF + CRLF;
+            while (!headersVerbatim.endsWith(CRLF + CRLF)) {
+                headersVerbatim += CRLF;
             }
             httpheaders = headersVerbatim.getBytes();
         }

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.protocol.HttpHeaders;
+import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
 
 /** Generate a byte representation of a WARC entry from a tuple **/
 @SuppressWarnings("serial")
@@ -317,6 +318,18 @@ public class WARCRecordFormat implements RecordFormat {
                 ct = "application/octet-stream";
             }
             buffer.append("Content-Type: ").append(ct).append(CRLF);
+        }
+
+        String truncated = metadata.getFirstValue("http.trimmed");
+        if (truncated != null) {
+            // content is truncated
+            truncated = metadata.getFirstValue("http.trimmed.reason");
+            if (truncated == null) {
+                truncated = ProtocolResponse.TrimmedContentReason.UNSPECIFIED
+                        .toString().toLowerCase(Locale.ROOT);
+            }
+            buffer.append("WARC-Truncated").append(": ").append(truncated)
+                    .append(CRLF);
         }
 
         buffer.append("WARC-Payload-Digest").append(": ").append(payloadDigest)

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
@@ -37,7 +37,7 @@ public class WARCRequestRecordFormat extends WARCRecordFormat {
             LOG.warn("No request header for {}", url);
             return new byte[] {};
         } else {
-            // check that ends with an empty line
+            // check that header ends with an empty line
             while (!headersVerbatim.endsWith(CRLF + CRLF)) {
                 headersVerbatim += CRLF;
             }

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
@@ -1,0 +1,106 @@
+package com.digitalpebble.stormcrawler.warc;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.stormcrawler.Metadata;
+
+/**
+ * Generate a byte representation of a WARC request record from a tuple if the
+ * request HTTP headers are present. The request record ID is stored in the
+ * metadata so that a WARC response record (created later) can refer to it.
+ **/
+@SuppressWarnings("serial")
+public class WARCRequestRecordFormat extends WARCRecordFormat {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(WARCRequestRecordFormat.class);
+
+    @Override
+    public byte[] format(Tuple tuple) {
+
+        String url = tuple.getStringByField("url");
+        Metadata metadata = (Metadata) tuple.getValueByField("metadata");
+
+        String headersVerbatim = metadata.getFirstValue("_request.headers_");
+        byte[] httpheaders = new byte[0];
+        if (StringUtils.isBlank(headersVerbatim)) {
+            // no request header: return empty record
+            LOG.warn("No request header for {}", url);
+            return new byte[] {};
+        } else {
+            // check that ends with an empty line
+            if (!headersVerbatim.endsWith(CRLF + CRLF)) {
+                headersVerbatim += CRLF + CRLF;
+            }
+            httpheaders = headersVerbatim.getBytes();
+        }
+
+        StringBuilder buffer = new StringBuilder();
+        buffer.append(WARC_VERSION);
+        buffer.append(CRLF);
+        buffer.append("WARC-Type").append(": ").append("request").append(CRLF);
+
+        String mainID = UUID.randomUUID().toString();
+        buffer.append("WARC-Record-ID").append(": ").append("<urn:uuid:")
+                .append(mainID).append(">").append(CRLF);
+        /*
+         * The request record ID is stored in the metadata so that a WARC
+         * response record can later refer to it.
+         */
+        metadata.addValue("_request.warc_record_id_", mainID);
+
+        int contentLength = httpheaders.length;
+        buffer.append("Content-Length").append(": ")
+                .append(Integer.toString(contentLength)).append(CRLF);
+
+        String blockDigest = getDigestSha1(httpheaders);
+
+        // get actual fetch time from metadata if any
+        String captureTime = metadata.getFirstValue("_request.time_");
+        if (captureTime == null) {
+            Date now = new Date();
+            captureTime = WARC_DF.format(now);
+        }
+        buffer.append("WARC-Date").append(": ").append(captureTime)
+                .append(CRLF);
+
+        // must be a valid URI
+        try {
+            String normalised = url.replaceAll(" ", "%20");
+            String targetURI = URI.create(normalised).toASCIIString();
+            buffer.append("WARC-Target-URI").append(": ").append(targetURI)
+                    .append(CRLF);
+        } catch (Exception e) {
+            LOG.warn("Incorrect URI: {}", url);
+            return new byte[] {};
+        }
+
+        buffer.append("Content-Type: application/http; msgtype=request")
+                .append(CRLF);
+        buffer.append("WARC-Block-Digest").append(": ").append(blockDigest)
+                .append(CRLF);
+
+        byte[] buffasbytes = buffer.toString().getBytes(StandardCharsets.UTF_8);
+
+        int capacity = 6 + buffasbytes.length + httpheaders.length;
+
+        ByteBuffer bytebuffer = ByteBuffer.allocate(capacity);
+        bytebuffer.put(buffasbytes);
+        bytebuffer.put(CRLF_BYTES);
+        bytebuffer.put(httpheaders);
+        bytebuffer.put(CRLF_BYTES);
+        bytebuffer.put(CRLF_BYTES);
+
+        return bytebuffer.array();
+    }
+
+}

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
@@ -38,8 +38,8 @@ public class WARCRequestRecordFormat extends WARCRecordFormat {
             return new byte[] {};
         } else {
             // check that ends with an empty line
-            if (!headersVerbatim.endsWith(CRLF + CRLF)) {
-                headersVerbatim += CRLF + CRLF;
+            while (!headersVerbatim.endsWith(CRLF + CRLF)) {
+                headersVerbatim += CRLF;
             }
             httpheaders = headersVerbatim.getBytes();
         }

--- a/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormatTest.java
+++ b/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormatTest.java
@@ -57,7 +57,7 @@ public class WARCRecordFormatTest {
         String sha1str = "sha1:D6FMCDZDYW23YELHXWUEXAZ6LQCXU56S";
         Metadata metadata = new Metadata();
         metadata.addValue("_response.headers_",
-                "HTTP/1.1 200 OK\r\nContent-Type: text/html");
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n");
         Tuple tuple = mock(Tuple.class);
         when(tuple.getBinaryByField("content")).thenReturn(content);
         when(tuple.getStringByField("url")).thenReturn(
@@ -77,6 +77,8 @@ public class WARCRecordFormatTest {
                 warcString.startsWith("WARC/1.0"));
         assertTrue("WARC record: incorrect format of HTTP header",
                 warcString.contains("\r\n\r\nHTTP/1.1 200 OK\r\n"));
+        assertTrue("WARC record: single new line between HTTP header and payload",
+                warcString.contains("Content-Type: text/html\r\n\r\nabcdef"));
         assertTrue("WARC record: record is required to end with \\r\\n\\r\\n",
                 warcString.endsWith("\r\n\r\n"));
         assertTrue("WARC record: payload mangled",

--- a/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormatTest.java
+++ b/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormatTest.java
@@ -1,6 +1,7 @@
 package com.digitalpebble.stormcrawler.warc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -77,7 +78,8 @@ public class WARCRecordFormatTest {
                 warcString.startsWith("WARC/1.0"));
         assertTrue("WARC record: incorrect format of HTTP header",
                 warcString.contains("\r\n\r\nHTTP/1.1 200 OK\r\n"));
-        assertTrue("WARC record: single new line between HTTP header and payload",
+        assertTrue(
+                "WARC record: single empty line between HTTP header and payload",
                 warcString.contains("Content-Type: text/html\r\n\r\nabcdef"));
         assertTrue("WARC record: record is required to end with \\r\\n\\r\\n",
                 warcString.endsWith("\r\n\r\n"));
@@ -87,6 +89,41 @@ public class WARCRecordFormatTest {
                 "WARC record: no or incorrect payload digest",
                 warcString.contains("\r\nWARC-Payload-Digest: " + sha1str
                         + "\r\n"));
+    }
+
+    @Test
+    public void testReplaceHeaders() {
+        // test whether wrong/misleading HTTP headers are replaced
+        // because payload is not saved in original Content-Encoding and
+        // Transfer-Encoding
+        String txt = "abcdef";
+        byte[] content = txt.getBytes(StandardCharsets.UTF_8);
+        String sha1str = "sha1:D6FMCDZDYW23YELHXWUEXAZ6LQCXU56S";
+        Metadata metadata = new Metadata();
+        metadata.addValue("_response.headers_", //
+                "HTTP/1.1 200 OK\r\n" //
+                        + "Content-Type: text/html\r\n" //
+                        + "Content-Encoding: gzip\r\n" //
+                        + "Content-Length: 26\r\n" //
+                        + "Connection: close");
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getBinaryByField("content")).thenReturn(content);
+        when(tuple.getStringByField("url")).thenReturn(
+                "https://www.example.org/");
+        when(tuple.getValueByField("metadata")).thenReturn(metadata);
+        WARCRecordFormat format = new WARCRecordFormat();
+        byte[] warcBytes = format.format(tuple);
+        String warcString = new String(warcBytes, StandardCharsets.UTF_8);
+        assertFalse("WARC record: HTTP header Content-Encoding not replaced",
+                warcString.contains("\r\nContent-Encoding: gzip\r\n"));
+        assertFalse("WARC record: HTTP header Content-Length not replaced",
+                warcString.contains("\r\nContent-Length: 26\r\n"));
+        // the correct Content-Length is 6 (txt = "abcdef")
+        assertTrue(
+                "WARC record: HTTP header Content-Length does not match payload length",
+                warcString.contains("\r\nContent-Length: 6\r\n"));
+        assertTrue("WARC record: HTTP header does not end with \\r\\n\\r\\n",
+                warcString.contains("\r\nConnection: close\r\n\r\nabcdef"));
     }
 
 }


### PR DESCRIPTION
This PR combines a list of improvements to the WARC writer bolt and record formats but also to the okhttp-based protocol implementation:
- generate WARC request records (#509) by calling `withRequestRecords()` on an existing WARCHdfsBolt.
- use capture time (when fetching began) for WARC-Date not the time the WARC record is written. This also ensures that response and request record have the same `WARC-Date`
- add field `WARC-IP-Address (address commoncrawl/news-crawl#29)
- ports back a couple of improvements from Nutch's protocol-okhttp:
  - use okhttp's internal byte buffer, do not buffer content twice
  - optionally keep partially fetched content (e.g., if a single read fails with a socket timeout) if `http.content.partial.as.trimmed` is true
- track reason for trimmed content (content or time limit, read or connection failure) and add it as `WARC-Truncated` field (address commoncrawl/news-crawl#31)
-  mask HTTP headers (Content-Length, Content-Encoding and Transfer-Encoding) which may cause errors when processing WARC records because the content is stored uncompressed and unchunked and may be of different length than originally received. The prefix to mask the original headers is `X-Crawler`. Address commoncrawl/news-crawl#30.

I can split the PR into multiple one if required.

The result WARC files have been checked and validated using warcio's new check utility (webrecorder/warcio#68). An example request/response record pair with all changes applied:
```
WARC/1.0
WARC-Type: request
WARC-Record-ID: <urn:uuid:8dfc0435-7417-4b4c-8189-705d766a3b16>
Content-Length: 377
WARC-Date: 2019-03-13T13:56:00.953Z
WARC-Target-URI: https://www.theguardian.com/politics/2019/mar/13/theresa-may-confirms-she-will-vote-to-block-no-deal-brexit-pmqs-jeremy-corbyn
Content-Type: application/http; msgtype=request
WARC-Block-Digest: sha1:KVPT2QYXP5FMSI542GRPAG4VXOUVCNRC

GET /politics/2019/mar/13/theresa-may-confirms-she-will-vote-to-block-no-deal-brexit-pmqs-jeremy-corbyn 
User-Agent: CCBot/3.0 (http://commoncrawl.org/faq/; info@commoncrawl.org)
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en-gb,en;q=0.7,*;q=0.3
Host: www.theguardian.com
Connection: Keep-Alive
Accept-Encoding: gzip



WARC/1.0
WARC-Record-ID: <urn:uuid:203780a2-dcb8-49a7-973e-1d88b125f587>
WARC-Concurrent-To: <urn:uuid:8dfc0435-7417-4b4c-8189-705d766a3b16>
Content-Length: 1041736
WARC-Date: 2019-03-13T13:56:00.953Z
WARC-Type: response
WARC-IP-Address: 151.101.113.111
WARC-Target-URI: https://www.theguardian.com/politics/2019/mar/13/theresa-may-confirms-she-will-vote-to-block-no-deal-brexit-pmqs-jeremy-corbyn
Content-Type: application/http; msgtype=response
WARC-Payload-Digest: sha1:YWXUX773QVKHQPO4MQXAFFBOH7IIYIA4
WARC-Block-Digest: sha1:DY6IIMGARYQGPERMPEUT6RUB3VZRQF76

HTTP/1.1 200 OK
X-Crawler-Content-Encoding: gzip
Content-Type: text/html; charset=utf-8
ETag: W/"hash-826299181980705017"
Link: <https://assets.guim.co.uk/stylesheets/ed6dfcab2e0ddab1c51867a93921f6ca/content.garnett.css>; rel=preload; as=style; nopush,<https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill>; rel=preload; as=script; nopush,<https://assets.guim.co.uk/javascripts/ff1648a1c5e6beec11e0/graun.standard.js>; rel=preload; as=script; nopush,<https://assets.guim.co.uk/javascripts/9a2a60d293fd119118cf/graun.commercial.js>; rel=preload; as=script; nopush
X-Crawler-Content-Length: 164346
Content-Length: 1040002
Accept-Ranges: bytes
Date: Wed, 13 Mar 2019 13:56:00 GMT
Age: 36
Connection: keep-alive
Set-Cookie: GU_mvt_id=186384; expires=Tue, 11 Jun 2019 13:56:00 GMT; path=/; domain=.theguardian.com; Secure
X-Timer: S1552485361.961381,VS0,VE0
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Security-Policy: default-src https:; script-src https: 'unsafe-inline' 'unsafe-eval'; style-src https: 'unsafe-inline'; img-src https: data: blob:; media-src https: data: blob:; font-src https: data:; connect-src https: wss:
Referrer-Policy: no-referrer-when-downgrade
Feature-Policy: camera 'none'; microphone 'none'; midi 'none'
X-GU-Edition: int
Cache-Control: max-age=60, stale-while-revalidate=6, stale-if-error=864000, private
Vary: Accept-Encoding,User-Agent
Set-Cookie: GU_geo_continent=EU; path=/; Secure


<!DOCTYPE html>
<html id="js-context" class="js-off is-not-modern id--signed-out" lang="en" data-page-path="/politics/2019/mar/13/theresa-may-confirms-she-will-vote-to-block-no-deal-brexit-pmqs-jeremy-corbyn">
<head>
<!--
     __        __                      _     _      _
     \ \      / /__    __ _ _ __ ___  | |__ (_)_ __(_)_ __   __ _
      \ \ /\ / / _ \  / _` | '__/ _ \ | '_ \| | '__| | '_ \ / _` |
       \ V  V /  __/ | (_| | | |  __/ | | | | | |  | | | | | (_| |
        \_/\_/ \___|  \__,_|_|  \___| |_| |_|_|_|  |_|_| |_|\__, |
                                                            |___/
    Ever thought about joining us?
    https://workforus.theguardian.com/careers/digital-development/
     --->
<title>Theresa May confirms she will vote to block no-deal Brexit | Politics | The Guardian</title>
<meta charset="utf-8">
```