### PR TITLE
ESSeedInjector: filter bolt to subscribe to spout's status stream, fixes #715

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/URLFilterBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/URLFilterBolt.java
@@ -27,12 +27,16 @@ import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.filtering.URLFilters;
 import com.digitalpebble.stormcrawler.persistence.Status;
 
 public class URLFilterBolt extends BaseRichBolt {
+
+    public static final Logger LOG = LoggerFactory.getLogger(URLFilterBolt.class);
 
     private URLFilters urlFilters;
 
@@ -52,7 +56,7 @@ public class URLFilterBolt extends BaseRichBolt {
 
         String filtered = urlFilters.filter(null, null, urlString);
         if (StringUtils.isBlank(filtered)) {
-            // LOG? Add counter?
+            LOG.debug("URL rejected: {}", urlString);
             collector.ack(input);
             return;
         }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/spout/FileSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/spout/FileSpout.java
@@ -102,6 +102,7 @@ public class FileSpout extends BaseRichSpout {
         this.withDiscoveredStatus = withDiscoveredStatus;
         Path pdir = Paths.get(dir);
         _inputFiles = new LinkedList<>();
+        LOG.info("Reading directory: {} (filter: {})", pdir, filter);
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(pdir,
                 filter)) {
             for (Path entry : stream) {

--- a/external/elasticsearch/es-injector.flux
+++ b/external/elasticsearch/es-injector.flux
@@ -23,11 +23,23 @@ spouts:
       - true
 
 bolts:
+# comment in to filter injected URLs
+#  - id: "filter"
+#    className: "com.digitalpebble.stormcrawler.bolt.URLFilterBolt"
+#    parallelism: 1
   - id: "status"
     className: "com.digitalpebble.stormcrawler.elasticsearch.persistence.StatusUpdaterBolt"
     parallelism: 1
 
 streams:
+# to filter injected URLs: comment in and connect "filter" and "status" bolts
+#  - from: "spout"
+#    to: "filter"
+#    grouping:
+#      type: FIELDS
+#      args: ["url"]
+#      streamId: "status"
+#  - from: "filter"
   - from: "spout"
     to: "status"
     grouping:

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/ESSeedInjector.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/ESSeedInjector.java
@@ -57,7 +57,7 @@ public class ESSeedInjector extends ConfigurableTopology {
         Fields key = new Fields("url");
 
         builder.setBolt("filter", new URLFilterBolt()).fieldsGrouping("spout",
-                key);
+                Constants.StatusStreamName, key);
 
         // example of using the custom URLStreamGrouping
         builder.setBolt("enqueue", new StatusUpdaterBolt(), 10).customGrouping(


### PR DESCRIPTION
- ESSeedInjector: explicitly set name of stream for source of URL filter bolt
- more verbose logging in FileSpout and URLFilterBolt - for easier debugging to exclude trivial reasons such as URLs have been filtered due to misconfigured filters
- add optional URL filter bolt config to es-injector.flux
