### PR TITLE
NPE in WARCHdfsBolt on cleanup(), fixes #720

### DIFF
--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/GzipHdfsBolt.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/GzipHdfsBolt.java
@@ -183,6 +183,10 @@ public class GzipHdfsBolt extends AbstractHdfsBolt {
     @Override
     public void cleanup() {
         LOG.info("Cleanup called on bolt");
+        if (this.out == null) {
+            LOG.warn("Nothing to cleanup: output stream not initialized");
+            return;
+        }
         try {
             this.out.flush();
             this.out.close();


### PR DESCRIPTION
Check whether output stream is not null before flushing and closing.