### PR TITLE
Force English Locale for SimpleDateFormat in coockie converter.

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/CookieConverter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/CookieConverter.java
@@ -23,6 +23,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
+
 import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.cookie.BasicClientCookie;
 
@@ -33,7 +35,7 @@ import org.apache.http.impl.cookie.BasicClientCookie;
 public class CookieConverter {
 
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(
-            "EEE, dd MMM yyyy HH:mm:ss zzz");
+            "EEE, dd MMM yyyy HH:mm:ss zzz",Locale.ENGLISH);
 
     /**
      * Get a list of cookies based on the cookies string taken from response


### PR DESCRIPTION
The coockie parser test will fail on german pc bacause the SimpleDateFormatter will use german day names at the expire check in CookieConverter

