### PR TITLE
Pluggable URLBuffer and hybrid Elasticsearch spout

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/FetcherBolt.java
@@ -421,7 +421,7 @@ public class FetcherBolt extends StatusEmitterBolt {
             while (true) {
                 FetchItem fit = fetchQueues.getFetchItem();
                 if (fit == null) {
-                    LOG.debug("{} spin-waiting ...", getName());
+                    LOG.trace("{} spin-waiting ...", getName());
                     // spin-wait.
                     spinWaiting.incrementAndGet();
                     try {

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
@@ -182,7 +182,7 @@ public abstract class AbstractQueryingSpout extends BaseRichSpout {
             timeLastQuerySent = System.currentTimeMillis();
         }
 
-        if (!buffer.hasNext()) {
+        if (buffer.hasNext()) {
             // track how long the buffer had been empty for
             if (timestampEmptyBuffer != -1) {
                 eventCounter.scope("empty.buffer").incrBy(

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
@@ -114,6 +114,8 @@ public abstract class AbstractQueryingSpout extends BaseRichSpout {
         buffer = new URLBuffer();
         
         context.registerMetric("buffer_size", () -> buffer.size(), 10);
+        context.registerMetric("numQueues", () -> buffer.numQueues(), 10);
+
         context.registerMetric("beingProcessed", () -> beingProcessed.size(), 10);
         context.registerMetric("inPurgatory", () -> beingProcessed.inCache(), 10);
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
@@ -19,11 +19,8 @@ package com.digitalpebble.stormcrawler.persistence;
 
 import java.time.Instant;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -33,7 +30,6 @@ import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.base.BaseRichSpout;
 import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Values;
 import org.apache.storm.utils.Utils;
 
 import com.digitalpebble.stormcrawler.util.CollectionMetric;
@@ -180,32 +176,27 @@ public abstract class AbstractQueryingSpout extends BaseRichSpout {
         if (!active)
             return;
 
-        // synchronize access to buffer needed in case of asynchronous
-        // queries to the backend
-        synchronized (buffer) {
+        // force the refresh of the buffer even if the buffer is not empty
+        if (!isInQuery.get() && triggerQueries()) {
+            populateBuffer();
+            timeLastQuerySent = System.currentTimeMillis();
+        }
 
-            // force the refresh of the buffer even if the buffer is not empty
-            if (!isInQuery.get() && triggerQueries()) {
-                populateBuffer();
-                timeLastQuerySent = System.currentTimeMillis();
+        if (!buffer.hasNext()) {
+            // track how long the buffer had been empty for
+            if (timestampEmptyBuffer != -1) {
+                eventCounter.scope("empty.buffer").incrBy(
+                        System.currentTimeMillis() - timestampEmptyBuffer);
+                timestampEmptyBuffer = -1;
             }
-
-            if (!buffer.hasNext()) {
-                // track how long the buffer had been empty for
-                if (timestampEmptyBuffer != -1) {
-                    eventCounter.scope("empty.buffer").incrBy(
-                            System.currentTimeMillis() - timestampEmptyBuffer);
-                    timestampEmptyBuffer = -1;
-                }
-                List<Object> fields = buffer.next();
-                String url = fields.get(0).toString();
-                this._collector.emit(fields, url);
-                beingProcessed.put(url, null);
-                eventCounter.scope("emitted").incrBy(1);
-                return;
-            } else if (timestampEmptyBuffer == -1) {
-                timestampEmptyBuffer = System.currentTimeMillis();
-            }
+            List<Object> fields = buffer.next();
+            String url = fields.get(0).toString();
+            this._collector.emit(fields, url);
+            beingProcessed.put(url, null);
+            eventCounter.scope("emitted").incrBy(1);
+            return;
+        } else if (timestampEmptyBuffer == -1) {
+            timestampEmptyBuffer = System.currentTimeMillis();
         }
 
         if (isInQuery.get() || throttleQueries() > 0) {

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
@@ -274,6 +274,7 @@ public abstract class AbstractQueryingSpout extends BaseRichSpout {
     public void ack(Object msgId) {
         beingProcessed.remove(msgId);
         eventCounter.scope("acked").incrBy(1);
+        buffer.acked(msgId.toString());
     }
 
     @Override

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractQueryingSpout.java
@@ -111,7 +111,7 @@ public abstract class AbstractQueryingSpout extends BaseRichSpout {
         eventCounter = context.registerMetric("counters",
                 new MultiCountMetric(), 10);
 
-        buffer = new URLBuffer();
+        buffer = URLBuffer.getInstance(stormConf);
         
         context.registerMetric("buffer_size", () -> buffer.size(), 10);
         context.registerMetric("numQueues", () -> buffer.numQueues(), 10);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractURLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractURLBuffer.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.persistence;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.digitalpebble.stormcrawler.Metadata;
+
+/**
+ * Abstract class for URLBuffer interface, meant to simplify the code of the
+ * implementations and provide some default methods
+ * 
+ * @since 1.15
+ **/
+public abstract class AbstractURLBuffer implements URLBuffer {
+
+    protected Set<String> in_buffer = new HashSet<>();
+    protected EmptyQueueListener listener = null;
+
+    /**
+     * Stores the URL and its Metadata using the hostname as key.
+     * 
+     * @return false if the URL was already in the buffer, true if it wasn't and
+     *         was added
+     **/
+    public synchronized boolean add(String URL, Metadata m) {
+        return add(URL, m, null);
+    }
+
+    /** Total number of URLs in the buffer **/
+    public int size() {
+        return in_buffer.size();
+    }
+
+    public void setEmptyQueueListener(EmptyQueueListener l) {
+        listener = l;
+    }
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/EmptyQueueListener.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/EmptyQueueListener.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.persistence;
+
+/**
+ * Used by URLBuffer to inform the spouts when a queue has no more URLs in it
+ **/
+public interface EmptyQueueListener {
+    abstract void emptyQueue(String queueName);
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/SimpleURLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/SimpleURLBuffer.java
@@ -36,14 +36,8 @@ import org.slf4j.LoggerFactory;
 import com.digitalpebble.stormcrawler.Metadata;
 
 /**
- * Buffers URLs to be processed into separate queues; used by spouts. Guarantees
- * that no URL can be put in the buffer more than once.
- * 
- * Configured by setting
- * 
- *   urlbuffer.class: "com.digitalpebble.stormcrawler.persistence.SimpleURLBuffer"
- * 
- * in the configuration
+ * Simple implementation of a URLBuffer which rotates on the queues without
+ * applying any priority.
  * 
  * @since 1.15
  **/

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/SimpleURLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/SimpleURLBuffer.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.persistence;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Queue;
+import java.util.Set;
+
+import org.apache.storm.tuple.Values;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.stormcrawler.Metadata;
+
+/**
+ * Buffers URLs to be processed into separate queues; used by spouts. Guarantees
+ * that no URL can be put in the buffer more than once.
+ * 
+ * Configured by setting
+ * 
+ *   urlbuffer.class: "com.digitalpebble.stormcrawler.persistence.SimpleURLBuffer"
+ * 
+ * in the configuration
+ * 
+ * @since 1.15
+ **/
+
+public class SimpleURLBuffer implements URLBuffer {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(SimpleURLBuffer.class);
+
+    private Set<String> in_buffer = new HashSet<>();
+    private Map<String, Queue<URLMetadata>> queues = Collections
+            .synchronizedMap(new LinkedHashMap<>());
+    private EmptyQueueListener listener = null;
+
+    /**
+     * Stores the URL and its Metadata under a given key.
+     * 
+     * @return false if the URL was already in the buffer, true if it wasn't and
+     *         was added
+     **/
+    public synchronized boolean add(String URL, Metadata m, String key) {
+
+        LOG.debug("Adding {}", URL);
+
+        if (in_buffer.contains(URL)) {
+            LOG.debug("already in buffer {}", URL);
+            return false;
+        }
+
+        // determine which queue to use
+        // configure with other than hostname
+        if (key == null) {
+            try {
+                URL u = new URL(URL);
+                key = u.getHost();
+            } catch (MalformedURLException e) {
+                return false;
+            }
+        }
+
+        // create the queue if it does not exist
+        // and add the url
+        queues.computeIfAbsent(key, k -> new LinkedList<URLMetadata>())
+                .add(new URLMetadata(URL, m));
+        return in_buffer.add(URL);
+    }
+
+    /**
+     * Stores the URL and its Metadata using the hostname as key.
+     * 
+     * @return false if the URL was already in the buffer, true if it wasn't and
+     *         was added
+     **/
+    public synchronized boolean add(String URL, Metadata m) {
+        return add(URL, m, null);
+    }
+
+    /** Total number of URLs in the buffer **/
+    public int size() {
+        return in_buffer.size();
+    }
+
+    /** Total number of queues in the buffer **/
+    public int numQueues() {
+        return queues.size();
+    }
+
+    /**
+     * Retrieves the next available URL, guarantees that the URLs are always
+     * perfectly shuffled
+     **/
+    public synchronized Values next() {
+        Iterator<Entry<String, Queue<URLMetadata>>> i = queues.entrySet()
+                .iterator();
+
+        if (!i.hasNext()) {
+            LOG.debug("Empty iterator");
+            return null;
+        }
+
+        Map.Entry<String, Queue<URLMetadata>> nextEntry = i.next();
+
+        Queue<URLMetadata> queue = nextEntry.getValue();
+        String queueName = nextEntry.getKey();
+
+        // remove the entry
+        i.remove();
+
+        LOG.debug("Next queue {}", queueName);
+
+        // remove the first element
+        URLMetadata item = queue.poll();
+
+        LOG.debug("Item {}", item.url);
+
+        // any left? add to the end of the iterator
+        if (!queue.isEmpty()) {
+            LOG.debug("adding to the back of the queue {}", queueName);
+            queues.put(queueName, queue);
+        }
+        // notify that the queue is empty
+        else {
+            if (listener != null) {
+                listener.emptyQueue(queueName);
+            }
+        }
+
+        // remove it from the list of URLs in the queue
+        in_buffer.remove(item.url);
+        return new Values(item.url, item.metadata);
+    }
+
+    public synchronized boolean hasNext() {
+        return !queues.isEmpty();
+    }
+
+    private class URLMetadata {
+        String url;
+        Metadata metadata;
+
+        URLMetadata(String u, Metadata m) {
+            url = u;
+            metadata = m;
+        }
+    }
+
+    public void setEmptyQueueListener(EmptyQueueListener l) {
+        listener = l;
+    }
+
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/SimpleURLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/SimpleURLBuffer.java
@@ -174,4 +174,8 @@ public class SimpleURLBuffer implements URLBuffer {
         listener = l;
     }
 
+    @Override
+    public void acked(String url) {
+    }
+
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/SimpleURLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/SimpleURLBuffer.java
@@ -170,6 +170,7 @@ public class SimpleURLBuffer implements URLBuffer {
 
     @Override
     public void acked(String url) {
+        // do nothing with the information about URLs being acked
     }
 
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
@@ -30,16 +30,21 @@ import java.util.Queue;
 import java.util.Set;
 
 import org.apache.storm.tuple.Values;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.Metadata;
 
-/** 
- * Buffers URLs to be processed into separate queues; used by spouts.
- * Guarantees that no URL can be put in the buffer more than once.
+/**
+ * Buffers URLs to be processed into separate queues; used by spouts. Guarantees
+ * that no URL can be put in the buffer more than once.
+ * 
  * @since 1.15
  **/
 
 public class URLBuffer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(URLBuffer.class);
 
     private Set<String> in_buffer = new HashSet<>();
     private Map<String, Queue<URLMetadata>> queues = Collections
@@ -94,7 +99,7 @@ public class URLBuffer {
     public int numQueues() {
         return queues.size();
     }
-    
+
     /**
      * Retrieves the next available URL, guarantees that the URLs are always
      * perfectly shuffled
@@ -104,6 +109,7 @@ public class URLBuffer {
                 .iterator();
 
         if (!i.hasNext()) {
+            LOG.debug("Empty iterator");
             return null;
         }
 
@@ -115,11 +121,16 @@ public class URLBuffer {
         // remove the entry
         i.remove();
 
+        LOG.debug("Next queue {}", queueName);
+
         // remove the first element
         URLMetadata item = queue.poll();
+        
+        LOG.debug("Item {}", item.url);
 
         // any left? add to the end of the iterator
         if (!queue.isEmpty()) {
+            LOG.debug("adding to the back of the queue {}", queueName);
             queues.put(queueName, queue);
         }
         // notify that the queue is empty
@@ -151,5 +162,5 @@ public class URLBuffer {
     public void setEmptyQueueListener(EmptyQueueListener l) {
         listener = l;
     }
-    
+
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
@@ -58,7 +58,11 @@ public class URLBuffer {
      *         was added
      **/
     public synchronized boolean add(String URL, Metadata m, String key) {
+        
+        LOG.debug("Adding {}", URL);
+        
         if (in_buffer.contains(URL)) {
+            LOG.debug("already in buffer {}", URL);
             return false;
         }
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
@@ -93,7 +93,7 @@ public interface URLBuffer {
      **/
     public abstract void acked(String url);
 
-    /** Returns a IURLBuffer instance based on the configuration **/
+    /** Returns a URLBuffer instance based on the configuration **/
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static URLBuffer getInstance(Map stormConf) {
         URLBuffer buffer;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
@@ -56,6 +56,12 @@ public interface URLBuffer {
     public abstract boolean hasNext();
 
     public abstract void setEmptyQueueListener(EmptyQueueListener l);
+    
+    /**
+     * Notify the buffer that a URL has been successfully processed
+     * used e.g to compute an ideal delay for a host queue
+     **/
+    public abstract void acked(String url);
 
     /** Returns a IURLBuffer instance based on the configuration **/
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
@@ -31,7 +31,7 @@ import com.digitalpebble.stormcrawler.util.ConfUtils;
  * 
  * Configured by setting
  * 
- *   urlbuffer.class: "com.digitalpebble.stormcrawler.persistence.SimpleURLBuffer"
+ * urlbuffer.class: "com.digitalpebble.stormcrawler.persistence.SimpleURLBuffer"
  * 
  * in the configuration
  * 
@@ -63,7 +63,9 @@ public interface URLBuffer {
      * @return false if the URL was already in the buffer, true if it wasn't and
      *         was added
      **/
-    public abstract boolean add(String URL, Metadata m);
+    public default boolean add(String URL, Metadata m) {
+        return add(URL, m, null);
+    }
 
     /** Total number of URLs in the buffer **/
     public abstract int size();
@@ -86,12 +88,14 @@ public interface URLBuffer {
     public abstract boolean hasNext();
 
     public abstract void setEmptyQueueListener(EmptyQueueListener l);
-    
+
     /**
-     * Notify the buffer that a URL has been successfully processed
-     * used e.g to compute an ideal delay for a host queue
+     * Notify the buffer that a URL has been successfully processed used e.g to
+     * compute an ideal delay for a host queue
      **/
-    public abstract void acked(String url);
+    public default void acked(String url) {
+        // do nothing with the information about URLs being acked
+    }
 
     /** Returns a URLBuffer instance based on the configuration **/
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
@@ -1,0 +1,98 @@
+package com.digitalpebble.stormcrawler.persistence;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Queue;
+import java.util.Set;
+
+import org.apache.storm.tuple.Values;
+
+import com.digitalpebble.stormcrawler.Metadata;
+
+public class URLBuffer {
+
+    private Set<String> in_buffer = new HashSet<>();
+    private Map<String, Queue<URLMetadata>> queues = Collections
+            .synchronizedMap(new LinkedHashMap<>());
+
+    /**
+     * Returns false if the URL was already in the buffer, true if it wasn't and
+     * was added
+     **/
+    public synchronized boolean add(String URL, Metadata m) {
+        if (in_buffer.contains(URL)) {
+            return false;
+        }
+        // determine which queue to use
+        // TODO configure with other than hostname
+        String key = null;
+        try {
+            URL u = new URL(URL);
+            key = u.getHost();
+        } catch (MalformedURLException e) {
+            return false;
+        }
+
+        // create the queue if it does not exist
+        // and add the
+        queues.computeIfAbsent(key, k -> new LinkedList<URLMetadata>())
+                .add(new URLMetadata(URL, m));
+        in_buffer.add(URL);
+        return true;
+    }
+
+    /**
+     * Retrieves the next available URL, guarantees that the URLs are always
+     * perfectly shuffled
+     **/
+    public synchronized Values next() {
+        Iterator<Entry<String, Queue<URLMetadata>>> i = queues.entrySet()
+                .iterator();
+
+        if (!i.hasNext()) {
+            return null;
+        }
+
+        Map.Entry<String, Queue<URLMetadata>> nextEntry = i.next();
+
+        Queue<URLMetadata> queue = nextEntry.getValue();
+        String queueName = nextEntry.getKey();
+
+        // remove the entry
+        i.remove();
+
+        // remove the first element
+        URLMetadata item = queue.poll();
+
+        // any left? add to the end of the iterator
+        if (!queue.isEmpty()) {
+            queues.put(queueName, queue);
+        }
+
+        // remove it from the list of URLs in the queue
+        in_buffer.remove(item.url);
+        return new Values(item.url, item.metadata);
+    }
+
+    public synchronized boolean hasNext() {
+        return queues.isEmpty();
+    }
+
+    private class URLMetadata {
+        String url;
+        Metadata metadata;
+
+        URLMetadata(String u, Metadata m) {
+            url = u;
+            metadata = m;
+        }
+    }
+
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.digitalpebble.stormcrawler.persistence;
 
 import java.util.Map;
@@ -7,6 +24,19 @@ import org.apache.storm.tuple.Values;
 
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
+
+/**
+ * Buffers URLs to be processed into separate queues; used by spouts. Guarantees
+ * that no URL can be put in the buffer more than once.
+ * 
+ * Configured by setting
+ * 
+ *   urlbuffer.class: "com.digitalpebble.stormcrawler.persistence.SimpleURLBuffer"
+ * 
+ * in the configuration
+ * 
+ * @since 1.15
+ **/
 
 public interface URLBuffer {
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
@@ -33,11 +33,18 @@ import org.apache.storm.tuple.Values;
 
 import com.digitalpebble.stormcrawler.Metadata;
 
+/** 
+ * Buffers URLs to be processed into separate queues; used by spouts.
+ * Guarantees that no URL can be put in the buffer more than once.
+ * @since 1.15
+ **/
+
 public class URLBuffer {
 
     private Set<String> in_buffer = new HashSet<>();
     private Map<String, Queue<URLMetadata>> queues = Collections
             .synchronizedMap(new LinkedHashMap<>());
+    private EmptyQueueListener listener = null;
 
     /**
      * Stores the URL and its Metadata under a given key.
@@ -110,6 +117,12 @@ public class URLBuffer {
         if (!queue.isEmpty()) {
             queues.put(queueName, queue);
         }
+        // notify that the queue is empty
+        else {
+            if (listener != null) {
+                listener.emptyQueue(queueName);
+            }
+        }
 
         // remove it from the list of URLs in the queue
         in_buffer.remove(item.url);
@@ -130,4 +143,8 @@ public class URLBuffer {
         }
     }
 
+    public void setEmptyQueueListener(EmptyQueueListener l) {
+        listener = l;
+    }
+    
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/URLBuffer.java
@@ -90,6 +90,11 @@ public class URLBuffer {
         return in_buffer.size();
     }
 
+    /** Total number of queues in the buffer **/
+    public int numQueues() {
+        return queues.size();
+    }
+    
     /**
      * Retrieves the next available URL, guarantees that the URLs are always
      * perfectly shuffled

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -43,6 +43,8 @@ config:
   
   # alternative values are "byIP" and "byDomain"
   partition.url.mode: "byHost"
+  
+  urlbuffer.class: "com.digitalpebble.stormcrawler.persistence.SimpleURLBuffer"
 
   # metadata to transfer to the outlinks
   # used by Fetcher for redirections, sitemapparser, etc...

--- a/core/src/test/java/com/digitalpebble/stormcrawler/persistence/URLBufferTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/persistence/URLBufferTest.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.digitalpebble.stormcrawler.persistence;
 
 import java.net.MalformedURLException;
@@ -13,9 +30,19 @@ public class URLBufferTest {
         URLBuffer buffer = new URLBuffer();
         Assert.assertFalse(buffer.hasNext());
         buffer.add("http://a.net/test.html", new Metadata());
+        buffer.add("http://a.net/test2.html", new Metadata());
         buffer.add("http://b.net/test.html", new Metadata());
         buffer.add("http://c.net/test.html", new Metadata());
         Assert.assertEquals("http://a.net/test.html",buffer.next().get(0));
         Assert.assertEquals("http://b.net/test.html",buffer.next().get(0));
+        // should return false if already there
+        boolean added = buffer.add("http://c.net/test.html", new Metadata());
+        Assert.assertFalse(added);
+        added = buffer.add("http://d.net/test.html", new Metadata());
+        Assert.assertTrue(added);
+        Assert.assertEquals("http://c.net/test.html",buffer.next().get(0));
+        Assert.assertEquals("http://a.net/test2.html",buffer.next().get(0));
+        Assert.assertEquals("http://d.net/test.html",buffer.next().get(0));
+        Assert.assertFalse(buffer.hasNext());
     }
 }

--- a/core/src/test/java/com/digitalpebble/stormcrawler/persistence/URLBufferTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/persistence/URLBufferTest.java
@@ -1,0 +1,21 @@
+package com.digitalpebble.stormcrawler.persistence;
+
+import java.net.MalformedURLException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.digitalpebble.stormcrawler.Metadata;
+
+public class URLBufferTest {
+    @Test
+    public void testURLBuffer() throws MalformedURLException {
+        URLBuffer buffer = new URLBuffer();
+        Assert.assertFalse(buffer.hasNext());
+        buffer.add("http://a.net/test.html", new Metadata());
+        buffer.add("http://b.net/test.html", new Metadata());
+        buffer.add("http://c.net/test.html", new Metadata());
+        Assert.assertEquals("http://a.net/test.html",buffer.next().get(0));
+        Assert.assertEquals("http://b.net/test.html",buffer.next().get(0));
+    }
+}

--- a/core/src/test/java/com/digitalpebble/stormcrawler/persistence/URLBufferTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/persistence/URLBufferTest.java
@@ -27,7 +27,7 @@ import com.digitalpebble.stormcrawler.Metadata;
 public class URLBufferTest {
     @Test
     public void testURLBuffer() throws MalformedURLException {
-        URLBuffer buffer = new URLBuffer();
+        URLBuffer buffer = new SimpleURLBuffer();
         Assert.assertFalse(buffer.hasNext());
         buffer.add("http://a.net/test.html", new Metadata());
         buffer.add("http://a.net/test2.html", new Metadata());

--- a/core/src/test/java/com/digitalpebble/stormcrawler/persistence/URLBufferTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/persistence/URLBufferTest.java
@@ -33,16 +33,16 @@ public class URLBufferTest {
         buffer.add("http://a.net/test2.html", new Metadata());
         buffer.add("http://b.net/test.html", new Metadata());
         buffer.add("http://c.net/test.html", new Metadata());
-        Assert.assertEquals("http://a.net/test.html",buffer.next().get(0));
-        Assert.assertEquals("http://b.net/test.html",buffer.next().get(0));
+        Assert.assertEquals("http://a.net/test.html", buffer.next().get(0));
+        Assert.assertEquals("http://b.net/test.html", buffer.next().get(0));
         // should return false if already there
         boolean added = buffer.add("http://c.net/test.html", new Metadata());
         Assert.assertFalse(added);
         added = buffer.add("http://d.net/test.html", new Metadata());
         Assert.assertTrue(added);
-        Assert.assertEquals("http://c.net/test.html",buffer.next().get(0));
-        Assert.assertEquals("http://a.net/test2.html",buffer.next().get(0));
-        Assert.assertEquals("http://d.net/test.html",buffer.next().get(0));
+        Assert.assertEquals("http://c.net/test.html", buffer.next().get(0));
+        Assert.assertEquals("http://a.net/test2.html", buffer.next().get(0));
+        Assert.assertEquals("http://d.net/test.html", buffer.next().get(0));
         Assert.assertFalse(buffer.hasNext());
     }
 }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/ElasticSearchConnection.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/ElasticSearchConnection.java
@@ -171,7 +171,7 @@ public class ElasticSearchConnection {
             @Override
             public void select(Iterable<Node> nodes) {
                 for (Node node : nodes) {
-                    LOG.info("Connected to ES node {} [{}] for {}",
+                    LOG.debug("Connected to ES node {} [{}] for {}",
                             node.getName(), node.getHost(), boltType);
                 }
             }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
@@ -27,6 +27,7 @@ import java.util.Map.Entry;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.search.SearchHit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,8 +143,8 @@ public abstract class AbstractSpout extends AbstractQueryingSpout {
 
         // if more than one instance is used we expect their number to be the
         // same as the number of shards
-        int totalTasks = context
-                .getComponentTasks(context.getThisComponentId()).size();
+        int totalTasks = context.getComponentTasks(context.getThisComponentId())
+                .size();
         if (totalTasks > 1) {
             logIdprefix = "[" + context.getThisComponentId() + " #"
                     + context.getThisTaskIndex() + "] ";
@@ -186,8 +187,8 @@ public abstract class AbstractSpout extends AbstractQueryingSpout {
         totalSortField = ConfUtils.getString(stormConf,
                 ESStatusGlobalSortFieldParamName);
 
-        maxURLsPerBucket = ConfUtils.getInt(stormConf,
-                ESStatusMaxURLsParamName, 1);
+        maxURLsPerBucket = ConfUtils.getInt(stormConf, ESStatusMaxURLsParamName,
+                1);
         maxBucketNum = ConfUtils.getInt(stormConf, ESStatusMaxBucketParamName,
                 10);
 
@@ -196,6 +197,16 @@ public abstract class AbstractSpout extends AbstractQueryingSpout {
 
     /** Builds a query and use it retrieve the results from ES **/
     protected abstract void populateBuffer();
+
+    protected final boolean addHitToBuffer(SearchHit hit) {
+        Map<String, Object> keyValues = hit.getSourceAsMap();
+        String url = (String) keyValues.get("url");
+        // is already being processed - skip it!
+        if (beingProcessed.containsKey(url)) {
+            return false;
+        }
+        return buffer.add(url, fromKeyValues(keyValues));
+    }
 
     protected final Metadata fromKeyValues(Map<String, Object> keyValues) {
         Map<String, List<String>> mdAsMap = (Map<String, List<String>>) keyValues

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
@@ -57,7 +57,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.Metadata;
-import com.digitalpebble.stormcrawler.persistence.EmptyQueueListener;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 
 /**
@@ -69,7 +68,7 @@ import com.digitalpebble.stormcrawler.util.ConfUtils;
  **/
 @SuppressWarnings("serial")
 public class AggregationSpout extends AbstractSpout implements
-        ActionListener<SearchResponse>, EmptyQueueListener {
+        ActionListener<SearchResponse> {
 
     private static final Logger LOG = LoggerFactory
             .getLogger(AggregationSpout.class);
@@ -96,7 +95,6 @@ public class AggregationSpout extends AbstractSpout implements
                 ESMostRecentDateMinGapParamName, recentDateMinGap);
         super.open(stormConf, context, collector);
         currentBuckets = new HashSet<>();
-        buffer.setEmptyQueueListener(this);
     }
 
     @Override
@@ -341,10 +339,4 @@ public class AggregationSpout extends AbstractSpout implements
         // remove lock
         markQueryReceivedNow();
     }
-
-    @Override
-    public void emptyQueue(String queueName) {
-        LOG.info("Emptied buffer queue for {}", queueName);
-    }
-
 }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
@@ -90,8 +90,8 @@ public class AggregationSpout extends AbstractSpout implements
                 ESMostRecentDateIncreaseParamName, recentDateIncrease);
         recentDateMinGap = ConfUtils.getInt(stormConf,
                 ESMostRecentDateMinGapParamName, recentDateMinGap);
-        buffer.setEmptyQueueListener(this);
         super.open(stormConf, context, collector);
+        buffer.setEmptyQueueListener(this);
     }
 
     @Override

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AggregationSpout.java
@@ -90,6 +90,7 @@ public class AggregationSpout extends AbstractSpout implements
                 ESMostRecentDateIncreaseParamName, recentDateIncrease);
         recentDateMinGap = ConfUtils.getInt(stormConf,
                 ESMostRecentDateMinGapParamName, recentDateMinGap);
+        buffer.setEmptyQueueListener(this);
         super.open(stormConf, context, collector);
     }
 

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
@@ -232,15 +232,4 @@ public class CollapsingSpout extends AbstractSpout implements
         markQueryReceivedNow();
     }
 
-    private final boolean addHitToBuffer(SearchHit hit) {
-        Map<String, Object> keyValues = hit.getSourceAsMap();
-        String url = (String) keyValues.get("url");
-        // is already being processed - skip it!
-        if (beingProcessed.containsKey(url)) {
-            return false;
-        }
-        Metadata metadata = fromKeyValues(keyValues);
-        return buffer.add(url, metadata);
-    }
-
 }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
@@ -192,12 +192,6 @@ public class CollapsingSpout extends AbstractSpout implements
                     }
                 }
             }
-
-            // Shuffle the URLs so that we don't get blocks of URLs from the
-            // same host or domain
-            if (numBuckets != numDocs) {
-                Collections.shuffle((List) buffer);
-            }
         }
 
         queryTimes.addMeasurement(timeTaken);
@@ -247,14 +241,8 @@ public class CollapsingSpout extends AbstractSpout implements
         if (beingProcessed.containsKey(url)) {
             return false;
         }
-        if (in_buffer.contains(url)) {
-            return false;
-        }
         Metadata metadata = fromKeyValues(keyValues);
-        boolean added = buffer.add(new Values(url, metadata));
-        if (added)
-            in_buffer.add(url);
-        return added;
+        return buffer.add(url, metadata);
     }
 
 }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
@@ -20,7 +20,6 @@ package com.digitalpebble.stormcrawler.elasticsearch.persistence;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,7 +28,6 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
-import org.apache.storm.tuple.Values;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -49,7 +47,6 @@ import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 
 /**

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/CollapsingSpout.java
@@ -172,24 +172,22 @@ public class CollapsingSpout extends AbstractSpout implements
         int alreadyprocessed = 0;
         int numDocs = 0;
 
-        synchronized (buffer) {
-            for (SearchHit hit : hits) {
-                Map<String, SearchHits> innerHits = hit.getInnerHits();
-                // wanted just one per bucket : no inner hits
-                if (innerHits == null) {
-                    numDocs++;
-                    if (!addHitToBuffer(hit)) {
-                        alreadyprocessed++;
-                    }
-                    continue;
+        for (SearchHit hit : hits) {
+            Map<String, SearchHits> innerHits = hit.getInnerHits();
+            // wanted just one per bucket : no inner hits
+            if (innerHits == null) {
+                numDocs++;
+                if (!addHitToBuffer(hit)) {
+                    alreadyprocessed++;
                 }
-                // more than one per bucket
-                SearchHits inMyBucket = innerHits.get("urls_per_bucket");
-                for (SearchHit subHit : inMyBucket.getHits()) {
-                    numDocs++;
-                    if (!addHitToBuffer(subHit)) {
-                        alreadyprocessed++;
-                    }
+                continue;
+            }
+            // more than one per bucket
+            SearchHits inMyBucket = innerHits.get("urls_per_bucket");
+            for (SearchHit subHit : inMyBucket.getHits()) {
+                numDocs++;
+                if (!addHitToBuffer(subHit)) {
+                    alreadyprocessed++;
                 }
             }
         }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/HybridSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/HybridSpout.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.persistence.EmptyQueueListener;
+import com.digitalpebble.stormcrawler.util.ConfUtils;
 
 public class HybridSpout extends AggregationSpout
         implements EmptyQueueListener {
@@ -32,10 +33,16 @@ public class HybridSpout extends AggregationSpout
     private static final Logger LOG = LoggerFactory
             .getLogger(HybridSpout.class);
 
+    protected static final String RELOADPARAMNAME = "es.status.max.urls.per.reload";
+
+    private int bufferReloadSize = 10;
+
     @Override
     public void open(Map stormConf, TopologyContext context,
             SpoutOutputCollector collector) {
         super.open(stormConf, context, collector);
+        bufferReloadSize = ConfUtils.getInt(stormConf, RELOADPARAMNAME,
+                maxURLsPerBucket);
         buffer.setEmptyQueueListener(this);
     }
 
@@ -67,7 +74,7 @@ public class HybridSpout extends AggregationSpout
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
         sourceBuilder.query(queryBuilder);
         sourceBuilder.from(0);
-        sourceBuilder.size(maxURLsPerBucket);
+        sourceBuilder.size(bufferReloadSize);
         sourceBuilder.explain(false);
         sourceBuilder.trackTotalHits(false);
 

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/HybridSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/HybridSpout.java
@@ -1,0 +1,124 @@
+package com.digitalpebble.stormcrawler.elasticsearch.persistence;
+
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+import org.joda.time.format.ISODateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.stormcrawler.persistence.EmptyQueueListener;
+
+public class HybridSpout extends AggregationSpout
+        implements EmptyQueueListener {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(HybridSpout.class);
+
+    @Override
+    public void open(Map stormConf, TopologyContext context,
+            SpoutOutputCollector collector) {
+        super.open(stormConf, context, collector);
+        buffer.setEmptyQueueListener(this);
+    }
+
+    @Override
+    public void emptyQueue(String queueName) {
+
+        LOG.info("Emptied buffer queue for {}", queueName);
+
+        if (!currentBuckets.contains(queueName)) {
+            // not interested in this one any more
+            return;
+        }
+
+        LOG.info("Querying for more docs for {}", queueName);
+
+        String formattedQueryDate = ISODateTimeFormat.dateTimeNoMillis()
+                .print(queryDate.getTime());
+
+        BoolQueryBuilder queryBuilder = boolQuery().filter(QueryBuilders
+                .rangeQuery("nextFetchDate").lte(formattedQueryDate));
+
+        queryBuilder.filter(QueryBuilders.termQuery(partitionField, queueName));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(queryBuilder);
+        sourceBuilder.from(0);
+        sourceBuilder.size(maxURLsPerBucket);
+        sourceBuilder.explain(false);
+        sourceBuilder.trackTotalHits(false);
+
+        // sort within a bucket
+        if (StringUtils.isNotBlank(bucketSortField)) {
+            FieldSortBuilder sorter = SortBuilders.fieldSort(bucketSortField)
+                    .order(SortOrder.ASC);
+            sourceBuilder.sort(sorter);
+        }
+
+        SearchRequest request = new SearchRequest(indexName);
+
+        request.source(sourceBuilder);
+
+        // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-preference.html
+        // _shards:2,3
+        if (shardID != -1) {
+            request.preference("_shards:" + shardID);
+        }
+
+        // dump query to log
+        LOG.debug("{} ES query {} - {}", logIdprefix, queueName,
+                request.toString());
+
+        client.searchAsync(request, RequestOptions.DEFAULT, this);
+    }
+
+    /**
+     * gets the results for a specific host
+     */
+    public void onResponse(SearchResponse response) {
+
+        int alreadyprocessed = 0;
+        int numDocs = 0;
+
+        SearchHit[] hits = response.getHits().getHits();
+
+        for (SearchHit hit : hits) {
+            numDocs++;
+            if (!addHitToBuffer(hit)) {
+                alreadyprocessed++;
+            }
+        }
+
+        eventCounter.scope("ES_queries").incrBy(1);
+        eventCounter.scope("ES_docs").incrBy(numDocs);
+        eventCounter.scope("already_being_processed").incrBy(alreadyprocessed);
+
+        LOG.info(
+                "{} ES term query returned {} hits  in {} msec with {} already being processed.",
+                logIdprefix, numDocs, response.getTook().getMillis(),
+                alreadyprocessed);
+    }
+
+    /**
+     * A failure caused by an exception at some phase of the task.
+     */
+    public void onFailure(Exception e) {
+        LOG.error("Exception with ES query", e);
+    }
+
+}

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/HybridSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/HybridSpout.java
@@ -2,6 +2,8 @@ package com.digitalpebble.stormcrawler.elasticsearch.persistence;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 
+import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
@@ -48,6 +50,11 @@ public class HybridSpout extends AggregationSpout
         }
 
         LOG.info("Querying for more docs for {}", queueName);
+
+        if (queryDate == null) {
+            queryDate = new Date();
+            lastTimeResetToNOW = Instant.now();
+        }
 
         String formattedQueryDate = ISODateTimeFormat.dateTimeNoMillis()
                 .print(queryDate.getTime());

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/HybridSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/HybridSpout.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.digitalpebble.stormcrawler.elasticsearch.persistence;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
@@ -15,7 +32,6 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
@@ -26,6 +42,14 @@ import org.slf4j.LoggerFactory;
 
 import com.digitalpebble.stormcrawler.persistence.EmptyQueueListener;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
+
+/**
+ * Uses collapsing spouts to get an initial set of URLs and keys to query for
+ * and gets emptyQueue notifications from the URLBuffer to query ES for a
+ * specific key.
+ * 
+ * @since 1.15
+ */
 
 public class HybridSpout extends AggregationSpout
         implements EmptyQueueListener {

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/HybridSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/HybridSpout.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
@@ -91,6 +92,12 @@ public class HybridSpout extends AggregationSpout
      * gets the results for a specific host
      */
     public void onResponse(SearchResponse response) {
+
+        // aggregations? process with the super class
+        if (response.getAggregations() != null) {
+            super.onResponse(response);
+            return;
+        }
 
         int alreadyprocessed = 0;
         int numDocs = 0;

--- a/external/solr/src/main/java/com/digitalpebble/stormcrawler/solr/persistence/SolrSpout.java
+++ b/external/solr/src/main/java/com/digitalpebble/stormcrawler/solr/persistence/SolrSpout.java
@@ -18,9 +18,7 @@
 package com.digitalpebble.stormcrawler.solr.persistence;
 
 import java.time.Instant;
-import java.util.Calendar;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -31,7 +29,6 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
-import org.apache.storm.tuple.Values;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -219,7 +216,7 @@ public class SolrSpout extends AbstractQueryingSpout {
                     }
                 }
 
-                buffer.add(new Values(url, metadata));
+                buffer.add(url, metadata);
             }
 
             LOG.info(

--- a/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/SQLSpout.java
+++ b/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/SQLSpout.java
@@ -24,7 +24,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -32,10 +31,10 @@ import org.apache.storm.spout.Scheme;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.tuple.Values;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.persistence.AbstractQueryingSpout;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 import com.digitalpebble.stormcrawler.util.StringTabScheme;
@@ -180,9 +179,7 @@ public class SQLSpout extends AbstractQueryingSpout {
                 String URLMD = url + metadata;
                 List<Object> v = SCHEME.deserialize(ByteBuffer.wrap(URLMD
                         .getBytes()));
-                Values vals = new Values();
-                vals.addAll(v);
-                buffer.add(vals);
+                buffer.add(url,(Metadata)v.get(1));
             }
 
             // no results? reset the date


### PR DESCRIPTION
Most spouts currently hold a queue of tuples waiting to be released and a set of strings to check whether an incoming tuple is already being processed or not. This PR replaces them with a URLBuffer which combines both functionalities and offers a lower level synchronisation mechanism. This makes it easier to write test code and simplifies the logic of the spouts. The implementation is pluggable and it is possible to specify any class implementing the URLBuffer interface. The default implementation puts the URLs into buckets based on the hostname and returns the tuples by iterating on the buckets. Other implementations could optimise the buckets based on how fast its URLs get processed.

Additionally, this PR contains a first version of a hybrid spout for ES which extends AggregationSpout and listens to queues getting empty in the URLBuffer, in which case it emits a simple term query to retrieve new URLs. The assumption is that many frequent small term queries would be faster than one rare large aggregation. Also, new URLs can be obtained without waiting for the whole buffer to get empty.



