### PR TITLE
okhttp protocol: reliably mark trimmed content because of content limit

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -298,9 +298,14 @@ public class HttpProtocol extends AbstractHttpProtocol {
         int bytesRequested = 0;
         int bufferGrowStepBytes = 8192;
 
-        while (source.getBuffer().size() < maxContentBytes) {
+        while (source.getBuffer().size() <= maxContentBytes) {
             bytesRequested += Math.min(bufferGrowStepBytes,
-                    (maxContentBytes - bytesRequested));
+                    /*
+                     * request one byte more than required to reliably detect
+                     * truncated content, but beware of integer overflows
+                     */
+                    (maxContentBytes == Integer.MAX_VALUE ? maxContentBytes
+                            : (1 + maxContentBytes)) - bytesRequested);
             boolean success = false;
             try {
                 success = source.request(bytesRequested);


### PR DESCRIPTION
(fixes #756)

With the patch applied the content is reliably marked as trimmed:
```
> java -cp ... com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol ... http://localhost/sitemap.xml
...
http.trimmed.reason: length
...
http.trimmed: true
```
