### PR TITLE
Fix NullPointerException in JSONResourceWrappers

### DIFF
--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/filtering/JSONURLFilterWrapper.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/filtering/JSONURLFilterWrapper.java
@@ -95,8 +95,6 @@ public class JSONURLFilterWrapper implements URLFilter {
             throw new RuntimeException("urlfilter.class undefined!");
         }
 
-        JSONResource resource = null;
-
         // load an instance of the delegated parsefilter
         try {
             Class<?> filterClass = Class.forName(urlfilterclass);
@@ -132,6 +130,8 @@ public class JSONURLFilterWrapper implements URLFilter {
             refreshRate = node.asInt(refreshRate);
         }
 
+        final JSONResource resource = (JSONResource) delegatedURLFilter;
+
         new Timer().schedule(new TimerTask() {
             private RestHighLevelClient esClient;
 
@@ -154,7 +154,7 @@ public class JSONURLFilterWrapper implements URLFilter {
                         resource.loadJSONResources(new ByteArrayInputStream(
                                 response.getSourceAsBytes()));
                     } catch (Exception e) {
-                        LOG.error("Can't load config from ES", e.getMessage());
+                        LOG.error("Can't load config from ES", e);
                     }
                 }
             }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/parse/filter/JSONResourceWrapper.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/parse/filter/JSONResourceWrapper.java
@@ -94,8 +94,6 @@ public class JSONResourceWrapper extends ParseFilter {
             throw new RuntimeException("parsefilter.class undefined!");
         }
 
-        JSONResource resource = null;
-
         // load an instance of the delegated parsefilter
         try {
             Class<?> filterClass = Class.forName(parsefilterclass);
@@ -132,6 +130,8 @@ public class JSONResourceWrapper extends ParseFilter {
             refreshRate = node.asInt(refreshRate);
         }
 
+        final JSONResource resource = (JSONResource) delegatedParseFilter;
+
         new Timer().schedule(new TimerTask() {
             private RestHighLevelClient esClient;
 
@@ -153,7 +153,7 @@ public class JSONResourceWrapper extends ParseFilter {
                         resource.loadJSONResources(new ByteArrayInputStream(
                                 response.getSourceAsBytes()));
                     } catch (Exception e) {
-                        LOG.error("Can't load config from ES", e.getMessage());
+                        LOG.error("Can't load config from ES", e);
                     }
                 }
             }


### PR DESCRIPTION
`JSONURLFilterWrapper` and `JSONResourceWrapper` will always throw a `NullPointerException` during their `Timer`'s run method as `JSONResource resource` is never initialized.

Also cleans up invalid calls to `LOG.error`.