### PR TITLE
add download images functions and configs

### DIFF
--- a/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -33,6 +33,8 @@ config:
    - error.source
    - isSitemap
    - isFeed
+   - isRenamed
+   - newName
 
   http.agent.name: "Anonymous Coward"
   http.agent.version: "1.0"
@@ -63,7 +65,9 @@ config:
 
   # never revisit a page with an error (or set a value in minutes)
   fetchInterval.error: -1
-
+  # if download is true, make sure set an absolute path in dest.directory. the default path is /home/username/figures/.
+  download.images: false
+  dest.directory: ""
   # text extraction for JSoupParserBolt
   textextractor.include.pattern:
    - DIV[id="maincontent"]


### PR DESCRIPTION
I couldn't find any function to save images while crawling, so I added one.
I added a function in **JSoupParserBolt.java** and call that function where content-type exception is getting thrown. This function saves images in a directory with the name of domain name of that image. For example images from _Google.com_ will save in _/home/username/figures/google.com/some_image.jpg_. This function also checks if an image exists with the same name with the new image and if it does, it renames the new image and set _true_ in _metadata.isRenamed_ and set the new name in _metadata.newName_.
I also added two new configurations so the user can choose if they want to save images or not and can set a custom directory to save images in that directory.