### PR TITLE
(Storm 2.x) Fix call of storm jar / storm local in README

### DIFF
--- a/archetype/src/main/resources/archetype-resources/README.md
+++ b/archetype/src/main/resources/archetype-resources/README.md
@@ -10,7 +10,7 @@ mvn clean package
 before submitting the topology using the storm command:
 
 ``` sh
-storm local target/${artifactId}-${version}.jar ${package}.CrawlTopology -conf crawler-conf.yaml --local-ttl 60
+storm local target/${artifactId}-${version}.jar --local-ttl 60 -- ${package}.CrawlTopology -conf crawler-conf.yaml
 ```
 
 This will run the topology in local mode for 60 seconds. Simply use the 'storm jar' to start the topology in distributed mode, where it will run indefinitely.


### PR DESCRIPTION
The Storm 2.x command-line parser has been rewritten. Without any additional hint it also consumes the options and flags for the crawl topology class. The `--` tells storm that the remaining options and flags should be passed to the topology main class. Storm options need be given before.

Without the `--` when launching the topology via `storm jar` or `storm local` the `-conf` options are stripped and the Java command is logged:
```
Running: java ... package.CrawlTopology /path/es-conf.yaml /path/crawler-conf.yaml
```
Consequently, the crawl topology does not read the configuration files. By calling the topology as
```
storm {jar,local} [<storm-opts>] -- package.CrawlTopology [<crawl-topology-opts>]
```
the Java command correct:
```
Running: java ... package.CrawlTopology -conf /path/es-conf.yaml -conf /path/crawler-conf.yaml
```

Btw., successfully run a test crawl on Storm 2.1.0 and ES 7.5.0