### PR TITLE
Issue # 800 : elasticsearch IndexerBolt issue causing ack failures

### DIFF
--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/IndexerBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/IndexerBolt.java
@@ -295,9 +295,9 @@ public class IndexerBolt extends AbstractIndexerBolt implements
 
                 if (!failed) {
                     acked++;
-                    _collector.ack(t);
                     _collector.emit(StatusStreamName, t, new Values(u,
                             metadata, Status.FETCHED));
+                    _collector.ack(t);
                 } else {
                     failurecount++;
                     LOG.error("update ID {}, URL {}, failure: {}", id, u, f);


### PR DESCRIPTION
Elasticsearch Indexer bolt is acking before emit tuples in afterBulk method is causing ack failures in spout after timeout set in topology.
Order recommended by storm for correctly acking is emit and then ack 
