### PR TITLE
Implemented Sitemap extension parsing (issue #749)

### DIFF
--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -153,6 +153,18 @@ config:
   # used by fetcher bolts
   sitemap.discovery: false
 
+  # determines what sitemap extensions to parse from the sitemap and add
+  # to an outlinks metadata object
+  sitemap.extensions:
+  # Illustrates enabling sitemap extension parsing
+  # there are 5 supported types "IMAGE", "LINKS", "MOBILE", "NEWS", and "VIDEO"
+  # sitemap.extensions:
+  #   - IMAGE
+  #   - LINKS
+  #   - MOBILE
+  #   - NEWS
+  #   - VIDEO
+
   # Default implementation of Scheduler
   scheduler.class: "com.digitalpebble.stormcrawler.persistence.DefaultScheduler"
 

--- a/core/src/test/java/com/digitalpebble/stormcrawler/bolt/SiteMapParserBoltTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/bolt/SiteMapParserBoltTest.java
@@ -18,10 +18,15 @@
 package com.digitalpebble.stormcrawler.bolt;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import clojure.lang.PersistentVector;
+import crawlercommons.sitemaps.extension.Extension;
+import org.apache.storm.tuple.Values;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +36,6 @@ import org.apache.storm.task.OutputCollector;
 import com.digitalpebble.stormcrawler.Constants;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.TestUtil;
-import com.digitalpebble.stormcrawler.bolt.SiteMapParserBolt;
 import com.digitalpebble.stormcrawler.parse.ParsingTester;
 import com.digitalpebble.stormcrawler.protocol.HttpHeaders;
 
@@ -69,6 +73,147 @@ public class SiteMapParserBoltTest extends ParsingTester {
     }
 
     @Test
+    public void testSitemapParsingWithImageExtensions() throws IOException {
+        Map parserConfig = new HashMap();
+        parserConfig.put("sitemap.extensions", PersistentVector
+                .create(Collections.singletonList(Extension.IMAGE.name())));
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+
+        Metadata metadata = new Metadata();
+        // specify that it is a sitemap file
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        // and its mime-type
+        metadata.setValue(HttpHeaders.CONTENT_TYPE, "application/xml");
+
+        parse("http://www.digitalpebble.com/sitemap.xml",
+                "digitalpebble.sitemap.extensions.image.xml", metadata);
+        Values values = (Values) output.getEmitted(Constants.StatusStreamName)
+                .get(0);
+        Metadata parsedMetadata = (Metadata) values.get(1);
+        assertImageAttributes(parsedMetadata);
+    }
+
+    @Test
+    public void testSitemapParsingWithMobileExtensions() throws IOException {
+        Map parserConfig = new HashMap();
+        parserConfig.put("sitemap.extensions", PersistentVector
+                .create(Collections.singletonList(Extension.MOBILE.name())));
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+
+        Metadata metadata = new Metadata();
+        // specify that it is a sitemap file
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        // and its mime-type
+        metadata.setValue(HttpHeaders.CONTENT_TYPE, "application/xml");
+
+        parse("http://www.digitalpebble.com/sitemap.xml",
+                "digitalpebble.sitemap.extensions.mobile.xml", metadata);
+        Values values = (Values) output.getEmitted(Constants.StatusStreamName)
+                .get(0);
+        Metadata parsedMetadata = (Metadata) values.get(1);
+        assertMobileAttributes(parsedMetadata);
+    }
+
+    @Test
+    public void testSitemapParsingWithLinkExtensions() throws IOException {
+        Map parserConfig = new HashMap();
+        parserConfig.put("sitemap.extensions", PersistentVector
+                .create(Collections.singletonList(Extension.LINKS.name())));
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+
+        Metadata metadata = new Metadata();
+        // specify that it is a sitemap file
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        // and its mime-type
+        metadata.setValue(HttpHeaders.CONTENT_TYPE, "application/xml");
+
+        parse("http://www.digitalpebble.com/sitemap.xml",
+                "digitalpebble.sitemap.extensions.links.xml", metadata);
+        Values values = (Values) output.getEmitted(Constants.StatusStreamName)
+                .get(0);
+        Metadata parsedMetadata = (Metadata) values.get(1);
+        assertLinksAttributes(parsedMetadata);
+    }
+
+    @Test
+    public void testSitemapParsingWithNewsExtensions() throws IOException {
+        Map parserConfig = new HashMap();
+        parserConfig.put("sitemap.extensions", PersistentVector
+                .create(Collections.singletonList(Extension.NEWS.name())));
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+
+        Metadata metadata = new Metadata();
+        // specify that it is a sitemap file
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        // and its mime-type
+        metadata.setValue(HttpHeaders.CONTENT_TYPE, "application/xml");
+
+        parse("http://www.digitalpebble.com/sitemap.xml",
+                "digitalpebble.sitemap.extensions.news.xml", metadata);
+        Values values = (Values) output.getEmitted(Constants.StatusStreamName)
+                .get(0);
+        Metadata parsedMetadata = (Metadata) values.get(1);
+        assertNewsAttributes(parsedMetadata);
+    }
+
+    @Test
+    public void testSitemapParsingWithVideoExtensions() throws IOException {
+        Map parserConfig = new HashMap();
+        parserConfig.put("sitemap.extensions", PersistentVector
+                .create(Collections.singletonList(Extension.VIDEO.name())));
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+
+        Metadata metadata = new Metadata();
+        // specify that it is a sitemap file
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        // and its mime-type
+        metadata.setValue(HttpHeaders.CONTENT_TYPE, "application/xml");
+
+        parse("http://www.digitalpebble.com/sitemap.xml",
+                "digitalpebble.sitemap.extensions.video.xml", metadata);
+        Values values = (Values) output.getEmitted(Constants.StatusStreamName)
+                .get(0);
+        Metadata parsedMetadata = (Metadata) values.get(1);
+        assertVideoAttributes(parsedMetadata);
+    }
+
+    @Test
+    public void testSitemapParsingWithAllExtensions() throws IOException {
+        Map parserConfig = new HashMap();
+        parserConfig.put("sitemap.extensions", PersistentVector.create(Arrays
+                .asList(Extension.MOBILE.name(), Extension.NEWS.name(),
+                        Extension.LINKS.name(), Extension.VIDEO.name(),
+                        Extension.IMAGE.name())));
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+
+        Metadata metadata = new Metadata();
+        // specify that it is a sitemap file
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        // and its mime-type
+        metadata.setValue(HttpHeaders.CONTENT_TYPE, "application/xml");
+
+        parse("http://www.digitalpebble.com/sitemap.xml",
+                "digitalpebble.sitemap.extensions.all.xml", metadata);
+        Values values = (Values) output.getEmitted(Constants.StatusStreamName)
+                .get(0);
+        Metadata parsedMetadata = (Metadata) values.get(1);
+        assertImageAttributes(parsedMetadata);
+        assertNewsAttributes(parsedMetadata);
+        assertVideoAttributes(parsedMetadata);
+        assertLinksAttributes(parsedMetadata);
+        assertMobileAttributes(parsedMetadata);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSitemapParsingWithIllegalExtensionConfigured()
+            throws IOException {
+        Map parserConfig = new HashMap();
+        parserConfig.put("sitemap.extensions",
+                PersistentVector.create(Arrays.asList("AUDIONEWSLINKS")));
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+    }
+
+    @Test
     public void testSitemapParsingNoMT() throws IOException {
 
         Map parserConfig = new HashMap();
@@ -103,4 +248,77 @@ public class SiteMapParserBoltTest extends ParsingTester {
         Assert.assertEquals(1, output.getEmitted().size());
     }
 
+    private void assertNewsAttributes(Metadata metadata) {
+        long numAttributes = metadata.keySet()
+                .stream()
+                .filter(key -> key.startsWith(Extension.NEWS.name() + "."))
+                .count();
+        Assert.assertEquals(7, numAttributes);
+        Assert.assertEquals("The Example Times", metadata.getFirstValue(Extension.NEWS.name() + "." + "name"));
+        Assert.assertEquals("en", metadata.getFirstValue(Extension.NEWS.name() + "." + "language"));
+        Assert.assertArrayEquals(new String[] { "PressRelease", "Blog" }, metadata.getValues(Extension.NEWS.name() + "." + "genres"));
+        Assert.assertEquals("2008-12-23T00:00Z", metadata.getFirstValue(Extension.NEWS.name() + "." + "publication_date"));
+        Assert.assertEquals("Companies A, B in Merger Talks", metadata.getFirstValue(Extension.NEWS.name() + "." + "title"));
+        Assert.assertArrayEquals(new String[] { "business", "merger", "acquisition", "A", "B" }, metadata.getValues(Extension.NEWS.name() + "." + "keywords"));
+        Assert.assertArrayEquals(new String[] { "NASDAQ:A", "NASDAQ:B"}, metadata.getValues(Extension.NEWS.name() + "." + "stock_tickers"));
+    }
+
+    private void assertImageAttributes(Metadata metadata) {
+        long numAttributes = metadata.keySet()
+                .stream()
+                .filter(key -> key.startsWith(Extension.IMAGE.name() + "."))
+                .count();
+        Assert.assertEquals(5, numAttributes);
+        Assert.assertEquals("This is the caption.", metadata.getFirstValue(Extension.IMAGE.name() + "." + "caption"));
+        Assert.assertEquals("http://example.com/photo.jpg", metadata.getFirstValue(Extension.IMAGE.name() + "." + "loc"));
+        Assert.assertEquals("Example photo shot in Limerick, Ireland", metadata.getFirstValue(Extension.IMAGE.name() + "." + "title"));
+        Assert.assertEquals("https://creativecommons.org/licenses/by/4.0/legalcode", metadata.getFirstValue(Extension.IMAGE.name() + "." + "license"));
+        Assert.assertEquals("Limerick, Ireland", metadata.getFirstValue(Extension.IMAGE.name() + "." + "geo_location"));
+    }
+
+    private void assertLinksAttributes(Metadata metadata) {
+        long numAttributes = metadata.keySet()
+                .stream()
+                .filter(key -> key.startsWith(Extension.LINKS.name() + "."))
+                .count();
+        Assert.assertEquals(3, numAttributes);
+        Assert.assertEquals("alternate", metadata.getFirstValue(Extension.LINKS.name() + "." + "params.rel"));
+        Assert.assertEquals("http://www.example.com/english/", metadata.getFirstValue(Extension.LINKS.name() + "." + "href"));
+        Assert.assertEquals("en", metadata.getFirstValue(Extension.LINKS.name() + "." + "params.hreflang"));
+    }
+
+    private void assertVideoAttributes(Metadata metadata) {
+        long numAttributes = metadata.keySet()
+                .stream()
+                .filter(key -> key.startsWith(Extension.VIDEO.name() + "."))
+                .count();
+        Assert.assertEquals(19, numAttributes);
+        Assert.assertEquals("http://www.example.com/thumbs/123.jpg", metadata.getFirstValue(Extension.VIDEO.name() + "." + "thumbnail_loc"));
+        Assert.assertEquals("Grilling steaks for summer", metadata.getFirstValue(Extension.VIDEO.name() + "." + "title"));
+        Assert.assertEquals("Alkis shows you how to get perfectly done steaks every time", metadata.getFirstValue(Extension.VIDEO.name() + "." + "description"));
+        Assert.assertEquals("http://www.example.com/video123.flv", metadata.getFirstValue(Extension.VIDEO.name() + "." + "content_loc"));
+        Assert.assertEquals("http://www.example.com/videoplayer.swf?video=123", metadata.getFirstValue(Extension.VIDEO.name() + "." + "player_loc"));
+        //Assert.assertEquals("600", metadata.getFirstValue(Extension.VIDEO.name() + "." + "duration"));
+        Assert.assertEquals("2009-11-05T19:20:30+08:00", metadata.getFirstValue(Extension.VIDEO.name() + "." + "expiration_date"));
+        Assert.assertEquals("4.2", metadata.getFirstValue(Extension.VIDEO.name() + "." + "rating"));
+        Assert.assertEquals("12345", metadata.getFirstValue(Extension.VIDEO.name() + "." + "view_count"));
+        Assert.assertEquals("2007-11-05T19:20:30+08:00", metadata.getFirstValue(Extension.VIDEO.name() + "." + "publication_date"));
+        Assert.assertEquals("true", metadata.getFirstValue(Extension.VIDEO.name() + "." + "family_friendly"));
+        Assert.assertArrayEquals(new String[]{ "sample_tag1", "sample_tag2" }, metadata.getValues(Extension.VIDEO.name() + "." + "tags"));
+        Assert.assertArrayEquals(new String[]{ "IE", "GB", "US", "CA" }, metadata.getValues(Extension.VIDEO.name() + "." + "allowed_countries"));
+        Assert.assertEquals("http://cooking.example.com", metadata.getFirstValue(Extension.VIDEO.name() + "." + "gallery_loc"));
+        Assert.assertEquals("value: 1.99, currency: EUR, type: own, resolution: null", metadata.getFirstValue(Extension.VIDEO.name() + "." + "prices"));
+        Assert.assertEquals("true", metadata.getFirstValue(Extension.VIDEO.name() + "." + "requires_subscription"));
+        Assert.assertEquals("GrillyMcGrillerson", metadata.getFirstValue(Extension.VIDEO.name() + "." + "uploader"));
+        Assert.assertEquals("http://www.example.com/users/grillymcgrillerson", metadata.getFirstValue(Extension.VIDEO.name() + "." + "uploader_info"));
+        Assert.assertEquals("false", metadata.getFirstValue(Extension.VIDEO.name() + "." + "is_live"));
+    }
+
+    private void assertMobileAttributes(Metadata metadata) {
+        long numAttributes = metadata.keySet()
+                .stream()
+                .filter(key -> key.startsWith(Extension.MOBILE.name() + "."))
+                .count();
+        Assert.assertEquals(0, numAttributes);
+    }
 }

--- a/core/src/test/resources/digitalpebble.sitemap.extensions.all.xml
+++ b/core/src/test/resources/digitalpebble.sitemap.extensions.all.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+      xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
+      xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+      xmlns:xhtml="http://www.w3.org/1999/xhtml"
+      xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
+      xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+<url>
+  <loc>http://digitalpebble.com/</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+  <mobile:mobile/>
+  <xhtml:link rel="alternate" hreflang="en" href="http://www.example.com/english/" />
+  <image:image>
+    <image:loc>http://example.com/photo.jpg</image:loc>
+    <image:caption>This is the caption.</image:caption>
+    <image:geo_location>Limerick, Ireland</image:geo_location>
+    <image:title>Example photo shot in Limerick, Ireland</image:title>
+    <image:license>https://creativecommons.org/licenses/by/4.0/legalcode</image:license>
+  </image:image>
+  <news:news>
+    <news:publication>
+      <news:name>The Example Times</news:name>
+      <news:language>en</news:language>
+    </news:publication>
+    <news:genres>PressRelease, Blog</news:genres>
+    <news:publication_date>2008-12-23</news:publication_date>
+    <news:title>Companies A, B in Merger Talks</news:title>
+    <news:keywords>business, merger, acquisition, A, B</news:keywords>
+    <news:stock_tickers>NASDAQ:A, NASDAQ:B</news:stock_tickers>
+  </news:news>
+  <video:video>
+    <video:thumbnail_loc>http://www.example.com/thumbs/123.jpg</video:thumbnail_loc>
+    <video:title>Grilling steaks for summer</video:title>
+    <video:description>Alkis shows you how to get perfectly done steaks every time</video:description>
+    <video:content_loc>http://www.example.com/video123.flv</video:content_loc>
+    <video:player_loc allow_embed="yes" autoplay="ap=1">http://www.example.com/videoplayer.swf?video=123</video:player_loc>
+    <video:duration>600</video:duration>
+    <video:expiration_date>2009-11-05T19:20:30+08:00</video:expiration_date>
+    <video:rating>4.2</video:rating>
+    <video:view_count>12345</video:view_count>
+    <video:publication_date>2007-11-05T19:20:30+08:00</video:publication_date>
+    <video:tag>sample_tag1</video:tag>
+    <video:tag>sample_tag2</video:tag>
+    <video:family_friendly>yes</video:family_friendly>
+    <video:restriction relationship="allow">IE GB US CA</video:restriction>
+    <video:gallery_loc title="Cooking Videos">http://cooking.example.com</video:gallery_loc>
+    <video:price currency="EUR">1.99</video:price>
+    <video:requires_subscription>yes</video:requires_subscription>
+    <video:uploader info="http://www.example.com/users/grillymcgrillerson">GrillyMcGrillerson</video:uploader>
+    <video:live>no</video:live>
+  </video:video>
+</url>
+<url>
+  <loc>http://digitalpebble.com/index.html</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/solutions.html</loc>
+  <lastmod>2012-09-06T16:53:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/references.html</loc>
+  <lastmod>2014-04-16T14:40:10+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/contact.html</loc>
+  <lastmod>2012-12-05T10:59:00+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+</urlset>

--- a/core/src/test/resources/digitalpebble.sitemap.extensions.image.xml
+++ b/core/src/test/resources/digitalpebble.sitemap.extensions.image.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+      xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+<url>
+  <loc>http://digitalpebble.com/</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+  <image:image>
+    <image:loc>http://example.com/photo.jpg</image:loc>
+    <image:caption>This is the caption.</image:caption>
+    <image:geo_location>Limerick, Ireland</image:geo_location>
+    <image:title>Example photo shot in Limerick, Ireland</image:title>
+    <image:license>https://creativecommons.org/licenses/by/4.0/legalcode</image:license>
+  </image:image>
+</url>
+<url>
+  <loc>http://digitalpebble.com/index.html</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/solutions.html</loc>
+  <lastmod>2012-09-06T16:53:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/references.html</loc>
+  <lastmod>2014-04-16T14:40:10+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/contact.html</loc>
+  <lastmod>2012-12-05T10:59:00+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+</urlset>

--- a/core/src/test/resources/digitalpebble.sitemap.extensions.links.xml
+++ b/core/src/test/resources/digitalpebble.sitemap.extensions.links.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+        xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+<url>
+  <loc>http://digitalpebble.com/</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+  <xhtml:link rel="alternate" hreflang="en" href="http://www.example.com/english/" />
+</url>
+<url>
+  <loc>http://digitalpebble.com/index.html</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/solutions.html</loc>
+  <lastmod>2012-09-06T16:53:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/references.html</loc>
+  <lastmod>2014-04-16T14:40:10+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/contact.html</loc>
+  <lastmod>2012-12-05T10:59:00+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+</urlset>

--- a/core/src/test/resources/digitalpebble.sitemap.extensions.mobile.xml
+++ b/core/src/test/resources/digitalpebble.sitemap.extensions.mobile.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+      xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+<url>
+  <loc>http://digitalpebble.com/</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+  <mobile:mobile/>
+</url>
+<url>
+  <loc>http://digitalpebble.com/index.html</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/solutions.html</loc>
+  <lastmod>2012-09-06T16:53:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/references.html</loc>
+  <lastmod>2014-04-16T14:40:10+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/contact.html</loc>
+  <lastmod>2012-12-05T10:59:00+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+</urlset>

--- a/core/src/test/resources/digitalpebble.sitemap.extensions.news.xml
+++ b/core/src/test/resources/digitalpebble.sitemap.extensions.news.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+      xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+<url>
+  <loc>http://digitalpebble.com/</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+  <news:news>
+    <news:publication>
+      <news:name>The Example Times</news:name>
+      <news:language>en</news:language>
+    </news:publication>
+    <news:genres>PressRelease, Blog</news:genres>
+    <news:publication_date>2008-12-23</news:publication_date>
+    <news:title>Companies A, B in Merger Talks</news:title>
+    <news:keywords>business, merger, acquisition, A, B</news:keywords>
+    <news:stock_tickers>NASDAQ:A, NASDAQ:B</news:stock_tickers>
+  </news:news>
+</url>
+<url>
+  <loc>http://digitalpebble.com/index.html</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/solutions.html</loc>
+  <lastmod>2012-09-06T16:53:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/references.html</loc>
+  <lastmod>2014-04-16T14:40:10+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/contact.html</loc>
+  <lastmod>2012-12-05T10:59:00+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+</urlset>

--- a/core/src/test/resources/digitalpebble.sitemap.extensions.video.xml
+++ b/core/src/test/resources/digitalpebble.sitemap.extensions.video.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+      xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+<url>
+  <loc>http://digitalpebble.com/</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+  <video:video>
+    <video:thumbnail_loc>http://www.example.com/thumbs/123.jpg</video:thumbnail_loc>
+    <video:title>Grilling steaks for summer</video:title>
+    <video:description>Alkis shows you how to get perfectly done steaks every time</video:description>
+    <video:content_loc>http://www.example.com/video123.flv</video:content_loc>
+    <video:player_loc allow_embed="yes" autoplay="ap=1">http://www.example.com/videoplayer.swf?video=123</video:player_loc>
+    <video:duration>600</video:duration>
+    <video:expiration_date>2009-11-05T19:20:30+08:00</video:expiration_date>
+    <video:rating>4.2</video:rating>
+    <video:view_count>12345</video:view_count>
+    <video:publication_date>2007-11-05T19:20:30+08:00</video:publication_date>
+    <video:tag>sample_tag1</video:tag>
+    <video:tag>sample_tag2</video:tag>
+    <video:family_friendly>yes</video:family_friendly>
+    <video:restriction relationship="allow">IE GB US CA</video:restriction>
+    <video:gallery_loc title="Cooking Videos">http://cooking.example.com</video:gallery_loc>
+    <video:price currency="EUR">1.99</video:price>
+    <video:requires_subscription>yes</video:requires_subscription>
+    <video:uploader info="http://www.example.com/users/grillymcgrillerson">GrillyMcGrillerson</video:uploader>
+    <video:live>no</video:live>
+  </video:video>
+</url>
+<url>
+  <loc>http://digitalpebble.com/index.html</loc>
+  <lastmod>2012-12-05T10:59:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/solutions.html</loc>
+  <lastmod>2012-09-06T16:53:04+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/references.html</loc>
+  <lastmod>2014-04-16T14:40:10+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>http://digitalpebble.com/contact.html</loc>
+  <lastmod>2012-12-05T10:59:00+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+</urlset>


### PR DESCRIPTION
Implemented Sitemap extension parsing (issue #749)
- extracting the extension attributes out of each extension object for a given Sitemap URL added adding it to the outlink metadata object (prefixed by the extension type)

Somewhat related, while implementing this, I noticed that crawler-commons isn't adding the `duration` attribute from the `VideoExtension` to the map generated by `VideoExtension.asMap()` (oversight on my part).  I wrote this up as an issue, [crawler-commons/300](https://github.com/crawler-commons/crawler-commons/issues/300) and submitted a PR.  A future release will include duration, however, it will be missing from StormCrawler until a new version of `crawler-commons` is published with the fix.
