### PR TITLE
Fix HttpHeaders#formatDate to parse ISO dates, fixes #821

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpHeaders.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpHeaders.java
@@ -21,6 +21,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 
 /**
  * A collection of HTTP header names and utilities around header values.
@@ -65,12 +66,13 @@ public interface HttpHeaders {
      * in RFC 7231</a>. The latter specifies the format defined in RFC 1123 as
      * the &quot;preferred&quot; format.
      */
-    public static final DateTimeFormatter HTTP_DATE_FORMATTER = DateTimeFormatter.RFC_1123_DATE_TIME
+    public static final DateTimeFormatter HTTP_DATE_FORMATTER = DateTimeFormatter
+            .ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.ROOT)
             .withZone(ZoneId.of(ZoneOffset.UTC.toString()));
 
     /** Formatter to parse ISO-formatted dates persisted in status index */
     public static final DateTimeFormatter ISO_INSTANT_FORMATTER = DateTimeFormatter.ISO_INSTANT
-            .withZone(ZoneId.of("UTC"));
+            .withZone(ZoneId.of(ZoneOffset.UTC.toString()));
 
     /**
      * Format an ISO date string as HTTP date used in HTTP headers, e.g.,

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpHeaders.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpHeaders.java
@@ -68,6 +68,10 @@ public interface HttpHeaders {
     public static final DateTimeFormatter HTTP_DATE_FORMATTER = DateTimeFormatter.RFC_1123_DATE_TIME
             .withZone(ZoneId.of(ZoneOffset.UTC.toString()));
 
+    /** Formatter to parse ISO-formatted dates persisted in status index */
+    public static final DateTimeFormatter ISO_INSTANT_FORMATTER = DateTimeFormatter.ISO_INSTANT
+            .withZone(ZoneId.of("UTC"));
+
     /**
      * Format an ISO date string as HTTP date used in HTTP headers, e.g.,
      * 
@@ -85,7 +89,7 @@ public interface HttpHeaders {
      */
     public static String formatHttpDate(String isoDate) {
         try {
-            ZonedDateTime date = DateTimeFormatter.ISO_INSTANT.parse(isoDate,
+            ZonedDateTime date = ISO_INSTANT_FORMATTER.parse(isoDate,
                     ZonedDateTime::from);
             return HTTP_DATE_FORMATTER.format(date);
         } catch (DateTimeParseException e) {

--- a/core/src/test/java/com/digitalpebble/stormcrawler/protocol/HttpHeadersTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/protocol/HttpHeadersTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.protocol;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HttpHeadersTest {
+
+    @Test
+    public void testHttpDate() {
+        String[][] dates = { //
+                { "Tue, 22 Sep 2020 08:00:00 GMT", "2020-09-22T08:00:00.000Z" }, //
+                // { "Sun, 06 Nov 1994 08:49:37 GMT", "1994-11-06T08:49:37.000Z" } //
+        };
+        for (int i = 0; i < dates.length; i++) {
+            Assert.assertEquals(dates[i][0], HttpHeaders.formatHttpDate(dates[i][1]));
+        }
+    }
+}

--- a/core/src/test/java/com/digitalpebble/stormcrawler/protocol/HttpHeadersTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/protocol/HttpHeadersTest.java
@@ -25,7 +25,8 @@ public class HttpHeadersTest {
     public void testHttpDate() {
         String[][] dates = { //
                 { "Tue, 22 Sep 2020 08:00:00 GMT", "2020-09-22T08:00:00.000Z" }, //
-                // { "Sun, 06 Nov 1994 08:49:37 GMT", "1994-11-06T08:49:37.000Z" } //
+                { "Sun, 06 Nov 1994 08:49:37 GMT", "1994-11-06T08:49:37.000Z" }, //
+                { "Sun, 06 Nov 1994 20:49:37 GMT", "1994-11-06T20:49:37.000Z" }, //
         };
         for (int i = 0; i < dates.length; i++) {
             Assert.assertEquals(dates[i][0], HttpHeaders.formatHttpDate(dates[i][1]));


### PR DESCRIPTION
- provide ISO_INSTANT formatter with "UTC" time zone
- add unit test to verify date parsing and formatting as HTTP date used for the "If-modified-since" header (the dates to verify #820 are commented out)

... first part to fix #821, I'll try to find a solution for #820 as well and update the PR 