### PR TITLE
WARCSpout: add metadata field "fetch.statusCode" (HTTP status code)

### DIFF
--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCSpout.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCSpout.java
@@ -434,6 +434,9 @@ public class WARCSpout extends FileSpout {
 
         Metadata metadata = new Metadata();
 
+        // add HTTP status code expected by schedulers
+        metadata.addValue("fetch.statusCode", Integer.toString(http.status()));
+
         // Add HTTP response headers to metadata
         for (Map.Entry<String, List<String>> e : http.headers().map()
                 .entrySet()) {


### PR DESCRIPTION
Same as (Simple)FetcherBolt WARCSpout should add "fetch.statusCode" which holds HTTP status code to metadata. It's required by AdaptiveScheduler which will fail with a NPE if the field is not provided.