### PR TITLE
WARCSpout/FileSpout: ClassCastException if message ID of failed tuples is not of type byte[]

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/spout/FileSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/spout/FileSpout.java
@@ -254,8 +254,19 @@ public class FileSpout extends BaseRichSpout {
 
     @Override
     public void fail(Object msgId) {
-        String msg = new String((byte[]) msgId);
-        LOG.error("Failed - adding back to the queue: {}", msg);
-        buffer.add((byte[]) msgId);
+        if (msgId instanceof byte[]) {
+            String msg = new String((byte[]) msgId);
+            LOG.error("Failed - adding back to the queue: {}", msg);
+            buffer.add((byte[]) msgId);
+        } else if (withDiscoveredStatus && msgId instanceof String) {
+            // messageID is the injected URL
+            LOG.error("Failed - cannot replay URL without metadata: {}", msgId);
+        } else {
+            // unknown object type from extending class
+            LOG.error("Failed - unknown message ID type `{}': {}",
+                    msgId.getClass().getCanonicalName(), msgId);
+            throw new IllegalStateException("Unknown message ID type: "
+                    + msgId.getClass().getCanonicalName());
+        }
     }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/spout/FileSpout.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/spout/FileSpout.java
@@ -214,8 +214,7 @@ public class FileSpout extends BaseRichSpout {
 
         if (withDiscoveredStatus) {
             fields.add(Status.DISCOVERED);
-            this._collector.emit(Constants.StatusStreamName, fields, fields
-                    .get(0).toString());
+            this._collector.emit(Constants.StatusStreamName, fields, head);
         } else {
             this._collector.emit(fields, head);
         }
@@ -258,9 +257,6 @@ public class FileSpout extends BaseRichSpout {
             String msg = new String((byte[]) msgId);
             LOG.error("Failed - adding back to the queue: {}", msg);
             buffer.add((byte[]) msgId);
-        } else if (withDiscoveredStatus && msgId instanceof String) {
-            // messageID is the injected URL
-            LOG.error("Failed - cannot replay URL without metadata: {}", msgId);
         } else {
             // unknown object type from extending class
             LOG.error("Failed - unknown message ID type `{}': {}",

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCSpout.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCSpout.java
@@ -517,4 +517,8 @@ public class WARCSpout extends FileSpout {
         declarer.declare(new Fields("url", "content", "metadata"));
     }
 
+    @Override
+    public void fail(Object msgId) {
+        LOG.error("Failed - unable to replay WARC record of: {}", msgId);
+    }
 }


### PR DESCRIPTION
fixes #825

- FileSpout: check for type of message ID
    byte[] : replay
    String : log error, cannot replay
    (anything else) : log error and throw Exception
- WARCSpout: log error, cannot replay


