### PR TITLE
HTTP protocol implementation: allow to configure which protocol version(s) to use

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/AbstractHttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/AbstractHttpProtocol.java
@@ -47,6 +47,8 @@ public abstract class AbstractHttpProtocol implements Protocol {
 
     protected boolean useCookies = false;
 
+    protected List<String> protocolVersions;
+
     protected static final String RESPONSE_COOKIES_HEADER = "set-cookie";
 
     protected String protocolMDprefix = "";
@@ -58,6 +60,8 @@ public abstract class AbstractHttpProtocol implements Protocol {
         this.storeHTTPHeaders = ConfUtils.getBoolean(conf,
                 "http.store.headers", false);
         this.useCookies = ConfUtils.getBoolean(conf, "http.use.cookies", false);
+        this.protocolVersions = ConfUtils
+                .loadListFromConf("http.protocol.versions", conf);
         robots = new HttpRobotRulesParser(conf);
         protocolMDprefix = ConfUtils.getString(conf,
                 ProtocolResponse.PROTOCOL_MD_PREFIX_PARAM, protocolMDprefix);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -88,6 +89,8 @@ public class ConfUtils {
 
         if (obj instanceof PersistentVector) {
             list.addAll((PersistentVector) obj);
+        } else if (obj instanceof Collection) {
+            list.addAll((Collection<String>) obj);
         } else { // single value?
             list.add(obj.toString());
         }

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -113,6 +113,21 @@ config:
   https.protocol.implementation: "com.digitalpebble.stormcrawler.protocol.httpclient.HttpProtocol"
   file.protocol.implementation: "com.digitalpebble.stormcrawler.protocol.file.FileProtocol"
 
+  # the http/https protocol versions to use, in order of preference
+  # Details of the protocol negotiation between the client and
+  # the crawled server depend on the chosen protocol implementation.
+  # If no protocol versions are listed the protocol implementation
+  # will use its defaults.
+  http.protocol.versions:
+  # HTTP/2 over TLS (protocol negotiation via ALPN)
+  #- "h2"
+  # HTTP/1.1
+  #- "http/1.1"
+  # HTTP/1.0
+  #- "http/1.0"
+  # HTTP/2 over TCP
+  ##- "h2c"
+
   # key values obtained by the protocol can be prefixed
   # to avoid accidental overwrites. Note that persisted
   # or transferred protocol metadata must also be prefixed.

--- a/external/warc/README.md
+++ b/external/warc/README.md
@@ -153,6 +153,12 @@ Writing complete and valid WARC requires that HTTP headers, IP address and captu
   https.protocol.implementation: com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol
 ```
 
+Until the WARC bolt can write HTTP/2 requests and response in a way compatible with most WARC readers (see #828), HTTP/1.1 should be used by setting:
+```
+  http.protocol.versions:
+  - "http/1.1"
+```
+
 
 ## Consuming WARC files
 


### PR DESCRIPTION
implements #827
- configuration key `http.protocol.versions` holds a list of protocols in order of preference
- implement selection of protocols in okhttp protocol implementation (httpclient should pick this once HTTP/2 is supported)
- fix loading of YAML lists when configuration isn't loaded via Storm (eg. by main method of AbstractHttpProtocol)
- add notice about protocol version to warc module README