### PR TITLE
WARCSpout to add `_request.time_` to metadata

### DIFF
--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCSpout.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCSpout.java
@@ -437,6 +437,10 @@ public class WARCSpout extends FileSpout {
         // add HTTP status code expected by schedulers
         metadata.addValue("fetch.statusCode", Integer.toString(http.status()));
 
+        // add time when page was fetched (capture time)
+        metadata.addValue(protocolMDprefix + ProtocolResponse.REQUEST_TIME_KEY,
+                Long.toString(w.date().toEpochMilli()));
+
         // Add HTTP response headers to metadata
         for (Map.Entry<String, List<String>> e : http.headers().map()
                 .entrySet()) {


### PR DESCRIPTION
Add the capture time from the WARC header to metadata field `_request.time_` same as done by the okhttp protocol. Of course, the capture time is useful when indexing the archive content, it's even required if WARC files are re-archived.