### PR TITLE
WARCSpout: IllegalArgumentException if http.content.limit == -1

### DIFF
--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCSpout.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCSpout.java
@@ -347,7 +347,7 @@ public class WARCSpout extends FileSpout {
         record = Optional.empty();
 
         maxContentSize = ConfUtils.getInt(conf, "http.content.limit", -1);
-        if (contentBufferSize > maxContentSize) {
+        if (maxContentSize > 0 && contentBufferSize > maxContentSize) {
             // no need to buffer more content than max. used
             contentBufferSize = maxContentSize;
         }


### PR DESCRIPTION
Stupid bug: if `http.content.limit` is -1 (the default), WARCSpout shrinks its internal buffer size to the "lower" content limit size which causes an exception if it tries to allocate a ByteBuffer of negative size:
```
java.lang.IllegalArgumentException: null
        at java.nio.ByteBuffer.allocate(ByteBuffer.java:334) ~[?:1.8.0_222]
        at com.digitalpebble.stormcrawler.warc.WARCSpout.getContent(WARCSpout.java:248) ~[stormjar.jar:?]
        at com.digitalpebble.stormcrawler.warc.WARCSpout.nextTuple(WARCSpout.java:479) ~[stormjar.jar:?]
```