### PR TITLE
WARCSpout doesn't handle http.content.limit -1 correctly, fixes #850

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/Constants.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/Constants.java
@@ -47,6 +47,9 @@ public class Constants {
 
     public static final String fetchErrorCountParamName = "fetch.error.count";
 
+    /** Maximum array size, safe value on any JVM */
+    public static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
     private Constants() {
     }
 }


### PR DESCRIPTION
- if http.content.limit is -1 trim content to the max. possible array size

The following issues where fixes to allow testing with 3 WARC files holding content of [2^31-8 (safe)](https://github.com/DigitalPebble/storm-crawler/files/5880994/test-size-int-max-safe.warc.gz), [2^31-1 (int_max)](https://github.com/DigitalPebble/storm-crawler/files/5880999/test-size-int-max.warc.gz) and [2^31 bytes](https://github.com/DigitalPebble/storm-crawler/files/5881003/test-size-int-max-overflow.warc.gz) and to fix bugs detected while testing these edge cases:
- when reading into multiple buffers: do not read more bytes than necessary
- avoid an integer overflow when reporting length of truncation
- implement gzip and deflate Content-Type decompression