### PR TITLE
Scheduler implementations return an Optional<Date>

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
@@ -238,8 +238,10 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
         // metadata is available to fetch schedulers
         metadata = mdTransfer.filter(metadata);
 
-        // round next fetch date
-        nextFetch = DateUtils.round(nextFetch, this.roundDateUnit);
+        // round next fetch date - unless it is never
+        if (!nextFetch.equals(DefaultScheduler.NEVER)) {
+            nextFetch = DateUtils.round(nextFetch, this.roundDateUnit);
+        }
 
         // extensions of this class will handle the storage
         // on a per document basis

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
@@ -239,7 +239,7 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
         metadata = mdTransfer.filter(metadata);
 
         // round next fetch date - unless it is never
-        if (!nextFetch.equals(DefaultScheduler.NEVER)) {
+        if (nextFetch != null) {
             nextFetch = DateUtils.round(nextFetch, this.roundDateUnit);
         }
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AdaptiveScheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AdaptiveScheduler.java
@@ -276,11 +276,13 @@ public class AdaptiveScheduler extends DefaultScheduler {
                 metadata.setValue(HttpHeaders.LAST_MODIFIED, modifiedTimeString);
             }
             Date nextFetch = super.schedule(status, metadata);
-            long fetchIntervalMinutes = Duration
-                    .between(now.toInstant(), nextFetch.toInstant())
-                    .toMinutes();
-            metadata.setValue(FETCH_INTERVAL_KEY,
-                    Long.toString(fetchIntervalMinutes));
+            if (nextFetch != null) {
+              long fetchIntervalMinutes = Duration
+                      .between(now.toInstant(), nextFetch.toInstant())
+                      .toMinutes();
+              metadata.setValue(FETCH_INTERVAL_KEY,
+                      Long.toString(fetchIntervalMinutes));
+            }
             return nextFetch;
         } else if (signature.equals(oldSignature)) {
             // unchanged

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AdaptiveScheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/AdaptiveScheduler.java
@@ -223,7 +223,7 @@ public class AdaptiveScheduler extends DefaultScheduler {
     }
 
     @Override
-    public Date schedule(Status status, Metadata metadata) {
+    public Optional<Date> schedule(Status status, Metadata metadata) {
         LOG.debug("Scheduling status: {}, metadata: {}", status, metadata);
 
         String signature = metadata.getFirstValue(SIGNATURE_KEY);
@@ -275,10 +275,10 @@ public class AdaptiveScheduler extends DefaultScheduler {
                 // set last-modified time for first fetch
                 metadata.setValue(HttpHeaders.LAST_MODIFIED, modifiedTimeString);
             }
-            Date nextFetch = super.schedule(status, metadata);
-            if (nextFetch != null) {
+            Optional<Date> nextFetch = super.schedule(status, metadata);
+            if (nextFetch.isPresent()) {
               long fetchIntervalMinutes = Duration
-                      .between(now.toInstant(), nextFetch.toInstant())
+                      .between(now.toInstant(), nextFetch.get().toInstant())
                       .toMinutes();
               metadata.setValue(FETCH_INTERVAL_KEY,
                       Long.toString(fetchIntervalMinutes));
@@ -340,7 +340,7 @@ public class AdaptiveScheduler extends DefaultScheduler {
 
         now.add(Calendar.MINUTE, interval);
 
-        return now.getTime();
+        return Optional.of(now.getTime());
     }
 
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/DefaultScheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/DefaultScheduler.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.digitalpebble.stormcrawler.Constants;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
@@ -34,11 +36,6 @@ import com.digitalpebble.stormcrawler.util.ConfUtils;
  * Schedules a nextFetchDate based on the configuration
  **/
 public class DefaultScheduler extends Scheduler {
-
-    /** Date far in the future used for never-refetch items. */
-    public static final Date NEVER = new Calendar.Builder()
-            .setCalendarType("iso8601").setDate(2099, Calendar.DECEMBER, 31)
-            .build().getTime();
 
     /**
      * Key used to pass a custom delay via metadata. Used by the sitemaps to
@@ -115,7 +112,7 @@ public class DefaultScheduler extends Scheduler {
      * com.digitalpebble.stormcrawler.Metadata)
      */
     @Override
-    public Date schedule(Status status, Metadata metadata) {
+    public @Nullable Date schedule(Status status, Metadata metadata) {
 
         int minutesIncrement = 0;
 
@@ -153,9 +150,9 @@ public class DefaultScheduler extends Scheduler {
         }
 
         // a value of -1 means never fetch
-        // we use a conventional value
+        // we return null
         if (minutesIncrement == -1) {
-            return NEVER;
+            return null;
         }
 
         Calendar cal = Calendar.getInstance();

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/DefaultScheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/DefaultScheduler.java
@@ -112,7 +112,7 @@ public class DefaultScheduler extends Scheduler {
      * com.digitalpebble.stormcrawler.Metadata)
      */
     @Override
-    public @Nullable Date schedule(Status status, Metadata metadata) {
+    public Optional<Date> schedule(Status status, Metadata metadata) {
 
         int minutesIncrement = 0;
 
@@ -152,13 +152,13 @@ public class DefaultScheduler extends Scheduler {
         // a value of -1 means never fetch
         // we return null
         if (minutesIncrement == -1) {
-            return null;
+            return Optional.empty();
         }
 
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.MINUTE, minutesIncrement);
 
-        return cal.getTime();
+        return Optional.of(cal.getTime());
     }
 
     /**

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/DefaultScheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/DefaultScheduler.java
@@ -87,8 +87,8 @@ public class DefaultScheduler extends Scheduler {
             }
             String mdname = m.group(2);
             String mdvalue = m.group(3);
-            int customInterval = ConfUtils.getInt(stormConf, key, -1);
-            if (customInterval != -1) {
+            int customInterval = ConfUtils.getInt(stormConf, key, Integer.MIN_VALUE);
+            if (customInterval != Integer.MIN_VALUE) {
                 CustomInterval interval = intervals.get(mdname + mdvalue);
                 if (interval == null) {
                     interval = new CustomInterval(mdname, mdvalue, status,

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/MemoryStatusUpdater.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/MemoryStatusUpdater.java
@@ -18,6 +18,7 @@
 package com.digitalpebble.stormcrawler.persistence;
 
 import java.util.Date;
+import java.util.Optional;
 
 import org.apache.storm.tuple.Tuple;
 
@@ -34,10 +35,10 @@ public class MemoryStatusUpdater extends AbstractStatusUpdaterBolt {
 
     @Override
     public void store(String url, Status status, Metadata metadata,
-            Date nextFetch, Tuple t) throws Exception {
+            Optional<Date> nextFetch, Tuple t) throws Exception {
         // null means never refetch
-        if (nextFetch != null) {
-            MemorySpout.add(url, metadata, nextFetch);
+        if (nextFetch.isPresent()) {
+            MemorySpout.add(url, metadata, nextFetch.get());
         }
         super.ack(t, url);
     }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/MemoryStatusUpdater.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/MemoryStatusUpdater.java
@@ -35,8 +35,8 @@ public class MemoryStatusUpdater extends AbstractStatusUpdaterBolt {
     @Override
     public void store(String url, Status status, Metadata metadata,
             Date nextFetch, Tuple t) throws Exception {
-        // by convention we do not refetch URLs with a next fetch date of EPOCH
-        if (!nextFetch.equals(DefaultScheduler.NEVER)) {
+        // null means never refetch
+        if (nextFetch != null) {
             MemorySpout.add(url, metadata, nextFetch);
         }
         super.ack(t, url);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/MemoryStatusUpdater.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/MemoryStatusUpdater.java
@@ -36,7 +36,7 @@ public class MemoryStatusUpdater extends AbstractStatusUpdaterBolt {
     @Override
     public void store(String url, Status status, Metadata metadata,
             Optional<Date> nextFetch, Tuple t) throws Exception {
-        // null means never refetch
+        // no next fetch date present means never refetch
         if (nextFetch.isPresent()) {
             MemorySpout.add(url, metadata, nextFetch.get());
         }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/Scheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/Scheduler.java
@@ -19,8 +19,7 @@ package com.digitalpebble.stormcrawler.persistence;
 
 import java.util.Date;
 import java.util.Map;
-
-import javax.annotation.Nullable;
+import java.util.Optional;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -42,7 +41,7 @@ public abstract class Scheduler {
      * Returns a Date indicating when the document should be refetched next,
      * based on its status or null if the URL should never be refetched.
      **/
-    public abstract @Nullable Date schedule(Status status, Metadata metadata);
+    public abstract Optional<Date> schedule(Status status, Metadata metadata);
 
     /** Returns a Scheduler instance based on the configuration **/
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/Scheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/Scheduler.java
@@ -38,8 +38,8 @@ public abstract class Scheduler {
     protected abstract void init(Map stormConf);
 
     /**
-     * Returns a Date indicating when the document should be refetched next,
-     * based on its status or null if the URL should never be refetched.
+     * Returns an optional Date indicating when the document should be refetched next,
+     * based on its status. It is empty if the URL should never be refetched.
      **/
     public abstract Optional<Date> schedule(Status status, Metadata metadata);
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/Scheduler.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/Scheduler.java
@@ -20,6 +20,8 @@ package com.digitalpebble.stormcrawler.persistence;
 import java.util.Date;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.lang.StringUtils;
 
 import com.digitalpebble.stormcrawler.Metadata;
@@ -38,9 +40,9 @@ public abstract class Scheduler {
 
     /**
      * Returns a Date indicating when the document should be refetched next,
-     * based on its status.
+     * based on its status or null if the URL should never be refetched.
      **/
-    public abstract Date schedule(Status status, Metadata metadata);
+    public abstract @Nullable Date schedule(Status status, Metadata metadata);
 
     /** Returns a Scheduler instance based on the configuration **/
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/StdOutStatusUpdater.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/StdOutStatusUpdater.java
@@ -35,10 +35,10 @@ public class StdOutStatusUpdater extends AbstractStatusUpdaterBolt {
     @Override
     public void store(String url, Status status, Metadata metadata,
             Optional<Date> nextFetch, Tuple t) throws Exception {
-    	String nextFetchS = "NEVER";
-    	if (nextFetch != null) {
-    		nextFetchS = nextFetch.toString();
-    	}
+        String nextFetchS = "NEVER";
+        if (nextFetch.isPresent()) {
+            nextFetchS = nextFetch.toString();
+        }
         System.out.println(url + "\t" + status + "\t" + nextFetchS);
         System.out.println(metadata.toString("\t"));
         super.ack(t, url);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/StdOutStatusUpdater.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/StdOutStatusUpdater.java
@@ -18,6 +18,7 @@
 package com.digitalpebble.stormcrawler.persistence;
 
 import java.util.Date;
+import java.util.Optional;
 
 import org.apache.storm.tuple.Tuple;
 
@@ -33,7 +34,7 @@ public class StdOutStatusUpdater extends AbstractStatusUpdaterBolt {
 
     @Override
     public void store(String url, Status status, Metadata metadata,
-            Date nextFetch, Tuple t) throws Exception {
+            Optional<Date> nextFetch, Tuple t) throws Exception {
     	String nextFetchS = "NEVER";
     	if (nextFetch != null) {
     		nextFetchS = nextFetch.toString();

--- a/core/src/main/java/com/digitalpebble/stormcrawler/persistence/StdOutStatusUpdater.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/persistence/StdOutStatusUpdater.java
@@ -34,7 +34,11 @@ public class StdOutStatusUpdater extends AbstractStatusUpdaterBolt {
     @Override
     public void store(String url, Status status, Metadata metadata,
             Date nextFetch, Tuple t) throws Exception {
-        System.out.println(url + "\t" + status + "\t" + nextFetch);
+    	String nextFetchS = "NEVER";
+    	if (nextFetch != null) {
+    		nextFetchS = nextFetch.toString();
+    	}
+        System.out.println(url + "\t" + status + "\t" + nextFetchS);
         System.out.println(metadata.toString("\t"));
         super.ack(t, url);
     }

--- a/core/src/test/java/com/digitalpebble/stormcrawler/persistence/AdaptiveSchedulerTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/persistence/AdaptiveSchedulerTest.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.lang.time.DateUtils;
 import org.junit.Assert;
@@ -62,19 +63,19 @@ public class AdaptiveSchedulerTest {
         Metadata metadata = new Metadata();
         metadata.addValue("testKey", "someValue");
         metadata.addValue("fetch.statusCode", "200");
-        Date nextFetch = scheduler.schedule(Status.FETCHED, metadata);
+        Optional<Date> nextFetch = scheduler.schedule(Status.FETCHED, metadata);
 
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.MINUTE, 6);
         Assert.assertEquals(DateUtils.round(cal.getTime(), Calendar.SECOND),
-                DateUtils.round(nextFetch, Calendar.SECOND));
+                DateUtils.round(nextFetch.get(), Calendar.SECOND));
 
         nextFetch = scheduler.schedule(Status.ERROR, metadata);
 
         cal = Calendar.getInstance();
         cal.add(Calendar.MINUTE, 8);
         Assert.assertEquals(DateUtils.round(cal.getTime(), Calendar.SECOND),
-                DateUtils.round(nextFetch, Calendar.SECOND));
+                DateUtils.round(nextFetch.get(), Calendar.SECOND));
     }
 
     @Test
@@ -85,7 +86,7 @@ public class AdaptiveSchedulerTest {
         Metadata metadata = new Metadata();
         metadata.addValue("fetch.statusCode", "200");
         metadata.addValue(AdaptiveScheduler.SIGNATURE_KEY, md5sumEmptyContent);
-        Date nextFetch = scheduler.schedule(Status.FETCHED, metadata);
+        Optional<Date> nextFetch = scheduler.schedule(Status.FETCHED, metadata);
         Instant firstFetch = DateUtils
                 .round(Calendar.getInstance().getTime(), Calendar.SECOND)
                 .toInstant();

--- a/core/src/test/java/com/digitalpebble/stormcrawler/persistence/DefaultSchedulerTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/persistence/DefaultSchedulerTest.java
@@ -21,6 +21,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.lang.time.DateUtils;
 import org.junit.Assert;
@@ -41,19 +42,19 @@ public class DefaultSchedulerTest {
 
         Metadata metadata = new Metadata();
         metadata.addValue("testKey", "someValue");
-        Date nextFetch = scheduler.schedule(Status.FETCHED, metadata);
+        Optional<Date> nextFetch = scheduler.schedule(Status.FETCHED, metadata);
 
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.MINUTE, 360);
         Assert.assertEquals(DateUtils.round(cal.getTime(), Calendar.SECOND),
-                DateUtils.round(nextFetch, Calendar.SECOND));
+                DateUtils.round(nextFetch.get(), Calendar.SECOND));
 
         nextFetch = scheduler.schedule(Status.ERROR, metadata);
 
         cal = Calendar.getInstance();
         cal.add(Calendar.MINUTE, 3600);
         Assert.assertEquals(DateUtils.round(cal.getTime(), Calendar.SECOND),
-                DateUtils.round(nextFetch, Calendar.SECOND));
+                DateUtils.round(nextFetch.get(), Calendar.SECOND));
     }
 
     @Test
@@ -65,12 +66,12 @@ public class DefaultSchedulerTest {
 
         Metadata metadata = new Metadata();
         metadata.addValue("testKey.key2", "someValue");
-        Date nextFetch = scheduler.schedule(Status.FETCHED, metadata);
+        Optional<Date> nextFetch = scheduler.schedule(Status.FETCHED, metadata);
 
         Calendar cal = Calendar.getInstance();
         cal.add(Calendar.MINUTE, 360);
         Assert.assertEquals(DateUtils.round(cal.getTime(), Calendar.SECOND),
-                DateUtils.round(nextFetch, Calendar.SECOND));
+                DateUtils.round(nextFetch.get(), Calendar.SECOND));
     }
 
     @Test
@@ -95,9 +96,9 @@ public class DefaultSchedulerTest {
         scheduler.init(stormConf);
 
         Metadata metadata = new Metadata();
-        Date nextFetch = scheduler.schedule(Status.ERROR, metadata);
+        Optional<Date> nextFetch = scheduler.schedule(Status.ERROR, metadata);
 
-        Assert.assertEquals(null, nextFetch);
+        Assert.assertEquals(false, nextFetch.isPresent());
     }
 
 }

--- a/core/src/test/java/com/digitalpebble/stormcrawler/persistence/DefaultSchedulerTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/persistence/DefaultSchedulerTest.java
@@ -97,7 +97,7 @@ public class DefaultSchedulerTest {
         Metadata metadata = new Metadata();
         Date nextFetch = scheduler.schedule(Status.ERROR, metadata);
 
-        Assert.assertEquals(DefaultScheduler.NEVER, nextFetch);
+        Assert.assertEquals(null, nextFetch);
     }
 
 }

--- a/core/src/test/java/com/digitalpebble/stormcrawler/persistence/DefaultSchedulerTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/persistence/DefaultSchedulerTest.java
@@ -101,4 +101,18 @@ public class DefaultSchedulerTest {
         Assert.assertEquals(false, nextFetch.isPresent());
     }
 
+    @Test
+    public void testSpecificNever() throws MalformedURLException {
+        Map<String, Object> stormConf = new HashMap<>();
+        stormConf.put("fetchInterval.FETCHED.isSpam=true", -1);
+        DefaultScheduler scheduler = new DefaultScheduler();
+        scheduler.init(stormConf);
+
+        Metadata metadata = new Metadata();
+        metadata.setValue("isSpam", "true");
+        Optional<Date> nextFetch = scheduler.schedule(Status.FETCHED, metadata);
+
+        Assert.assertEquals(false, nextFetch.isPresent());
+    }
+
 }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/StatusUpdaterBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/StatusUpdaterBolt.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.elasticsearch.ElasticSearchConnection;
 import com.digitalpebble.stormcrawler.persistence.AbstractStatusUpdaterBolt;
+import com.digitalpebble.stormcrawler.persistence.DefaultScheduler;
 import com.digitalpebble.stormcrawler.persistence.Status;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 import com.digitalpebble.stormcrawler.util.URLPartitioner;
@@ -224,7 +225,9 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt implements
             builder.field(fieldNameForRoutingKey, partitionKey);
         }
 
-        builder.timeField("nextFetchDate", nextFetch);
+        if (!nextFetch.equals(DefaultScheduler.NEVER)) {
+        	builder.timeField("nextFetchDate", nextFetch);
+        }
 
         builder.endObject();
 

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/StatusUpdaterBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/StatusUpdaterBolt.java
@@ -225,7 +225,7 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt implements
             builder.field(fieldNameForRoutingKey, partitionKey);
         }
 
-        if (!nextFetch.equals(DefaultScheduler.NEVER)) {
+        if (nextFetch != null) {
         	builder.timeField("nextFetchDate", nextFetch);
         }
 

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/StatusUpdaterBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/StatusUpdaterBolt.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
@@ -165,7 +166,7 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt implements
 
     @Override
     public void store(String url, Status status, Metadata metadata,
-            Date nextFetch, Tuple tuple) throws Exception {
+            Optional<Date> nextFetch, Tuple tuple) throws Exception {
 
         String sha256hex = org.apache.commons.codec.digest.DigestUtils
                 .sha256Hex(url);
@@ -225,7 +226,7 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt implements
             builder.field(fieldNameForRoutingKey, partitionKey);
         }
 
-        if (nextFetch != null) {
+        if (nextFetch.isPresent()) {
         	builder.timeField("nextFetchDate", nextFetch);
         }
 

--- a/external/solr/src/main/java/com/digitalpebble/stormcrawler/solr/persistence/StatusUpdaterBolt.java
+++ b/external/solr/src/main/java/com/digitalpebble/stormcrawler/solr/persistence/StatusUpdaterBolt.java
@@ -20,6 +20,7 @@ package com.digitalpebble.stormcrawler.solr.persistence;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.solr.common.SolrInputDocument;
 import org.slf4j.Logger;
@@ -73,7 +74,7 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
     @Override
     public void store(String url, Status status, Metadata metadata,
-            Date nextFetch, Tuple t) throws Exception {
+            Optional<Date> nextFetch, Tuple t) throws Exception {
 
         SolrInputDocument doc = new SolrInputDocument();
 
@@ -90,7 +91,7 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
             doc.setField(String.format("%s.%s", mdPrefix, key), values);
         }
 
-        if (nextFetch != null) {
+        if (nextFetch.isPresent()) {
         	doc.setField("nextFetchDate", nextFetch);
         }
 

--- a/external/solr/src/main/java/com/digitalpebble/stormcrawler/solr/persistence/StatusUpdaterBolt.java
+++ b/external/solr/src/main/java/com/digitalpebble/stormcrawler/solr/persistence/StatusUpdaterBolt.java
@@ -90,7 +90,9 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
             doc.setField(String.format("%s.%s", mdPrefix, key), values);
         }
 
-        doc.setField("nextFetchDate", nextFetch);
+        if (nextFetch != null) {
+        	doc.setField("nextFetchDate", nextFetch);
+        }
 
         connection.getClient().add(doc);
 

--- a/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/StatusUpdaterBolt.java
+++ b/external/sql/src/main/java/com/digitalpebble/stormcrawler/sql/StatusUpdaterBolt.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -129,7 +130,7 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
     @Override
     public synchronized void store(String url, Status status,
-            Metadata metadata, Date nextFetch, Tuple t) throws Exception {
+            Metadata metadata, Optional<Date> nextFetch, Tuple t) throws Exception {
         // check whether the batch needs sending
         checkExecuteBatch();
 
@@ -168,7 +169,8 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
         preparedStmt.setString(1, url);
         preparedStmt.setString(2, status.toString());
-        preparedStmt.setObject(3, nextFetch);
+        if (nextFetch.isPresent())
+        	preparedStmt.setObject(3, nextFetch);
         preparedStmt.setString(4, mdAsString.toString());
         preparedStmt.setInt(5, partition);
         preparedStmt.setString(6, partitionKey);


### PR DESCRIPTION
implements #861

Using Optional<Date> would have worked but require a big change in the API whereas _null_ allows to keep it as it is.

@sebastian-nagel any thoughts?

