### PR TITLE
Bugfix for fast charset identification for some rare cases with broken meta tag

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/CharsetIdentification.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/CharsetIdentification.java
@@ -188,8 +188,12 @@ public class CharsetIdentification {
             int end = html.indexOf('"', start + 15);
             // https://github.com/DigitalPebble/storm-crawler/issues/870
             // try on a slightly larger section of text if it is trimmed
-            if (end == -1) {
+            if (end == -1 && ((maxlength + 10) < buffer.length)) {
                 return getCharsetFromMeta(buffer, maxlength + 10);
+            }
+            if (end == -1) {
+                // there is an open tag meta but not closed = we have broken content!
+                return null;
             }
             return validateCharset(html.substring(start + 15, end));
         }


### PR DESCRIPTION
Fix for issue #892 
We have to ensure that were enough content for a recursive call with a bit large window.
If we have found broken the meta tag we should return null.