### PR TITLE
DelegatorProtocol

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/Metadata.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/Metadata.java
@@ -98,8 +98,11 @@ public class Metadata {
             return null;
         return values[0];
     }
-    
-    /** @return the first value for the key or null if it does not exist, given a prefix **/
+
+    /**
+     * @return the first value for the key or null if it does not exist, given a
+     *         prefix
+     **/
     public String getFirstValue(String key, String prefix) {
         if (prefix == null || prefix.length() == 0)
             return getFirstValue(key);
@@ -111,7 +114,7 @@ public class Metadata {
             return getValues(key);
         return getValues(prefix + key);
     }
-    
+
     public String[] getValues(String key) {
         String[] values = md.get(key);
         if (values == null)
@@ -119,6 +122,21 @@ public class Metadata {
         if (values.length == 0)
             return null;
         return values;
+    }
+
+    public boolean containsKey(String key) {
+        return md.containsKey(key);
+    }
+
+    public boolean containsKeyWithValue(String key, String value) {
+        String[] values = getValues(key);
+        if (values == null)
+            return false;
+        for (String s : values) {
+            if (s.equals(value))
+                return true;
+        }
+        return false;
     }
 
     /** Set the value for a given key. The value can be null. */
@@ -251,7 +269,7 @@ public class Metadata {
     }
 
     /**
-     * Release the lock on a metadata 
+     * Release the lock on a metadata
      * 
      * @since 1.16
      **/
@@ -261,8 +279,8 @@ public class Metadata {
     }
 
     /**
-    * @since 1.16
-    **/
+     * @since 1.16
+     **/
     private final void checkLockException() {
         if (locked)
             throw new ConcurrentModificationException(

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/DelegatorProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/DelegatorProtocol.java
@@ -1,0 +1,243 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.protocol;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.storm.Config;
+import org.slf4j.LoggerFactory;
+
+import com.digitalpebble.stormcrawler.Metadata;
+
+import crawlercommons.robots.BaseRobotRules;
+
+/**
+ * Protocol implementation that enables selection from a collection of
+ * sub-protocols using filters based on each call's metadata
+ *
+ * Is configured like this
+ *
+ * <pre>
+  protocol.delegator.config:
+    - className: "com.digitalpebble.stormcrawler.protocol.httpclient.HttpProtocol"
+      filters:
+        domain: "example.com"
+        depth: "3"
+        test: "true"
+    - className: "com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol"
+      filters:
+        js: "true"
+    - className: "com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol"
+ * </pre>
+ * 
+ * The last one in the list must not have filters as it is used as a default
+ * value. The protocols are tried for matches in the order in which they are
+ * listed in the configuration. The first to match gets used to fetch a URL.
+ * 
+ * @since 2.2
+ **/
+
+public class DelegatorProtocol implements Protocol {
+
+    private static final String DELEGATOR_CONFIG_KEY = "protocol.delegator.config";
+
+    protected static final org.slf4j.Logger LOG = LoggerFactory
+            .getLogger(DelegatorProtocol.class);
+
+    static class Filter {
+
+        String key;
+        String value;
+
+        public Filter(String k, String v) {
+            key = k;
+            value = v;
+        }
+    }
+
+    static class FilteredProtocol {
+
+        final Protocol protoInstance;
+        final List<Filter> filters = new LinkedList<>();
+
+        Protocol getProtocolInstance() {
+            return protoInstance;
+        }
+
+        public FilteredProtocol(String protocolimplementation, Object f,
+                Config config) {
+            // load the protocol
+            Class protocolClass;
+            try {
+                protocolClass = Class.forName(protocolimplementation);
+                boolean interfaceOK = Protocol.class
+                        .isAssignableFrom(protocolClass);
+                if (!interfaceOK) {
+                    throw new RuntimeException("Class " + protocolimplementation
+                            + " does not implement Protocol");
+                }
+                this.protoInstance = (Protocol) protocolClass.newInstance();
+                this.protoInstance.configure(config);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(
+                        "Can't load class " + protocolimplementation);
+            } catch (InstantiationException e) {
+                throw new RuntimeException(
+                        "Can't instanciate class " + protocolimplementation);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("IllegalAccessException for class "
+                        + protocolimplementation);
+            }
+
+            // instantiate filters
+            if (f != null) {
+                if (f instanceof Map) {
+                    ((Map<String, String>) f).forEach((k, v) -> {
+                        filters.add(new Filter(k, v));
+                    });
+                } else {
+                    throw new RuntimeException("Can't instanciate filter " + f);
+                }
+            }
+
+            // log filters found
+            LOG.info("Loaded {} filters for {}", filters.size(),
+                    protocolimplementation);
+        }
+
+        public ProtocolResponse getProtocolOutput(String url, Metadata metadata)
+                throws Exception {
+            return protoInstance.getProtocolOutput(url, metadata);
+        }
+
+        public BaseRobotRules getRobotRules(String url) {
+            return protoInstance.getRobotRules(url);
+        }
+
+        public void cleanup() {
+            protoInstance.cleanup();
+        }
+
+        boolean isMatch(final Metadata metadata) {
+            // if this FP has no filters - it can handle anything
+            if (filters.isEmpty())
+                return true;
+
+            // check that all its filters are satisfied
+            for (Filter f : filters) {
+                if (f.value == null || f.value.equals("")) {
+                    // just interested in the fact that the key exists
+                    if (!metadata.containsKey(f.key)) {
+                        LOG.trace("Key {} not found in metadata {}", f.key,
+                                metadata);
+                        return false;
+                    }
+                } else {
+                    // interested in the value associated with the key
+                    if (!metadata.containsKeyWithValue(f.key, f.value)) {
+                        LOG.trace(
+                                "Key {} not found with value {} in metadata {}",
+                                f.key, f.value, metadata);
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+    }
+
+    private final LinkedList<FilteredProtocol> protocols = new LinkedList<>();
+
+    @Override
+    public void configure(Config conf) {
+        Object obj = conf.get(DELEGATOR_CONFIG_KEY);
+
+        if (obj == null)
+            throw new RuntimeException(
+                    "DelegatorProtocol declared but no config set for it");
+
+        // should contain a list of maps
+        // each map having a className and optionally a number of filters
+        if (obj instanceof Collection) {
+            for (Map subConf : (Collection<Map>) obj) {
+                String className = (String) subConf.get("className");
+                Object filters = subConf.get("filters");
+                protocols.add(new FilteredProtocol(className, filters, conf));
+            }
+        } else { // single value?
+            throw new RuntimeException(
+                    "DelegatorProtocol declared but single object found in config "
+                            + obj);
+        }
+
+        // check that the last protocol has no filter
+        if (!protocols.peekLast().filters.isEmpty()) {
+            throw new RuntimeException(
+                    "The last sub protocol has filters but must not as it acts as the default");
+        }
+
+    }
+
+    final FilteredProtocol getProtocolFor(String url, Metadata metadata) {
+
+        for (FilteredProtocol p : protocols) {
+            if (p.isMatch(metadata)) {
+                return p;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public BaseRobotRules getRobotRules(String url) {
+
+        FilteredProtocol proto = getProtocolFor(url, Metadata.empty);
+        if (proto == null) {
+            throw new RuntimeException(
+                    "No sub protocol eligible to retrieve robots");
+        }
+        return proto.getRobotRules(url);
+    }
+
+    @Override
+    public ProtocolResponse getProtocolOutput(String url, Metadata metadata)
+            throws Exception {
+
+        // go through the filtered protocols to find which one to use
+        FilteredProtocol proto = getProtocolFor(url, metadata);
+        if (proto == null) {
+            throw new RuntimeException("No sub protocol eligible to retrieve "
+                    + url + "given " + metadata.toString());
+        }
+        // execute and return protocol with url-meta combo
+        return proto.getProtocolOutput(url, metadata);
+    }
+
+    @Override
+    public void cleanup() {
+        for (FilteredProtocol p : protocols)
+            p.cleanup();
+    }
+
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/DelegatorRemoteDriverProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/DelegatorRemoteDriverProtocol.java
@@ -31,6 +31,8 @@ import crawlercommons.robots.BaseRobotRules;
  * to a different implementation if the URL does not have a value for the
  * protocol.use.selenium in its metadata. Allows to use Selenium for some of the
  * URLs only.
+ * 
+ * @deprecated use DelegatorProtocol instead
  **/
 public class DelegatorRemoteDriverProtocol extends RemoteDriverProtocol {
 

--- a/core/src/test/java/com/digitalpebble/stormcrawler/protocol/DelegationProtocolTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/protocol/DelegationProtocolTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.digitalpebble.stormcrawler.protocol;
+
+import java.io.FileNotFoundException;
+
+import org.apache.storm.Config;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.digitalpebble.stormcrawler.Metadata;
+import com.digitalpebble.stormcrawler.protocol.DelegatorProtocol.FilteredProtocol;
+import com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol;
+import com.digitalpebble.stormcrawler.util.ConfUtils;
+
+public class DelegationProtocolTest {
+
+    private static final String OKHTTP = "com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol";
+    private static final String APACHE = "com.digitalpebble.stormcrawler.protocol.httpclient.HttpProtocol";
+
+    @Test
+    public void getProtocolTest() throws FileNotFoundException {
+
+        Config conf = new Config();
+
+        ConfUtils.loadConf("src/test/resources/delegator-conf.yaml", conf);
+
+        conf.put("http.agent.name", "this.is.only.a.test");
+
+        DelegatorProtocol superProto = new DelegatorProtocol();
+        superProto.configure(conf);
+
+        // try single filter
+        // TODO use a protocol which doesnt require an actual connection when
+        // configured
+        Metadata meta = new Metadata();
+        meta.setValue("js", "true");
+
+        FilteredProtocol pf = superProto
+                .getProtocolFor("https://digitalpebble.com", meta);
+
+        Assert.assertEquals(pf.getProtocolInstance().getClass().getName(),
+                OKHTTP);
+
+        // no filter at all
+        meta = new Metadata();
+        pf = superProto.getProtocolFor("https://www.example.com/robots.txt",
+                meta);
+
+        Assert.assertEquals(pf.getProtocolInstance().getClass().getName(),
+                OKHTTP);
+
+        // should match the last instance
+        // as the one above has more than one filter
+        meta = new Metadata();
+        meta.setValue("domain", "example.com");
+
+        pf = superProto.getProtocolFor("https://example.com", meta);
+
+        Assert.assertEquals(pf.getProtocolInstance().getClass().getName(),
+                OKHTTP);
+
+        // everything should match
+        meta = new Metadata();
+        meta.setValue("test", "true");
+        meta.setValue("depth", "3");
+        meta.setValue("domain", "example.com");
+
+        pf = superProto.getProtocolFor("https://www.example-two.com", meta);
+
+        Assert.assertEquals(pf.getProtocolInstance().getClass().getName(),
+                APACHE);
+
+        // should not match
+        meta = new Metadata();
+        meta.setValue("test", "false");
+        meta.setValue("depth", "3");
+        meta.setValue("domain", "example.com");
+
+        pf = superProto.getProtocolFor("https://www.example-two.com", meta);
+
+        Assert.assertEquals(pf.getProtocolInstance().getClass().getName(),
+                OKHTTP);
+    }
+
+}

--- a/core/src/test/resources/delegator-conf.yaml
+++ b/core/src/test/resources/delegator-conf.yaml
@@ -1,0 +1,13 @@
+config: 
+
+  protocol.delegator.config:
+    - className: "com.digitalpebble.stormcrawler.protocol.httpclient.HttpProtocol"
+      filters:
+        domain: "example.com"
+        depth: "3"
+        test: "true"
+    - className: "com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol"
+      filters:
+        js: "true"
+    - className: "com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol"
+    


### PR DESCRIPTION
See #899 

Adds a protocol implementation which delegates calls to sub protocol implementations based on matches on key / values in the metadata.

Gets configured via the standard config mechanism without requiring any additional files e.g.

```
  protocol.delegator.config:
    - className: "com.digitalpebble.stormcrawler.protocol.httpclient.HttpProtocol"
      filters:
        domain: "example.com"
        depth: "3"
        test: "true"
    - className: "com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol"
      filters:
        js: "true"
    - className: "com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol"
 ```
 
 with each implementation being configured in the usual way. 
 
 The matches are tried in the order listed, the last implementation specified must not have any filters as it is used as the default value.
 A filter can have a _null_ or empty value, in which case only the presence of the key in the metadata will be needed.