### PR TITLE
ISSUE-909: ConcurrentModificationException for Metadata in StatusMetricsBolt

### DIFF
--- a/external/elasticsearch/archetype/src/main/resources/archetype-resources/es-crawler.flux
+++ b/external/elasticsearch/archetype/src/main/resources/archetype-resources/es-crawler.flux
@@ -66,11 +66,12 @@ streams:
     to: "partitioner"
     grouping:
       type: SHUFFLE
-      
-  - from: "spout"
+
+  - from: "__system"
     to: "status_metrics"
     grouping:
-      type: SHUFFLE     
+      type: SHUFFLE
+      streamId: "__tick"
 
   - from: "partitioner"
     to: "fetcher"


### PR DESCRIPTION
Changed es-crawler.flux to connect status-metrics bolt to the __system component using the __tick stream. This will avoid sending the complete tuple that is not being used and fix ConcurrentModificationException for Metadata class.

Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've applied the formatting used by the project with `mvn java-formatter:format`
* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'

Thanks!

