### PR TITLE
ES Status configuration : Can override discovered links

### DIFF
--- a/external/elasticsearch/archetype/src/main/resources/archetype-resources/es-conf.yaml
+++ b/external/elasticsearch/archetype/src/main/resources/archetype-resources/es-conf.yaml
@@ -30,6 +30,8 @@ config:
   es.status.bulkActions: 500
   es.status.flushInterval: "5s"
   es.status.concurrentRequests: 1
+  # Override discovered status
+  es.status.override: false
   
   ################
   # spout config #

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/StatusUpdaterBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/StatusUpdaterBolt.java
@@ -73,8 +73,11 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt implements
     private static final String ESStatusIndexNameParamName = "es.%s.index.name";
     private static final String ESStatusRoutingParamName = "es.%s.routing";
     private static final String ESStatusRoutingFieldParamName = "es.%s.routing.fieldname";
+    private static final String ESStatusOverrideParamName = "es.%s.override";
 
     private boolean routingFieldNameInMetadata = false;
+
+    private boolean overrideStatus = false;
 
     private String indexName;
 
@@ -121,6 +124,9 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt implements
 
         doRouting = ConfUtils.getBoolean(stormConf, String.format(
                 StatusUpdaterBolt.ESStatusRoutingParamName, ESBoltType), false);
+
+        overrideStatus = ConfUtils.getBoolean(stormConf, String.format(
+                StatusUpdaterBolt.ESStatusOverrideParamName, ESBoltType), false);
 
         partitioner = new URLPartitioner();
         partitioner.configure(stormConf);
@@ -196,7 +202,7 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt implements
         // check that we don't overwrite an existing entry
         // When create is used, the index operation will fail if a document
         // by that id already exists in the index.
-        boolean create = status.equals(Status.DISCOVERED);
+        boolean create = status.equals(Status.DISCOVERED) && !overrideStatus;
 
         builder.startObject("metadata");
         Iterator<String> mdKeys = metadata.keySet().iterator();


### PR DESCRIPTION
Add a parameter to override a link in status index with ES StatusUpdaterBolt. 

Context : our topologies _create_ in a filter's ParserBolt some links. Those links aren't in the DOM page, so the classic discover cannot be used. Also, they must not be refetch automatically, only when the filter create it, so the StatusUpdaterBolt have to override the previous fetched one.

Signed-off-by: Mathieu Bret <mikwiss00@gmail.com>

Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've applied the formatting used by the project with `mvn java-formatter:format`
* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'

Thanks!

