### PR TITLE
OkHttp protocol: make connection pool configurable

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -240,8 +240,8 @@ public class HttpProtocol extends AbstractHttpProtocol {
             LOG.info(
                     "Using connection pool with max. {} idle connections "
                             + "and {} sec. connection keep-alive time",
-                    time,
-                    size);
+                    size,
+                    time);
         }
 
         client = builder.build();

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -232,7 +232,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
         builder.addInterceptor(BrotliInterceptor.INSTANCE);
 
         Map<String, Object> connectionPoolConf =
-                (Map<String, Object>) conf.get("http.protocol.connection.pool");
+                (Map<String, Object>) conf.get("okhttp.protocol.connection.pool");
         if (connectionPoolConf != null) {
             int size = ConfUtils.getInt(connectionPoolConf, "max.idle.connections", 5);
             int time = ConfUtils.getInt(connectionPoolConf, "connection.keep.alive", 300);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -45,6 +45,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Call;
 import okhttp3.Connection;
+import okhttp3.ConnectionPool;
 import okhttp3.Credentials;
 import okhttp3.EventListener;
 import okhttp3.EventListener.Factory;
@@ -229,6 +230,19 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
         // enable support for Brotli compression (Content-Encoding)
         builder.addInterceptor(BrotliInterceptor.INSTANCE);
+
+        Map<String, Object> connectionPoolConf =
+                (Map<String, Object>) conf.get("http.protocol.connection.pool");
+        if (connectionPoolConf != null) {
+            int size = ConfUtils.getInt(connectionPoolConf, "max.idle.connections", 5);
+            int time = ConfUtils.getInt(connectionPoolConf, "connection.keep.alive", 300);
+            builder.connectionPool(new ConnectionPool(size, time, TimeUnit.SECONDS));
+            LOG.info(
+                    "Using connection pool with max. {} idle connections "
+                            + "and {} sec. connection keep-alive time",
+                    time,
+                    size);
+        }
 
         client = builder.build();
     }

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -137,8 +137,8 @@ config:
   # HTTP/2 over TCP
   ##- "h2c"
 
-  # HTTP connection pool configuration (okhttp only)
-  http.protocol.connection.pool:
+  # connection pool configuration of OkHttp protocol
+  okhttp.protocol.connection.pool:
     # maximum number of idle connections (in addition to active connections)
     max.idle.connections: 5
     # maximum keep-alive time of the connections in seconds

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -137,6 +137,20 @@ config:
   # HTTP/2 over TCP
   ##- "h2c"
 
+  # HTTP connection pool configuration (okhttp only)
+  http.protocol.connection.pool:
+    # maximum number of idle connections (in addition to active connections)
+    max.idle.connections: 5
+    # maximum keep-alive time of the connections in seconds
+    connection.keep.alive: 300
+  # See also
+  #   https://square.github.io/okhttp/3.x/okhttp/okhttp3/ConnectionPool.html
+  # Note that OkHttp's connection pool (v4.9.1) is not optimized for fast
+  # look-up of connections, the pool size (idle and active connections)
+  # should not exceed 1000. To allow for efficient pooling in large and
+  # diverse crawls, it's recommended to increase also the number of protocol
+  # instances, see `protocol.instance.num`.
+
   # key values obtained by the protocol can be prefixed
   # to avoid accidental overwrites. Note that persisted
   # or transferred protocol metadata must also be prefixed.


### PR DESCRIPTION
[OkHttp's ConnectionPool](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-connection-pool/) by default "holds up to 5 idle connections which will be evicted after 5 minutes of inactivity."  A pool of this size is suitable for site crawls but not for larger crawls over many different sites.

Note: in the current version (4.9.2) the connection pool is implemented as a [linked queue](https://github.com/square/okhttp/blob/parent-4.9.2/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnectionPool.kt#L83) and searching for a pooled connection does not scale up. In order to scale beyond pool sizes exceeding 1000 a set of clients must be used each with its own connection pool.

Notes:
- so far, only partially tested: need to increase the pool size and run a test crawl to measure the impact
- proxied connections are unchanged, that is, for every fetch a client is created anew and no connection pool is used.  Depending on the proxy manager, it could make sense to define a connection pool ahead and pass it to the [client builder](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/connection-pool/). Since proxy information is included in the [okhttp address](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-address/) (stored in the connection pool) it should be possible to pool proxied connections.
- the documentation could be moved from crawler-default.yaml to the wiki