### PR TITLE
OkHttp protocol: add support for Brotli compression (Content-Encoding)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -199,6 +199,11 @@
 			<artifactId>okhttp</artifactId>
 			<version>${okhttp.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp-brotli</artifactId>
+			<version>${okhttp.version}</version>
+		</dependency>
 
 	</dependencies>
 </project>

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -71,6 +71,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.Route;
+import okhttp3.brotli.BrotliInterceptor;
 import okio.BufferedSource;
 
 public class HttpProtocol extends AbstractHttpProtocol {
@@ -235,6 +236,9 @@ public class HttpProtocol extends AbstractHttpProtocol {
                 return new DNSResolutionListener(DNStimes);
             }
         });
+
+        // enable support for Brotli compression (Content-Encoding)
+        builder.addInterceptor(BrotliInterceptor.INSTANCE);
 
         client = builder.build();
     }


### PR DESCRIPTION
enables OkHttp's interceptor to handle [Brotli](https://en.wikipedia.org/wiki/Brotli) Content-Encoding