### PR TITLE
Upgrade to Tika 2.1.0

### DIFF
--- a/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -90,6 +90,9 @@ config:
    - application/.+powerpoint.*
    - application/.*pdf.*
 
+  # Tika parser configuration file
+  parse.tika.config.file: "tika-config.xml"
+
   # custom fetch interval to be used when a document has the key/value in its metadata
   # and has been fetched successfully (value in minutes)
   # fetchInterval.FETCH_ERROR.isFeed=true: 30

--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/JSoupParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/JSoupParserBolt.java
@@ -42,6 +42,7 @@ import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.detect.Detector;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.jsoup.nodes.Element;
 import org.jsoup.parser.Parser;
@@ -474,7 +475,7 @@ public class JSoupParserBolt extends StatusEmitterBolt {
         }
 
         // use full URL as a clue
-        metadata.set(org.apache.tika.metadata.Metadata.RESOURCE_NAME_KEY, URL);
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, URL);
 
         metadata.set(org.apache.tika.metadata.Metadata.CONTENT_LENGTH,
                 Integer.toString(content.length));

--- a/external/elasticsearch/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/external/elasticsearch/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -90,6 +90,9 @@ config:
    - application/.+powerpoint.*
    - application/.*pdf.*
 
+  # Tika parser configuration file
+  parse.tika.config.file: "tika-config.xml"
+
   # custom fetch interval to be used when a document has the key/value in its metadata
   # and has been fetched successfully (value in minutes)
   # fetchInterval.FETCH_ERROR.isFeed=true: 30

--- a/external/tika/README.md
+++ b/external/tika/README.md
@@ -7,7 +7,7 @@ To use it alongside the JSoup parser i.e. let JSoup handle HTML content and Tika
 The next step is to use a [RedirectionBolt](https://github.com/DigitalPebble/storm-crawler/blob/master/external/tika/src/main/java/com/digitalpebble/stormcrawler/tika/RedirectionBolt.java) to send documents which have not been parsed with Jsoup to Tika on a bespoke stream called `tika`, finally the IndexingBolt needs to be connected to the outputs of both `shunt` and `tika` on the default stream. `tika` must also be connected to the StatusUpdaterBolt on the _status_ stream.
 
 ```
- builder.setBolt("jsoup", new JSoupParserBolt()).localOrShuffleGrouping(
+  builder.setBolt("jsoup", new JSoupParserBolt()).localOrShuffleGrouping(
           "sitemap");
   
   builder.setBolt("shunt", new RedirectionBolt()).localOrShuffleGrouping("jsoup");
@@ -29,4 +29,6 @@ The next step is to use a [RedirectionBolt](https://github.com/DigitalPebble/sto
   - application/.*pdf.*
  ```
  
- 
+## Configure Tika
+
+The Tika parser bolt loads a Tika configuration file from the Java classpath. The default file name (path) is `tika-config.xml` and can be changed by the configuration `parser.tika.config.file`. See [configuring Tika](https://tika.apache.org/2.1.0/configuring.html) and the default configuration file [tika-config.xml](./src/main/resources/tika-config.xml).

--- a/external/tika/pom.xml
+++ b/external/tika/pom.xml
@@ -23,7 +23,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.tika</groupId>
-			<artifactId>tika-parsers</artifactId>
+			<artifactId>tika-parsers-standard-package</artifactId>
 			<version>${tika.version}</version>
 			<exclusions>
 				<exclusion>

--- a/external/tika/src/main/java/com/digitalpebble/stormcrawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/com/digitalpebble/stormcrawler/tika/ParserBolt.java
@@ -40,6 +40,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 import org.apache.tika.Tika;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.html.HtmlMapper;
@@ -210,8 +211,7 @@ public class ParserBolt extends BaseRichBolt {
         // as well as the filename
         try {
             URL _url = new URL(url);
-            md.set(org.apache.tika.metadata.Metadata.RESOURCE_NAME_KEY,
-                    _url.getFile());
+            md.set(TikaCoreProperties.RESOURCE_NAME_KEY, _url.getFile());
         } catch (MalformedURLException e1) {
             throw new IllegalStateException("Malformed URL", e1);
         }

--- a/external/tika/src/main/java/com/digitalpebble/stormcrawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/com/digitalpebble/stormcrawler/tika/ParserBolt.java
@@ -21,6 +21,7 @@ import static com.digitalpebble.stormcrawler.Constants.StatusStreamName;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -40,6 +41,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 import org.apache.tika.Tika;
+import org.apache.tika.config.TikaConfig;
 import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
@@ -141,12 +143,7 @@ public class ParserBolt extends BaseRichBolt {
         protocolMDprefix = ConfUtils.getString(conf,
                 ProtocolResponse.PROTOCOL_MD_PREFIX_PARAM, "");
 
-        // instantiate Tika
-        long start = System.currentTimeMillis();
-        tika = new Tika();
-        long end = System.currentTimeMillis();
-
-        LOG.debug("Tika loaded in {} msec", end - start);
+        tika = instantiateTika(conf);
 
         this.collector = collector;
 
@@ -316,6 +313,31 @@ public class ParserBolt extends BaseRichBolt {
 
         collector.ack(tuple);
         eventCounter.scope("tuple_success").incrBy(1);
+    }
+
+    private Tika instantiateTika(Map<String, Object> conf) {
+        Tika tika = null;
+        String tikaConfigFile = ConfUtils.getString(conf, "parser.tika.config.file", "tika-config.xml");
+        long start = System.currentTimeMillis();
+        URL tikaConfigUrl = getClass().getClassLoader().getResource(tikaConfigFile);
+        if (tikaConfigUrl == null) {
+            LOG.error("Tika configuration file {} not found on classpath", tikaConfigFile);
+        } else {
+            LOG.info("Instantiating Tika using custom configuration {}", tikaConfigUrl);
+            try {
+                TikaConfig tikaConfig = new TikaConfig(tikaConfigUrl, getClass().getClassLoader());
+                tika = new Tika(tikaConfig);
+            } catch (Exception e) {
+                LOG.error("Failed to instantiate Tika using custom configuration {}", tikaConfigUrl, e);
+            }
+        }
+        if (tika == null) {
+            LOG.info("Instantiating Tika with default configuration");
+            tika = new Tika();
+        }
+        long end = System.currentTimeMillis();
+        LOG.debug("Tika loaded in {} msec", end - start);
+        return tika;
     }
 
     private void handleException(String url, Throwable e, Metadata metadata,

--- a/external/tika/src/main/java/com/digitalpebble/stormcrawler/tika/RedirectionBolt.java
+++ b/external/tika/src/main/java/com/digitalpebble/stormcrawler/tika/RedirectionBolt.java
@@ -19,7 +19,6 @@ package com.digitalpebble.stormcrawler.tika;
 
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;

--- a/external/tika/src/main/resources/tika-config.xml
+++ b/external/tika/src/main/resources/tika-config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<properties>
+
+    <!-- suppress Tika warnings on stderr -->
+    <service-loader initializableProblemHandler="ignore" loadErrorHandler="warn" />
+
+    <!-- disable TesseractOCRParser (it's enabled by default in Tika) -->
+    <parsers>
+        <parser class="org.apache.tika.parser.DefaultParser">
+            <parser-exclude class="org.apache.tika.parser.ocr.TesseractOCRParser"/>
+        </parser>
+        <parser class="org.apache.tika.parser.CompositeParser">
+            <parser-exclude class="org.apache.tika.parser.ocr.TesseractOCRParser"/>
+        </parser>
+    </parsers>
+</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<junit.version>4.13.2</junit.version>
 		<storm-client.version>2.3.0</storm-client.version>
 		<jackson-databind.version>2.11.1</jackson-databind.version>
-		<tika.version>1.27</tika.version>
+		<tika.version>2.1.0</tika.version>
 		<mockito.version>3.7.7</mockito.version>
 	</properties>
 


### PR DESCRIPTION
based on "tika-parsers-standard-package" (no extended and scientific parsers)

Open questions:
- add a tika-config.xml and disable OCR on images? Tika 2.x enables OCR by default Which may slow down the tika parser significantly in case Tesseract is installed on the system, see https://cwiki.apache.org/confluence/display/tika/tikaocr

See also:
  https://cwiki.apache.org/confluence/display/TIKA/Migrating+to+Tika+2.0.0