### PR TITLE
Allow to set http.content.limit per page in metadata

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpRobotRulesParser.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpRobotRulesParser.java
@@ -41,6 +41,8 @@ public class HttpRobotRulesParser extends RobotRulesParser {
 
     protected boolean allowForbidden = false;
 
+    protected Metadata fetchRobotsMd;
+
     HttpRobotRulesParser() {
     }
 
@@ -53,6 +55,12 @@ public class HttpRobotRulesParser extends RobotRulesParser {
         super.setConf(conf);
         allowForbidden = ConfUtils.getBoolean(conf, "http.robots.403.allow",
                 true);
+        fetchRobotsMd = new Metadata();
+        /* http.content.limit for fetching the robots.txt */
+        int robotsTxtContentLimit = ConfUtils.getInt(conf,
+                "http.robots.content.limit", 524288);
+        fetchRobotsMd.addValue("http.content.limit",
+                Integer.toString(robotsTxtContentLimit));
     }
 
     /**
@@ -127,7 +135,7 @@ public class HttpRobotRulesParser extends RobotRulesParser {
         List<Integer> bytesFetched = new LinkedList<>();
         try {
             ProtocolResponse response = http.getProtocolOutput(new URL(url,
-                    "/robots.txt").toString(), Metadata.empty);
+                    "/robots.txt").toString(), fetchRobotsMd);
             int code = response.getStatusCode();
             bytesFetched.add(response.getContent() != null ? response
                     .getContent().length : 0);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpRobotRulesParser.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpRobotRulesParser.java
@@ -58,7 +58,7 @@ public class HttpRobotRulesParser extends RobotRulesParser {
         fetchRobotsMd = new Metadata();
         /* http.content.limit for fetching the robots.txt */
         int robotsTxtContentLimit = ConfUtils.getInt(conf,
-                "http.robots.content.limit", 524288);
+                "http.robots.content.limit", -1);
         fetchRobotsMd.addValue("http.content.limit",
                 Integer.toString(robotsTxtContentLimit));
     }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
@@ -79,7 +79,7 @@ public class HttpProtocol extends AbstractHttpProtocol implements
 
     private static final PoolingHttpClientConnectionManager CONNECTION_MANAGER = new PoolingHttpClientConnectionManager();
 
-    private int maxContent;
+    private int globalMaxContent;
 
     private HttpClientBuilder builder;
 
@@ -103,7 +103,7 @@ public class HttpProtocol extends AbstractHttpProtocol implements
         }
         CONNECTION_MANAGER.setDefaultMaxPerRoute(maxPerRoute);
 
-        this.maxContent = ConfUtils.getInt(conf, "http.content.limit", -1);
+        globalMaxContent = ConfUtils.getInt(conf, "http.content.limit", -1);
 
         String userAgent = getAgentString(conf);
 
@@ -279,7 +279,7 @@ public class HttpProtocol extends AbstractHttpProtocol implements
     @Override
     public ProtocolResponse handleResponse(HttpResponse response)
             throws IOException {
-        return handleResponseWithContentLimit(response, maxContent);
+        return handleResponseWithContentLimit(response, globalMaxContent);
     }
 
     public ProtocolResponse handleResponseWithContentLimit(

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -84,7 +84,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
     private OkHttpClient client;
 
-    private int maxContent;
+    private int globalMaxContent;
 
     private int completionTimeout = -1;
 
@@ -134,7 +134,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
     public void configure(Config conf) {
         super.configure(conf);
 
-        this.maxContent = ConfUtils.getInt(conf, "http.content.limit", -1);
+        globalMaxContent = ConfUtils.getInt(conf, "http.content.limit", -1);
 
         int timeout = ConfUtils.getInt(conf, "http.timeout", 10000);
 
@@ -306,7 +306,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
             rb.header(k.getKey(), k.getValue());
         });
 
-        int pageMaxContent = maxContent;
+        int pageMaxContent = globalMaxContent;
 
         if (metadata != null) {
             String lastModified = metadata

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -306,6 +306,8 @@ public class HttpProtocol extends AbstractHttpProtocol {
             rb.header(k.getKey(), k.getValue());
         });
 
+        int pageMaxContent = maxContent;
+
         if (metadata != null) {
             String lastModified = metadata
                     .getFirstValue(HttpHeaders.LAST_MODIFIED);
@@ -329,6 +331,15 @@ public class HttpProtocol extends AbstractHttpProtocol {
                     .getFirstValue("http.accept.language");
             if (StringUtils.isNotBlank(acceptLanguage)) {
                 rb.header("Accept-Language", acceptLanguage);
+            }
+
+            String pageMaxContentStr = metadata.getFirstValue("http.content.limit");
+            if (StringUtils.isNotBlank(pageMaxContentStr)) {
+                try {
+                    pageMaxContent = Integer.parseInt(pageMaxContentStr);
+                } catch (NumberFormatException e) {
+                    LOG.warn("Invalid http.content.limit in metadata: {}", pageMaxContentStr);
+                }
             }
 
             if (useCookies) {
@@ -372,7 +383,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
             MutableObject trimmed = new MutableObject(
                     TrimmedContentReason.NOT_TRIMMED);
-            bytes = toByteArray(response.body(), trimmed);
+            bytes = toByteArray(response.body(), pageMaxContent, trimmed);
             if (trimmed.getValue() != TrimmedContentReason.NOT_TRIMMED) {
                 if (!call.isCanceled()) {
                     call.cancel();
@@ -397,7 +408,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
     }
 
     private final byte[] toByteArray(final ResponseBody responseBody,
-            MutableObject trimmed) throws IOException {
+            int maxContent, MutableObject trimmed) throws IOException {
 
         if (responseBody == null) {
             return new byte[] {};

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -107,7 +107,8 @@ config:
   # http.content.limit when fetching the robots.txt
   # (the robots.txt RFC draft requires to fetch and parse at least 500 kiB,
   #  see https://datatracker.ietf.org/doc/html/draft-rep-wg-topic-00#section-2.5)
-  http.robots.content.limit: 524288
+  # http.robots.content.limit: 524288  # 512 kiB
+  http.robots.content.limit: -1  # default same as http.content.limit
 
   # Guava caches used for the robots.txt directives 
   robots.cache.spec: "maximumSize=10000,expireAfterWrite=6h"

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -103,7 +103,12 @@ config:
 
   # should the URLs be removed when a page is marked as noFollow
   robots.noFollow.strict: true
-  
+
+  # http.content.limit when fetching the robots.txt
+  # (the robots.txt RFC draft requires to fetch and parse at least 500 kiB,
+  #  see https://datatracker.ietf.org/doc/html/draft-rep-wg-topic-00#section-2.5)
+  http.robots.content.limit: 524288
+
   # Guava caches used for the robots.txt directives 
   robots.cache.spec: "maximumSize=10000,expireAfterWrite=6h"
   robots.error.cache.spec: "maximumSize=10000,expireAfterWrite=1h"


### PR DESCRIPTION
Add property `http.robots.content.limit` to configure the robots.txt content limit independent from `http.content.limit`
- fixes #921 "http.content.limit has effect on robots.txt"
- default is 512 kiB to follow the [robots.txt RFC draft](https://datatracker.ietf.org/doc/html/draft-rep-wg-topic-00#section-2.5)