### PR TITLE
Support HEAD method in okhttp protocol

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -337,8 +337,13 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
             String postJSONData = metadata.getFirstValue("http.post.json");
             if (StringUtils.isNotBlank(postJSONData)) {
-                RequestBody body = RequestBody.create(JSON, postJSONData);
+                RequestBody body = RequestBody.create(postJSONData, JSON);
                 rb.post(body);
+            }
+
+            String useHead = metadata.getFirstValue("http.method.head");
+            if ("true".equalsIgnoreCase(useHead)) {
+                rb.head();
             }
         }
 


### PR DESCRIPTION
- send HEAD request if `http.method.head` is in page metadata and is true
- ports the behavior of #485 to the okhttp-based protocol implementation
- fix deprecation warning in POST method