### PR TITLE
Remove static keyword on JSoupFilters field

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/JSoupFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/JSoupFilters.java
@@ -59,7 +59,7 @@ public class JSoupFilters extends JSoupFilter implements JSONResource {
 		filters = new JSoupFilter[0];
 	}
 
-	public static String configFile = "jsoup.filters.config.file";
+	private String configFile;
 
 	private Map stormConf;
 
@@ -69,7 +69,7 @@ public class JSoupFilters extends JSoupFilter implements JSONResource {
 	 **/
 	@SuppressWarnings("rawtypes")
 	public static JSoupFilters fromConf(Map stormConf) {
-		String parseconfigfile = ConfUtils.getString(stormConf, configFile);
+		String parseconfigfile = ConfUtils.getString(stormConf,"jsoup.filters.config.file");
 		if (StringUtils.isNotBlank(parseconfigfile)) {
 			try {
 				return new JSoupFilters(stormConf, parseconfigfile);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/ParseFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/ParseFilters.java
@@ -61,7 +61,7 @@ public class ParseFilters extends ParseFilter implements JSONResource {
         filters = new ParseFilter[0];
     }
 
-    private String configFile = "parsefilters.config.file";
+    private String configFile;
 
     private Map stormConf;
 


### PR DESCRIPTION
Fixed issue #925 

Removed the static field into JSoupFilters. Also, removed the never used _configFile_ value into ParserFilters.

Signed-off-by: Mathieu Bret <mikwiss00@gmail.com>