### PR TITLE
Upgrade to log4j 2.17.0, fixes #935

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -96,6 +96,22 @@
 			<groupId>org.apache.storm</groupId>
 			<artifactId>storm-client</artifactId>
 		</dependency>
+		<!-- dependency overrides for vulnerable log4j versions -->
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j2.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j2.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>${log4j2.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.tika</groupId>

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -49,6 +49,22 @@
 			<groupId>org.apache.storm</groupId>
 			<artifactId>storm-client</artifactId>
 		</dependency>
+		<!-- dependency overrides for vulnerable log4j versions -->
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j2.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j2.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>${log4j2.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
 		<jackson-databind.version>2.11.1</jackson-databind.version>
 		<tika.version>2.1.0</tika.version>
 		<mockito.version>3.7.7</mockito.version>
+		<log4j2.version>2.17.0</log4j2.version>
 	</properties>
 
 	<distributionManagement>
@@ -136,6 +137,43 @@
 						<skipRemovingUnusedImports>false</skipRemovingUnusedImports>
 					</googleJavaFormatOptions>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<id>enforce-maven</id>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>3.5</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>exclude-vulnerable-log4j-versions</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<bannedDependencies>
+									<excludes>
+										<exclude>org.apache.logging.log4j:log4j-core:(,2.17.0)</exclude>
+									</excludes>
+								</bannedDependencies>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Enforce usage of 2.17.0 as minimum log4j-core version in all modules. If storm-client is upgraded and depends on a safe log4j version, we can remove the log4j dependency from sc.