### PR TITLE
Improve Metadata, add Tests and stabilize serialisation

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/ConfigurableTopology.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/ConfigurableTopology.java
@@ -32,9 +32,10 @@ public abstract class ConfigurableTopology {
 
     protected Config conf = new Config();
 
-    public static void start(ConfigurableTopology topology, String args[]) {
+    public static void start(ConfigurableTopology topology, String[] args) {
         // loads the default configuration file
-        Map defaultSCConfig = Utils.findAndReadConfigFile("crawler-default.yaml", false);
+        Map<String, Object> defaultSCConfig =
+                Utils.findAndReadConfigFile("crawler-default.yaml", false);
         topology.conf.putAll(ConfUtils.extractConfigElement(defaultSCConfig));
 
         String[] remainingArgs = topology.parse(args);
@@ -45,7 +46,7 @@ public abstract class ConfigurableTopology {
         return conf;
     }
 
-    protected abstract int run(String args[]);
+    protected abstract int run(String[] args);
 
     /** Submits the topology with the name taken from the configuration * */
     protected int submit(Config conf, TopologyBuilder builder) {
@@ -71,7 +72,7 @@ public abstract class ConfigurableTopology {
         return 0;
     }
 
-    private String[] parse(String args[]) {
+    private String[] parse(String[] args) {
 
         List<String> newArgs = new ArrayList<>();
         Collections.addAll(newArgs, args);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/Metadata.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/Metadata.java
@@ -14,105 +14,130 @@
  */
 package com.digitalpebble.stormcrawler;
 
-import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.StringArraySerializer;
-import com.esotericsoftware.kryo.serializers.DefaultSerializers.StringSerializer;
-import com.esotericsoftware.kryo.serializers.MapSerializer.BindMap;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.ConcurrentModificationException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import static java.util.Collections.EMPTY_MAP;
+
+import com.digitalpebble.stormcrawler.util.MetadataKryoSerializer;
+import com.esotericsoftware.kryo.DefaultSerializer;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import org.apache.commons.lang.StringUtils;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 /** Wrapper around Map &lt;String,String[]&gt; * */
+@DefaultSerializer(MetadataKryoSerializer.class)
 public class Metadata {
 
-    // customize the behaviour of Kryo via annotations
-    @BindMap(
-            valueSerializer = StringArraySerializer.class,
-            keySerializer = StringSerializer.class,
-            valueClass = String[].class,
-            keyClass = String.class,
-            keysCanBeNull = false)
-    private Map<String, String[]> md;
+    // The content of the metadata
+    private final @NotNull Map<@NotNull String, String @NotNull []> map;
 
-    public static final Metadata empty = new Metadata(Collections.<String, String[]>emptyMap());
-
-    public Metadata() {
-        md = new HashMap<>();
-    }
-
+    // Make it transient to protect from serialisation.
     private transient boolean locked = false;
 
-    /** Wraps an existing HashMap into a Metadata object - does not clone the content */
-    public Metadata(Map<String, String[]> metadata) {
-        if (metadata == null) throw new NullPointerException();
-        md = metadata;
+    /** An empty Metadata instance, readonly. */
+    @NotNull @Unmodifiable
+    public static final Metadata EMPTY_METADATA = new Metadata(Collections.emptyMap());
+
+    /**
+     * An empty Metadata instance, readonly.
+     *
+     * @deprecated use {@link Metadata#EMPTY_METADATA} or {@link Metadata#emptyMetadata()} instead.
+     */
+    @Deprecated @NotNull @Unmodifiable public static final Metadata empty = EMPTY_METADATA;
+
+    /** An empty Metadata instance, readonly. */
+    @NotNull
+    @Unmodifiable
+    @Contract(pure = true)
+    public static Metadata emptyMetadata() {
+        return EMPTY_METADATA;
     }
 
-    /** Puts all the metadata into the current instance * */
-    public void putAll(Metadata m) {
-        checkLockException();
+    /** Initializes an empty instance. */
+    public Metadata() {
+        this.map = new HashMap<>();
+    }
 
-        md.putAll(m.md);
+    /** Wraps an existing Map into a Metadata object - does not clone the content */
+    public Metadata(final @NotNull Map<String, String[]> map) {
+        this(map, false);
     }
 
     /**
-     * Puts all prefixed metadata into the current instance
-     *
-     * @param m metadata to be added
-     * @param prefix string to prefix keys in m before adding them to the current metadata. No
-     *     separator is inserted between prefix and original key, so the prefix must include any
-     *     separator (eg. a dot)
+     * Wraps an existing HashMap into a Metadata object if {@code clone} is false. Otherwise it
+     * creates a deep copy of the map.
      */
-    public void putAll(Metadata m, String prefix) {
-        if (prefix == null || prefix.isEmpty()) {
-            putAll(m);
-            return;
+    public Metadata(final @NotNull Map<String, String[]> map, final boolean clone) {
+        Objects.requireNonNull(map);
+        if (clone) {
+            this.map =
+                    map.entrySet().stream()
+                            .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().clone()));
+        } else {
+            this.map = map;
         }
-
-        Map<String, String[]> ma = m.asMap();
-        ma.forEach(
-                (k, v) -> {
-                    setValues(prefix + k, v);
-                });
     }
 
-    /** @return the first value for the key or null if it does not exist * */
-    public String getFirstValue(String key) {
-        String[] values = md.get(key);
-        if (values == null) return null;
-        if (values.length == 0) return null;
+    /** Returns true if this instance is locked by the serializer. */
+    public boolean isLocked() {
+        return locked;
+    }
+
+    /** Returns true if the instance has a {@link Collections#EMPTY_MAP} as backing map. */
+    public boolean isReadOnly() {
+        return this.map == EMPTY_MAP;
+    }
+
+    /** Returns the first value for the key or null if it does not exist */
+    @Contract(pure = true)
+    @Nullable
+    public String getFirstValue(@NotNull String key) {
+        String[] values = map.get(key);
+        if (values == null || values.length == 0) return null;
         return values[0];
     }
 
-    /** @return the first value for the key or null if it does not exist, given a prefix */
-    public String getFirstValue(String key, String prefix) {
-        if (prefix == null || prefix.length() == 0) return getFirstValue(key);
+    /** Returns the first value for the key or null if it does not exist, given a prefix */
+    @Contract(pure = true)
+    @Nullable
+    public String getFirstValue(@NotNull String key, @Nullable String prefix) {
+        if (isNullOrEmpty(prefix)) return getFirstValue(key);
         return getFirstValue(prefix + key);
     }
 
-    public String[] getValues(String key, String prefix) {
-        if (prefix == null || prefix.length() == 0) return getValues(key);
+    /**
+     * Returns the array of values for the given {@code key} and {@code prefix} by calling {@code
+     * getValues(prefix+key)} It ignores the prefix if it is null or empty.
+     */
+    @Contract(pure = true)
+    public String[] getValues(@NotNull String key, @Nullable String prefix) {
+        if (isNullOrEmpty(prefix)) return getValues(key);
         return getValues(prefix + key);
     }
 
-    public String[] getValues(String key) {
-        String[] values = md.get(key);
-        if (values == null) return null;
-        if (values.length == 0) return null;
+    /** Returns the array of values for the given {@code key}. */
+    @Contract(pure = true)
+    public String[] getValues(@NotNull String key) {
+        String[] values = map.get(key);
+        if (values == null || values.length == 0) return null;
         return values;
     }
 
-    public boolean containsKey(String key) {
-        return md.containsKey(key);
+    /**
+     * Returns true if this Metadata contains the given {@code key}.
+     *
+     * @throws NullPointerException if the {@code key} is null.
+     */
+    @Contract(pure = true)
+    public boolean containsKey(@NotNull String key) {
+        return map.containsKey(key);
     }
 
-    public boolean containsKeyWithValue(String key, String value) {
+    /** Returns true if the {@code key} points to an array containing the provided {@code value}. */
+    @Contract(pure = true)
+    public boolean containsKeyWithValue(@NotNull String key, @Nullable String value) {
         String[] values = getValues(key);
         if (values == null) return false;
         for (String s : values) {
@@ -121,72 +146,156 @@ public class Metadata {
         return false;
     }
 
-    /** Set the value for a given key. The value can be null. */
-    public void setValue(String key, String value) {
-        checkLockException();
-
-        md.put(key, new String[] {value});
+    /** Internal set method without safety check. */
+    @Contract(mutates = "this")
+    private String[] putValueInternal(@NotNull String key, @Nullable String value) {
+        return map.put(key, new String[] {value});
     }
 
-    public void setValues(String key, String[] values) {
+    /** Internal set method without safety check. */
+    @Contract(mutates = "this")
+    private void putValuesInternal(@NotNull String key, String[] values) {
+        if (values == null || values.length == 0) return;
+        map.put(key, values.clone());
+    }
+
+    /** Internal put method without safety check. */
+    @Contract(mutates = "this")
+    private void putAllInternal(@NotNull Map<String, String[]> mapToPut) {
+        if (mapToPut.isEmpty()) return;
+
+        for (Map.Entry<String, String[]> entry : mapToPut.entrySet()) {
+            putValuesInternal(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Puts all the entries of {@code mapToPut} into the current instance, overrides potentially
+     * existing keys.
+     */
+    @Contract(mutates = "this")
+    public void putAll(@NotNull Map<String, String[]> mapToPut) {
+        checkLockException();
+        putAllInternal(mapToPut);
+    }
+
+    /**
+     * Puts all the entries of {@code mapToPut} into the current instance with the provided prefix,
+     * overrides potentially existing keys.
+     */
+    @Contract(mutates = "this")
+    public void putAll(@NotNull Map<String, String[]> mapToPut, @Nullable String prefix) {
+        checkLockException();
+
+        if (isNullOrEmpty(prefix)) {
+            putAllInternal(mapToPut);
+        } else {
+            for (Map.Entry<String, String[]> entry : mapToPut.entrySet()) {
+                putValuesInternal(prefix + entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    /** Puts all the metadata into the current instance, overrides potentially existing keys. */
+    @Contract(mutates = "this")
+    public void putAll(@NotNull Metadata metadata) {
+        putAll(metadata.map);
+    }
+
+    /**
+     * Puts all prefixed metadata into the current instance, overrides potentially existing keys.
+     *
+     * @param metadata metadata to be added
+     * @param prefix string to prefix keys in metadata before adding them to the current metadata.
+     *     No separator is inserted between prefix and original key, so the prefix must include any
+     *     separator (eg. a dot)
+     */
+    @Contract(mutates = "this")
+    public void putAll(@NotNull Metadata metadata, @Nullable String prefix) {
+        putAll(metadata.map, prefix);
+    }
+
+    /**
+     * Sets the value for a given key and discards the old value. The new value can be null.
+     *
+     * @return the previous value associated with key, or null if there was no mapping for key. (A
+     *     null return can also indicate that the map previously associated null with key, if the
+     *     implementation supports null values.)
+     */
+    @Contract(mutates = "this")
+    public String[] setValue(@NotNull String key, @Nullable String value) {
+        checkLockException();
+        return putValueInternal(key, value);
+    }
+
+    /** Set the value for a given key. The value can be null. */
+    @Contract(mutates = "this")
+    public void setValues(@NotNull String key, String[] values) {
+        checkLockException();
+        putValuesInternal(key, values);
+    }
+
+    /** Add or set the value for a given key. The value can be null. */
+    @Contract(mutates = "this")
+    public void addValue(@NotNull String key, @Nullable String value) {
+        checkLockException();
+
+        String[] existingValues = map.get(key);
+        if (existingValues == null || existingValues.length == 0) {
+            putValueInternal(key, value);
+        } else {
+            map.put(key, concat(existingValues, value));
+        }
+    }
+
+    /** Add or set the value for a given key. The values can be null. */
+    @Contract(mutates = "this")
+    public void addValues(@NotNull String key, String[] values) {
         checkLockException();
 
         if (values == null || values.length == 0) return;
-        md.put(key, values);
+
+        String[] existingValues = map.get(key);
+        if (existingValues == null) {
+            putValuesInternal(key, values.clone());
+        } else {
+            map.put(key, concat(existingValues, values));
+        }
     }
 
-    public void addValue(String key, String value) {
-        checkLockException();
+    /** Add or set the value for a given key. The value can be null. */
+    @Contract(mutates = "this")
+    public void addValues(@NotNull String key, @Nullable Collection<String> values) {
+        String[] toAdd;
 
-        if (StringUtils.isBlank(value)) return;
-
-        String[] existingvals = md.get(key);
-        if (existingvals == null || existingvals.length == 0) {
-            setValue(key, value);
-            return;
+        if (values == null || values.isEmpty()) {
+            toAdd = null;
+        } else {
+            toAdd = values.toArray(new String[0]);
         }
 
-        int currentLength = existingvals.length;
-        String[] newvals = new String[currentLength + 1];
-        newvals[currentLength] = value;
-        System.arraycopy(existingvals, 0, newvals, 0, currentLength);
-        md.put(key, newvals);
-    }
-
-    public void addValues(String key, Collection<String> values) {
-        checkLockException();
-
-        if (values == null || values.size() == 0) return;
-        String[] existingvals = md.get(key);
-        if (existingvals == null) {
-            md.put(key, values.toArray(new String[0]));
-            return;
-        }
-
-        ArrayList<String> existing = new ArrayList<>(existingvals.length + values.size());
-        Collections.addAll(existing, existingvals);
-
-        existing.addAll(values);
-        md.put(key, existing.toArray(new String[0]));
+        addValues(key, toAdd);
     }
 
     /** @return the previous value(s) associated with <tt>key</tt> */
-    public String[] remove(String key) {
+    @Contract(mutates = "this")
+    @NotNull
+    public String[] remove(@NotNull String key) {
         checkLockException();
-        return md.remove(key);
+        return map.remove(key);
     }
 
+    @NotNull
     public String toString() {
         return toString("");
     }
 
     /** Returns a String representation of the metadata with one K/V per line */
+    @NotNull
     public String toString(String prefix) {
         StringBuilder sb = new StringBuilder();
         if (prefix == null) prefix = "";
-        Iterator<Entry<String, String[]>> iter = md.entrySet().iterator();
-        while (iter.hasNext()) {
-            Entry<String, String[]> entry = iter.next();
+        for (Entry<String, String[]> entry : map.entrySet()) {
             for (String val : entry.getValue()) {
                 sb.append(prefix).append(entry.getKey()).append(": ").append(val).append("\n");
             }
@@ -194,27 +303,72 @@ public class Metadata {
         return sb.toString();
     }
 
+    /** Returns the size of the keys in this */
     public int size() {
-        return md.size();
+        return map.size();
     }
 
-    public Set<String> keySet() {
-        return md.keySet();
+    /** Returns a set of all keys of this instance */
+    @NotNull
+    public Set<@Nullable String> keySet() {
+        return map.keySet();
     }
 
-    /** Returns the first non empty value found for the keys or null if none found. */
-    public static String getFirstValue(Metadata md, String... keys) {
+    /** Returns the first non-empty value found for the keys or null if none found. */
+    @Nullable
+    public static String getFirstValue(@NotNull Metadata md, String... keys) {
         for (String key : keys) {
             String val = md.getFirstValue(key);
-            if (StringUtils.isBlank(val)) continue;
-            return val;
+            if (!isNullOrEmpty(val)) return val;
         }
         return null;
     }
 
-    /** Returns the underlying Map * */
+    /**
+     * Returns the underlying Map
+     *
+     * @deprecated replace with getMap, getShallowCopyOfMap or getDeepCopyOfMap.
+     */
+    @Deprecated
+    @NotNull
     public Map<String, String[]> asMap() {
-        return md;
+        return map;
+    }
+
+    /** Returns the underlying map. */
+    @NotNull
+    public Map<String, String[]> getMap() {
+        return map;
+    }
+
+    /**
+     * Get a deep copy of the underlying map. Changes to the keys and values are not changing the
+     * original metadata.
+     */
+    @NotNull
+    public Map<String, String[]> createDeepCopyOfMap() {
+        return map.entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().clone()));
+    }
+
+    /**
+     * Creates a plain copy of this with the same underlying map. Therefor all changes done to the
+     * new instance are also done to the origin metadata
+     *
+     * @return a copy of this
+     */
+    @NotNull
+    public Metadata copy() {
+        return new Metadata(map);
+    }
+
+    /**
+     * Get a deep copy of this. Changes to the keys and values are not changing the original
+     * metadata.
+     */
+    @NotNull
+    public Metadata copyDeep() {
+        return new Metadata(createDeepCopyOfMap());
     }
 
     /**
@@ -227,6 +381,8 @@ public class Metadata {
      *
      * @since 1.16
      */
+    @Contract(" -> this")
+    @NotNull
     public Metadata lock() {
         locked = true;
         return this;
@@ -237,9 +393,35 @@ public class Metadata {
      *
      * @since 1.16
      */
+    @Contract(" -> this")
+    @NotNull
     public Metadata unlock() {
         locked = false;
         return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Metadata)) return false;
+        Metadata metadata = (Metadata) o;
+
+        for (Entry<String, String[]> stringEntry : map.entrySet()) {
+            if (!metadata.map.containsKey(stringEntry.getKey())) {
+                return false;
+            }
+            String[] otherValue = metadata.map.get(stringEntry.getKey());
+            if (!Arrays.equals(stringEntry.getValue(), otherValue)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(map);
     }
 
     /** @since 1.16 */
@@ -247,5 +429,29 @@ public class Metadata {
         if (locked)
             throw new ConcurrentModificationException(
                     "Attempt to modify a metadata after it has been sent to the serializer");
+    }
+
+    // Easier check.
+    @Contract("null -> true")
+    private static boolean isNullOrEmpty(@Nullable String s) {
+        return s == null || s.isEmpty();
+    }
+
+    // use (possibly) intrinsic methods for faster array concat.
+    @Contract(pure = true)
+    @NotNull
+    private static String[] concat(String @NotNull [] arr, @Nullable String toAppend) {
+        String[] result = Arrays.copyOf(arr, arr.length + 1);
+        result[result.length - 1] = toAppend;
+        return result;
+    }
+
+    // use (possibly) intrinsic methods for faster array concat.
+    @Contract(pure = true)
+    @NotNull
+    private static String[] concat(String @NotNull [] arr1, String @NotNull [] arr2) {
+        String[] result = Arrays.copyOf(arr1, arr1.length + arr2.length);
+        System.arraycopy(arr2, 0, result, arr1.length, arr2.length);
+        return result;
     }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/Metadata.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/Metadata.java
@@ -85,14 +85,14 @@ public class Metadata {
         return locked;
     }
 
-    /** Returns true if the instance has a {@link Collections#EMPTY_MAP} as backing map. */
-    public boolean isReadOnly() {
-        return this.map == EMPTY_MAP;
+    /** Returns false if the instance has a {@link Collections#EMPTY_MAP} as backing map. */
+    public boolean isModifiable() {
+        return this.map != EMPTY_MAP;
     }
 
     /** Returns the first value for the key or null if it does not exist */
-    @Contract(pure = true)
     @Nullable
+    @Contract(pure = true)
     public String getFirstValue(@NotNull String key) {
         String[] values = map.get(key);
         if (values == null || values.length == 0) return null;
@@ -100,8 +100,8 @@ public class Metadata {
     }
 
     /** Returns the first value for the key or null if it does not exist, given a prefix */
-    @Contract(pure = true)
     @Nullable
+    @Contract(pure = true)
     public String getFirstValue(@NotNull String key, @Nullable String prefix) {
         if (isNullOrEmpty(prefix)) return getFirstValue(key);
         return getFirstValue(prefix + key);
@@ -163,7 +163,6 @@ public class Metadata {
     @Contract(mutates = "this")
     private void putAllInternal(@NotNull Map<String, String[]> mapToPut) {
         if (mapToPut.isEmpty()) return;
-
         for (Map.Entry<String, String[]> entry : mapToPut.entrySet()) {
             putValuesInternal(entry.getKey(), entry.getValue());
         }
@@ -278,20 +277,22 @@ public class Metadata {
     }
 
     /** @return the previous value(s) associated with <tt>key</tt> */
-    @Contract(mutates = "this")
     @NotNull
+    @Contract(mutates = "this")
     public String[] remove(@NotNull String key) {
         checkLockException();
         return map.remove(key);
     }
 
     @NotNull
+    @Contract(value = " -> new", pure = true)
     public String toString() {
         return toString("");
     }
 
     /** Returns a String representation of the metadata with one K/V per line */
     @NotNull
+    @Contract(value = "_ -> new", pure = true)
     public String toString(String prefix) {
         StringBuilder sb = new StringBuilder();
         if (prefix == null) prefix = "";
@@ -304,12 +305,14 @@ public class Metadata {
     }
 
     /** Returns the size of the keys in this */
+    @Contract(pure = true)
     public int size() {
         return map.size();
     }
 
     /** Returns a set of all keys of this instance */
     @NotNull
+    @Contract(pure = true)
     public Set<@Nullable String> keySet() {
         return map.keySet();
     }
@@ -317,10 +320,13 @@ public class Metadata {
     /** Returns the first non-empty value found for the keys or null if none found. */
     @Nullable
     public static String getFirstValue(@NotNull Metadata md, String... keys) {
+        if (keys.length == 0) return null;
+
         for (String key : keys) {
             String val = md.getFirstValue(key);
             if (!isNullOrEmpty(val)) return val;
         }
+
         return null;
     }
 
@@ -346,13 +352,14 @@ public class Metadata {
      * original metadata.
      */
     @NotNull
+    @Contract(" -> new")
     public Map<String, String[]> createDeepCopyOfMap() {
         return map.entrySet().stream()
                 .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().clone()));
     }
 
     /**
-     * Creates a plain copy of this with the same underlying map. Therefor all changes done to the
+     * Creates a shallow copy of this with the same underlying map. Therefor all changes done to the
      * new instance are also done to the origin metadata
      *
      * @return a copy of this
@@ -367,6 +374,7 @@ public class Metadata {
      * metadata.
      */
     @NotNull
+    @Contract(" -> new")
     public Metadata copyDeep() {
         return new Metadata(createDeepCopyOfMap());
     }
@@ -381,8 +389,8 @@ public class Metadata {
      *
      * @since 1.16
      */
-    @Contract(" -> this")
     @NotNull
+    @Contract(value = " -> this", mutates = "this")
     public Metadata lock() {
         locked = true;
         return this;
@@ -393,14 +401,15 @@ public class Metadata {
      *
      * @since 1.16
      */
-    @Contract(" -> this")
     @NotNull
+    @Contract(value = " -> this", mutates = "this")
     public Metadata unlock() {
         locked = false;
         return this;
     }
 
     @Override
+    @Contract(pure = true)
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Metadata)) return false;
@@ -420,6 +429,7 @@ public class Metadata {
     }
 
     @Override
+    @Contract(pure = true)
     public int hashCode() {
         return Objects.hash(map);
     }
@@ -432,14 +442,14 @@ public class Metadata {
     }
 
     // Easier check.
-    @Contract("null -> true")
+    @Contract(value = "null -> true", pure = true)
     private static boolean isNullOrEmpty(@Nullable String s) {
         return s == null || s.isEmpty();
     }
 
     // use (possibly) intrinsic methods for faster array concat.
-    @Contract(pure = true)
     @NotNull
+    @Contract(value = "_, _ -> new", pure = true)
     private static String[] concat(String @NotNull [] arr, @Nullable String toAppend) {
         String[] result = Arrays.copyOf(arr, arr.length + 1);
         result[result.length - 1] = toAppend;
@@ -447,8 +457,8 @@ public class Metadata {
     }
 
     // use (possibly) intrinsic methods for faster array concat.
-    @Contract(pure = true)
     @NotNull
+    @Contract(value = "_, _ -> new", pure = true)
     private static String[] concat(String @NotNull [] arr1, String @NotNull [] arr2) {
         String[] result = Arrays.copyOf(arr1, arr1.length + arr2.length);
         System.arraycopy(arr2, 0, result, arr1.length, arr2.length);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/MetadataKryoSerializer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/MetadataKryoSerializer.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.util;
+
+import static java.util.Collections.EMPTY_MAP;
+
+import com.digitalpebble.stormcrawler.Metadata;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.DefaultArraySerializers;
+import com.esotericsoftware.kryo.serializers.DefaultSerializers;
+import java.util.Map;
+import org.apache.storm.serialization.types.HashMapSerializer;
+
+/** A Kryo serializer for Metadata */
+// We need that serializer to make sure, that we do protect an empty metadata instance.
+// Otherwise it'll be converted to an HashMap.
+public class MetadataKryoSerializer extends Serializer<Metadata> {
+
+    private final HashMapSerializer hashMapSerializer = new HashMapSerializer();
+
+    public MetadataKryoSerializer() {
+        hashMapSerializer.setKeysCanBeNull(false);
+        hashMapSerializer.setKeysCanBeNull(true);
+        hashMapSerializer.setKeyClass(String.class, new DefaultSerializers.StringSerializer());
+        hashMapSerializer.setValueClass(
+                String[].class, new DefaultArraySerializers.StringArraySerializer());
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, Metadata object) {
+        boolean isEmpty = object.getMap() == EMPTY_MAP;
+        output.writeBoolean(isEmpty);
+        if (!isEmpty) {
+            hashMapSerializer.write(kryo, output, object.getMap());
+        }
+    }
+
+    @Override
+    public Metadata read(Kryo kryo, Input input, Class<Metadata> type) {
+        boolean isEmpty = input.readBoolean();
+        if (isEmpty) {
+            return Metadata.EMPTY_METADATA;
+        } else {
+            //noinspection unchecked
+            return new Metadata(
+                    (Map<String, String[]>) hashMapSerializer.read(kryo, input, Map.class));
+        }
+    }
+}

--- a/core/src/test/java/com/digitalpebble/stormcrawler/MetadataTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/MetadataTest.java
@@ -1,0 +1,303 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler;
+
+import static java.util.Collections.EMPTY_MAP;
+
+import com.digitalpebble.stormcrawler.persistence.Status;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetadataTest {
+
+    @Test
+    public void testShallowCopy() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        meta.setValue("b", "b");
+        final Metadata copy = meta.copy();
+        copy.addValue("b", "c");
+        copy.setValues("u", new String[] {"u", "v", "w"});
+
+        Assert.assertTrue(meta.containsKey("a"));
+        Assert.assertTrue(copy.containsKey("a"));
+        Assert.assertArrayEquals(meta.getValues("b"), copy.getValues("b"));
+
+        Assert.assertTrue(meta.containsKey("u"));
+        Assert.assertTrue(copy.containsKey("u"));
+        Assert.assertArrayEquals(meta.getValues("u"), copy.getValues("u"));
+    }
+
+    @Test
+    public void testDeepCopy() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        final Metadata copy = meta.copyDeep();
+        copy.setValues("u", new String[] {"u", "v", "w"});
+        Assert.assertTrue(meta.containsKey("a"));
+        Assert.assertTrue(copy.containsKey("a"));
+        Assert.assertFalse(meta.containsKey("u"));
+        Assert.assertTrue(copy.containsKey("u"));
+    }
+
+    @Test
+    public void testGetValue_prefix() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a.b", "a");
+        Assert.assertNotNull(meta.getFirstValue("b", "a."));
+    }
+
+    @Test
+    public void testAddValue_newKey() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        meta.setValue("b", "b");
+        meta.setValue("c", "c");
+        final Map<String, String[]> deepCopyOfMap = meta.createDeepCopyOfMap();
+        meta.addValue("d", "d");
+
+        Assert.assertNotEquals(deepCopyOfMap.size(), meta.size());
+        Assert.assertEquals(deepCopyOfMap.size() + 1, meta.size());
+        for (Map.Entry<String, String[]> x : deepCopyOfMap.entrySet()) {
+            Assert.assertTrue(meta.containsKey(x.getKey()));
+        }
+        Assert.assertTrue(meta.containsKey("d"));
+    }
+
+    @Test
+    public void testAddValue_oldKey() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        meta.setValue("b", "b");
+        meta.setValue("c", "c");
+        final Map<String, String[]> deepCopyOfMap = meta.createDeepCopyOfMap();
+        meta.addValue("c", "d");
+
+        Assert.assertEquals(deepCopyOfMap.size(), meta.size());
+        for (Map.Entry<String, String[]> x : deepCopyOfMap.entrySet()) {
+            Assert.assertTrue(meta.containsKey(x.getKey()));
+        }
+        Assert.assertTrue(meta.containsKeyWithValue("c", "c"));
+        Assert.assertTrue(meta.containsKeyWithValue("c", "d"));
+    }
+
+    @Test
+    public void testAddValues_newKey() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        meta.setValue("b", "b");
+        meta.setValue("c", "c");
+        final Map<String, String[]> deepCopyOfMap = meta.createDeepCopyOfMap();
+        meta.addValues("d", new String[] {"d", "e"});
+
+        Assert.assertNotEquals(deepCopyOfMap.size(), meta.size());
+        Assert.assertEquals(deepCopyOfMap.size() + 1, meta.size());
+        for (Map.Entry<String, String[]> x : deepCopyOfMap.entrySet()) {
+            Assert.assertTrue(meta.containsKey(x.getKey()));
+        }
+        Assert.assertTrue(meta.containsKey("d"));
+        Assert.assertTrue(meta.containsKeyWithValue("d", "d"));
+        Assert.assertTrue(meta.containsKeyWithValue("d", "e"));
+    }
+
+    @Test
+    public void testAddValues_oldKey() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        meta.setValue("b", "b");
+        meta.setValue("c", "c");
+        final Map<String, String[]> deepCopyOfMap = meta.createDeepCopyOfMap();
+        meta.addValues("c", new String[] {"d", "e"});
+
+        Assert.assertEquals(deepCopyOfMap.size(), meta.size());
+        for (Map.Entry<String, String[]> x : deepCopyOfMap.entrySet()) {
+            Assert.assertTrue(meta.containsKey(x.getKey()));
+        }
+        Assert.assertTrue(meta.containsKeyWithValue("c", "c"));
+        Assert.assertTrue(meta.containsKeyWithValue("c", "d"));
+        Assert.assertTrue(meta.containsKeyWithValue("c", "e"));
+    }
+
+    @Test
+    public void testPutValues_oldKey() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        meta.setValue("b", "b");
+        meta.setValue("c", "c");
+        final Map<String, String[]> deepCopyOfMap = meta.createDeepCopyOfMap();
+
+        final HashMap<String, String[]> stringHashMap = new HashMap<>();
+
+        stringHashMap.put("a", new String[] {"ak", "av"});
+        stringHashMap.put("b", new String[] {"bk", "bv"});
+        meta.putAll(stringHashMap);
+
+        Assert.assertEquals(deepCopyOfMap.size(), meta.size());
+        for (Map.Entry<String, String[]> x : deepCopyOfMap.entrySet()) {
+            Assert.assertTrue(meta.containsKey(x.getKey()));
+        }
+        Assert.assertTrue(meta.containsKeyWithValue("a", "ak"));
+        Assert.assertTrue(meta.containsKeyWithValue("a", "av"));
+        Assert.assertTrue(meta.containsKeyWithValue("b", "bk"));
+        Assert.assertTrue(meta.containsKeyWithValue("b", "bv"));
+    }
+
+    @Test
+    public void testPutValues_newKey() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        meta.setValue("b", "b");
+        meta.setValue("c", "c");
+        final Map<String, String[]> deepCopyOfMap = meta.createDeepCopyOfMap();
+
+        final HashMap<String, String[]> stringHashMap = new HashMap<>();
+
+        stringHashMap.put("d", new String[] {"k", "v"});
+        meta.putAll(stringHashMap);
+
+        Assert.assertEquals(deepCopyOfMap.size() + 1, meta.size());
+        for (Map.Entry<String, String[]> x : deepCopyOfMap.entrySet()) {
+            Assert.assertTrue(meta.containsKey(x.getKey()));
+        }
+        Assert.assertTrue(meta.containsKeyWithValue("d", "k"));
+        Assert.assertTrue(meta.containsKeyWithValue("d", "v"));
+    }
+
+    @Test
+    public void testPutValues_oldKey_prefix() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        meta.setValue("b", "b");
+        meta.setValue("c", "c");
+        final Map<String, String[]> deepCopyOfMap = meta.createDeepCopyOfMap();
+
+        final HashMap<String, String[]> stringHashMap = new HashMap<>();
+
+        stringHashMap.put("a", new String[] {"ak", "av"});
+        stringHashMap.put("b", new String[] {"bk", "bv"});
+        meta.putAll(stringHashMap, "test.");
+
+        Assert.assertEquals(deepCopyOfMap.size() + 2, meta.size());
+        for (Map.Entry<String, String[]> x : deepCopyOfMap.entrySet()) {
+            Assert.assertTrue(meta.containsKey(x.getKey()));
+        }
+        Assert.assertFalse(meta.containsKeyWithValue("a", "ak"));
+        Assert.assertFalse(meta.containsKeyWithValue("a", "av"));
+        Assert.assertFalse(meta.containsKeyWithValue("b", "bk"));
+        Assert.assertFalse(meta.containsKeyWithValue("b", "bv"));
+        Assert.assertTrue(meta.containsKeyWithValue("test.a", "ak"));
+        Assert.assertTrue(meta.containsKeyWithValue("test.a", "av"));
+        Assert.assertTrue(meta.containsKeyWithValue("test.b", "bk"));
+        Assert.assertTrue(meta.containsKeyWithValue("test.b", "bv"));
+    }
+
+    @Test
+    public void testPutValues_newKey_prefix() {
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        meta.setValue("b", "b");
+        meta.setValue("c", "c");
+        final Map<String, String[]> deepCopyOfMap = meta.createDeepCopyOfMap();
+
+        final HashMap<String, String[]> stringHashMap = new HashMap<>();
+
+        stringHashMap.put("d", new String[] {"k", "v"});
+        meta.putAll(stringHashMap, "test.");
+
+        Assert.assertEquals(deepCopyOfMap.size() + 1, meta.size());
+        for (Map.Entry<String, String[]> x : deepCopyOfMap.entrySet()) {
+            Assert.assertTrue(meta.containsKey(x.getKey()));
+        }
+        Assert.assertFalse(meta.containsKey("d"));
+        Assert.assertTrue(meta.containsKey("test.d"));
+        Assert.assertTrue(meta.containsKeyWithValue("test.d", "k"));
+        Assert.assertTrue(meta.containsKeyWithValue("test.d", "v"));
+    }
+
+    @Test
+    public void testSerialisation() {
+
+        final Metadata meta = new Metadata();
+        meta.setValue("a", "a");
+        meta.setValue("b", "b");
+        meta.setValue("c", "c");
+        meta.setValues("d", new String[] {"d", "e"});
+        final Map<String, String[]> deepCopyOfMap = meta.createDeepCopyOfMap();
+
+        final Kryo kryo = new Kryo();
+        kryo.register(Metadata.class);
+        kryo.register(Status.class);
+
+        byte[] serialized;
+        try (ByteArrayOutputStream bOut = new ByteArrayOutputStream()) {
+            try (Output output = new Output(bOut)) {
+                kryo.writeObject(output, meta);
+            }
+            serialized = bOut.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        Metadata metaNew;
+        try (ByteArrayInputStream bIn = new ByteArrayInputStream(serialized)) {
+            try (Input input = new Input(bIn)) {
+                metaNew = kryo.readObject(input, Metadata.class);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertEquals(meta, metaNew);
+    }
+
+    @Test
+    public void testSerialisationOfEmpty() {
+
+        final Metadata meta = Metadata.emptyMetadata();
+
+        final Kryo kryo = new Kryo();
+        kryo.register(Metadata.class);
+        kryo.register(Status.class);
+
+        byte[] serialized;
+        try (ByteArrayOutputStream bOut = new ByteArrayOutputStream()) {
+            try (Output output = new Output(bOut)) {
+                kryo.writeObject(output, meta);
+            }
+            serialized = bOut.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        Metadata metaNew;
+        try (ByteArrayInputStream bIn = new ByteArrayInputStream(serialized)) {
+            try (Input input = new Input(bIn)) {
+                metaNew = kryo.readObject(input, Metadata.class);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertSame(meta.getMap(), metaNew.getMap());
+        Assert.assertSame(meta.getMap(), EMPTY_MAP);
+        Assert.assertSame(metaNew.getMap(), EMPTY_MAP);
+    }
+}


### PR DESCRIPTION
Hello @jnioche,

sorry for the first PR regarding the metadata, that PR was a mistake. I thought that a draft was only visible for me.

I improved the class Metadata in the following ways:
- Add annotations like `@Nullable` for easier utilisation and protection from NPEs because Metadata is a central class for the whole project/usage.
- Replace the old serialisation for Kyro with an explicit implementation to keep the information about the empty metadata instance, even if we serialize and deserialize it.
- Rename `asMap` to `getMap` because as implies a cast or conversion but the method `asMap` is implemented as a simple getter.
- Improve `addValues` by removing the usage of collections.
- Implement `equals` for metadata for easier comparison.
- Implement a basic `hashCode` because it would be unusual to override equals but not hashCode. (Maybe create hash based on key values?)
- Add basic tests for Metadata
- Add a check if an instance of Metadata is an empty map with `isReadOnly` (maybe rename to `isEmptyInstance()`?)
- Add `deepCopy` methods for Metadata and the underlying Map to ensure that the original is not modified if not wanted.
- Deprecate `empty` in favor of `EMPTY_METADATA` and `emptyMetadata` in order to be more streamlined with `Collections.emptyList` and `Collections.emptyMap`. Furthermore I added explicit annotations to indicate that it is unmodifiable.

Best regards,

Felix

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

