### PR TITLE
Add URL resolving for SeleniumProtocol, unify ConfUtils method interfaces

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/ConfigurableTopology.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/ConfigurableTopology.java
@@ -16,7 +16,6 @@ package com.digitalpebble.stormcrawler;
 
 import com.digitalpebble.stormcrawler.persistence.Status;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -85,11 +84,7 @@ public abstract class ConfigurableTopology {
                 }
                 iter.remove();
                 String resource = iter.next();
-                try {
-                    ConfUtils.loadConf(resource, conf);
-                } catch (FileNotFoundException e) {
-                    throw new RuntimeException("File not found : " + resource);
-                }
+                ConfUtils.loadConfigIntoTarget(resource, conf);
                 iter.remove();
             }
         }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/SiteMapParserBolt.java
@@ -348,7 +348,7 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
         scheduleSitemapsWithDelay =
                 ConfUtils.getInt(stormConf, "sitemap.schedule.delay", scheduleSitemapsWithDelay);
         List<String> extensionsStrings =
-                ConfUtils.loadListFromConf("sitemap.extensions", stormConf);
+                ConfUtils.loadListFromConf(stormConf, "sitemap.extensions");
         extensionsToParse = new ArrayList<>(extensionsStrings.size());
 
         for (String type : extensionsStrings) {

--- a/core/src/main/java/com/digitalpebble/stormcrawler/indexing/AbstractIndexerBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/indexing/AbstractIndexerBolt.java
@@ -104,7 +104,7 @@ public abstract class AbstractIndexerBolt extends BaseRichBolt {
 
         canonicalMetadataName = ConfUtils.getString(conf, canonicalMetadataParamName);
 
-        for (String mapping : ConfUtils.loadListFromConf(metadata2fieldParamName, conf)) {
+        for (String mapping : ConfUtils.loadListFromConf(conf, metadata2fieldParamName)) {
             int equals = mapping.indexOf('=');
             if (equals != -1) {
                 String key = mapping.substring(0, equals).trim();

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/JSoupFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/JSoupFilters.java
@@ -138,7 +138,7 @@ public class JSoupFilters extends JSoupFilter implements JSONResource {
 
         if (cmd.hasOption("c")) {
             String confFile = cmd.getOptionValue("c");
-            ConfUtils.loadConf(confFile, conf);
+            ConfUtils.loadConfigIntoTarget(confFile, conf);
         }
 
         JSoupFilters filters = JSoupFilters.fromConf(conf);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/ParseFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/ParseFilters.java
@@ -165,7 +165,7 @@ public class ParseFilters extends ParseFilter implements JSONResource {
 
         if (cmd.hasOption("c")) {
             String confFile = cmd.getOptionValue("c");
-            ConfUtils.loadConf(confFile, conf);
+            ConfUtils.loadConfigIntoTarget(confFile, conf);
         }
 
         ParseFilters filters = ParseFilters.fromConf(conf);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/TextExtractor.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/TextExtractor.java
@@ -66,9 +66,9 @@ public class TextExtractor {
 
     public TextExtractor(Map<String, Object> stormConf) {
         noText = ConfUtils.getBoolean(stormConf, NO_TEXT_PARAM_NAME, false);
-        inclusionPatterns = ConfUtils.loadListFromConf(INCLUDE_PARAM_NAME, stormConf);
+        inclusionPatterns = ConfUtils.loadListFromConf(stormConf, INCLUDE_PARAM_NAME);
         excludedTags = new HashSet<String>();
-        ConfUtils.loadListFromConf(EXCLUDE_PARAM_NAME, stormConf)
+        ConfUtils.loadListFromConf(stormConf, EXCLUDE_PARAM_NAME)
                 .forEach((s) -> excludedTags.add(s.toLowerCase()));
     }
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/AbstractHttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/AbstractHttpProtocol.java
@@ -90,9 +90,9 @@ public abstract class AbstractHttpProtocol implements Protocol {
 
         this.storeHTTPHeaders = ConfUtils.getBoolean(conf, "http.store.headers", false);
         this.useCookies = ConfUtils.getBoolean(conf, "http.use.cookies", false);
-        this.protocolVersions = ConfUtils.loadListFromConf("http.protocol.versions", conf);
+        this.protocolVersions = ConfUtils.loadListFromConf(conf, "http.protocol.versions");
 
-        List<String> headers = ConfUtils.loadListFromConf("http.custom.headers", conf);
+        List<String> headers = ConfUtils.loadListFromConf(conf, "http.custom.headers");
         for (String h : headers) {
             customHeaders.add(KeyValue.build(h));
         }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/AbstractHttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/AbstractHttpProtocol.java
@@ -209,7 +209,7 @@ public abstract class AbstractHttpProtocol implements Protocol {
 
         if (cmd.hasOption("c")) {
             String confFile = cmd.getOptionValue("c");
-            ConfUtils.loadConf(confFile, conf);
+            ConfUtils.loadConfigIntoTarget(confFile, conf);
         }
 
         protocol.configure(conf);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/DelegatorRemoteDriverProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/DelegatorRemoteDriverProtocol.java
@@ -60,7 +60,8 @@ public class DelegatorRemoteDriverProtocol extends RemoteDriverProtocol {
     }
 
     @Override
-    public ProtocolResponse getProtocolOutput(String url, Metadata metadata) throws Exception {
+    public @NotNull ProtocolResponse getProtocolOutput(
+            @NotNull String url, @NotNull Metadata metadata) throws Exception {
         if (metadata.getFirstValue(USE_SELENIUM_KEY) != null) {
             return super.getProtocolOutput(url, metadata);
         } else {

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/RemoteDriverProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/RemoteDriverProtocol.java
@@ -80,7 +80,7 @@ public class RemoteDriverProtocol extends SeleniumProtocol {
             throws MalformedURLException {
         Collection<Object> collection = ConfUtils.loadCollectionOrNull(conf, SELENIUM_ADDRESSES);
         if (collection == null) return null;
-        ArrayList<ResolvedUrl> retVal = new ArrayList<>(collection.size());
+        List<ResolvedUrl> retVal = new ArrayList<>(collection.size());
         for (Object entry : collection) {
             ResolvedUrl urlTuple;
             if (entry instanceof String) {

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/RemoteDriverProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/selenium/RemoteDriverProtocol.java
@@ -15,13 +15,19 @@
 package com.digitalpebble.stormcrawler.protocol.selenium;
 
 import com.digitalpebble.stormcrawler.util.ConfUtils;
+import com.digitalpebble.stormcrawler.util.URLResolver;
+import com.digitalpebble.stormcrawler.util.URLResolver.ResolvedUrl;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
-import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.storm.Config;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.openqa.selenium.WebDriver.Timeouts;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -29,11 +35,88 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 /**
  * Delegates the requests to one or more remote selenium servers. The processes must be started /
  * stopped separately. The URLs to connect to are specified with the config 'selenium.addresses'.
+ *
+ * <p>Is configured like this:
+ *
+ * <pre>
+ *   selenium.addresses:
+ *     # Similar to the second address
+ *     - http://first-address:4444
+ *     - address: http://second-address:4444
+ *     - address: http://second-address:4444
+ *       resolve: NOTHING
+ *     - address: http://third-address:4444
+ *       resolve: IP
+ *     - address: http://fourth-address:4444
+ *       resolve: IPv4
+ *     - address: http://fifth-address:4444
+ *       resolve: IPv6
+ *     - address: http://first-IP-address:4444
+ *       resolve: HOSTNAME
+ *     - address: http://second-IP-address:4444
+ *       resolve: CANONICAL_HOSTNAME
+ *   selenium.implicitlyWait: 1000000
+ *   selenium.pageLoadTimeout: 1000000
+ *   selenium.scriptTimeout: 1000000
+ *   selenium.capabilities:
+ *     takesScreenshot: true
+ *     loadImages: true
+ *     javascriptEnabled: true
+ *     browserName: chrome
+ * </pre>
+ *
+ * @see URLResolver for possible resolveTo targets.
  */
 public class RemoteDriverProtocol extends SeleniumProtocol {
 
+    public static final String SELENIUM_CAPABILITIES = "selenium.capabilities";
+    public static final String SELENIUM_ADDRESSES = "selenium.addresses";
+    public static final String SELENIUM_IMPLICIT_WAIT = "selenium.implicitlyWait";
+    public static final String SELENIUM_PAYLOAD_TIMEOUT = "selenium.pageLoadTimeout";
+    public static final String SELENIUM_SCRIPT_TIMEOUT = "selenium.scriptTimeout";
+
+    @Nullable
+    public static List<ResolvedUrl> loadURLsFromConfig(@NotNull Config conf)
+            throws MalformedURLException {
+        Collection<Object> collection = ConfUtils.loadCollectionOrNull(conf, SELENIUM_ADDRESSES);
+        if (collection == null) return null;
+        ArrayList<ResolvedUrl> retVal = new ArrayList<>(collection.size());
+        for (Object entry : collection) {
+            ResolvedUrl urlTuple;
+            if (entry instanceof String) {
+                urlTuple = ResolvedUrl.of(new URL((String) entry));
+            } else if (entry instanceof Map<?, ?>) {
+                //noinspection unchecked
+                Map<String, Object> subConfig = (Map<String, Object>) entry;
+                String address = ConfUtils.getString(subConfig, "address");
+                if (address == null) {
+                    throw new RuntimeException(
+                            String.format(
+                                    "The config for a %s entry is missing an 'address' field.",
+                                    SELENIUM_ADDRESSES));
+                }
+
+                URL origin = new URL(address);
+
+                URLResolver strategy =
+                        ConfUtils.getEnumOrDefault(subConfig, "resolve", null, URLResolver.class);
+
+                if (strategy != null) {
+                    urlTuple = strategy.resolve(origin);
+                } else {
+                    urlTuple = ResolvedUrl.of(origin);
+                }
+            } else {
+                throw new RuntimeException(
+                        String.format("Unsupported entry at %s", SELENIUM_ADDRESSES));
+            }
+            retVal.add(urlTuple);
+        }
+        return retVal;
+    }
+
     @Override
-    public void configure(Config conf) {
+    public void configure(@NotNull Config conf) {
         super.configure(conf);
 
         // see https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities
@@ -43,12 +126,9 @@ public class RemoteDriverProtocol extends SeleniumProtocol {
         String userAgentString = getAgentString(conf);
 
         // custom capabilities
-        Map<String, Object> confCapabilities =
-                (Map<String, Object>) conf.get("selenium.capabilities");
+        Map<String, Object> confCapabilities = ConfUtils.getSubConfig(conf, SELENIUM_CAPABILITIES);
         if (confCapabilities != null) {
-            Iterator<Entry<String, Object>> iter = confCapabilities.entrySet().iterator();
-            while (iter.hasNext()) {
-                Entry<String, Object> entry = iter.next();
+            for (Entry<String, Object> entry : confCapabilities.entrySet()) {
                 Object val = entry.getValue();
                 // substitute variable $useragent for the real value
                 if (val instanceof String && "$useragent".equalsIgnoreCase(val.toString())) {
@@ -58,29 +138,38 @@ public class RemoteDriverProtocol extends SeleniumProtocol {
             }
         }
 
-        // load adresses from config
-        List<String> addresses = ConfUtils.loadListFromConf("selenium.addresses", conf);
-        if (addresses.size() == 0) {
-            throw new RuntimeException("No value found for selenium.addresses");
-        }
+        List<ResolvedUrl> urls;
         try {
-            for (String cdaddress : addresses) {
-                RemoteWebDriver driver = new RemoteWebDriver(new URL(cdaddress), capabilities);
-                Timeouts touts = driver.manage().timeouts();
-                int implicitWait = ConfUtils.getInt(conf, "selenium.implicitlyWait", 0);
-                int pageLoadTimeout = ConfUtils.getInt(conf, "selenium.pageLoadTimeout", 0);
-                int scriptTimeout = ConfUtils.getInt(conf, "selenium.scriptTimeout", 0);
-                touts.implicitlyWait(Duration.ofMillis(implicitWait));
-                touts.pageLoadTimeout(Duration.ofMillis(pageLoadTimeout));
-                touts.scriptTimeout(Duration.ofMillis(scriptTimeout));
-                drivers.add(driver);
-            }
-        } catch (Exception e) {
+            urls = loadURLsFromConfig(conf);
+        } catch (MalformedURLException e) {
             throw new RuntimeException(e);
+        }
+
+        // load adresses from config
+        if (urls == null) {
+            throw new RuntimeException(String.format("No value found for %s", SELENIUM_ADDRESSES));
+        }
+
+        for (ResolvedUrl resolvedUrl : urls) {
+            if (resolvedUrl.wasNotSuccessfullyResolved()) {
+                LOG.warn("The url {} was not successfully resolved.", resolvedUrl.getOrigin());
+            }
+            LOG.info("Create RemoteWebDriver for: {}", resolvedUrl);
+            RemoteWebDriver driver =
+                    new RemoteWebDriver(resolvedUrl.getResolvedOrOrigin(), capabilities);
+            Timeouts touts = driver.manage().timeouts();
+            int implicitWait = ConfUtils.getInt(conf, SELENIUM_IMPLICIT_WAIT, 0);
+            int pageLoadTimeout = ConfUtils.getInt(conf, SELENIUM_PAYLOAD_TIMEOUT, 0);
+            int scriptTimeout = ConfUtils.getInt(conf, SELENIUM_SCRIPT_TIMEOUT, 0);
+            touts.implicitlyWait(Duration.ofMillis(implicitWait));
+            touts.pageLoadTimeout(Duration.ofMillis(pageLoadTimeout));
+            touts.scriptTimeout(Duration.ofMillis(scriptTimeout));
+            drivers.add(driver);
         }
     }
 
-    public static void main(String[] args) throws Exception {
-        RemoteDriverProtocol.main(new RemoteDriverProtocol(), args);
-    }
+    //    @TestOnly
+    //    public static void main(String[] args) throws Exception {
+    //        RemoteDriverProtocol.mainForTest(new RemoteDriverProtocol(), args);
+    //    }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
@@ -247,7 +247,7 @@ public class ConfUtils {
     public static List<String> loadListFromConf(
             @NotNull Map<String, Object> stormConf, @NotNull String key) {
         Object obj = stormConf.get(key);
-        List<String> list = new LinkedList<>();
+        List<String> list = new ArrayList<>();
 
         if (obj == null) return list;
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
@@ -14,23 +14,21 @@
  */
 package com.digitalpebble.stormcrawler.util;
 
-import java.io.FileInputStream;
+import static org.apache.storm.utils.Utils.findAndReadConfigFile;
+
 import java.io.FileNotFoundException;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import org.apache.storm.Config;
-import org.yaml.snakeyaml.Yaml;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ConfUtils {
 
     private ConfUtils() {}
 
-    public static int getInt(Map<String, Object> conf, String key, int defaultValue) {
+    public static int getInt(
+            @NotNull Map<String, Object> conf, @NotNull String key, int defaultValue) {
         Object ret = conf.get(key);
         if (ret == null) {
             ret = defaultValue;
@@ -38,7 +36,8 @@ public class ConfUtils {
         return ((Number) ret).intValue();
     }
 
-    public static long getLong(Map<String, Object> conf, String key, long defaultValue) {
+    public static long getLong(
+            @NotNull Map<String, Object> conf, @NotNull String key, long defaultValue) {
         Object ret = conf.get(key);
         if (ret == null) {
             ret = defaultValue;
@@ -46,7 +45,8 @@ public class ConfUtils {
         return ((Number) ret).longValue();
     }
 
-    public static float getFloat(Map<String, Object> conf, String key, float defaultValue) {
+    public static float getFloat(
+            @NotNull Map<String, Object> conf, @NotNull String key, float defaultValue) {
         Object ret = conf.get(key);
         if (ret == null) {
             ret = defaultValue;
@@ -54,19 +54,22 @@ public class ConfUtils {
         return ((Number) ret).floatValue();
     }
 
-    public static boolean getBoolean(Map<String, Object> conf, String key, boolean defaultValue) {
+    public static boolean getBoolean(
+            @NotNull Map<String, Object> conf, @NotNull String key, boolean defaultValue) {
         Object ret = conf.get(key);
         if (ret == null) {
             ret = defaultValue;
         }
-        return ((Boolean) ret).booleanValue();
+        return (Boolean) ret;
     }
 
-    public static String getString(Map<String, Object> conf, String key) {
+    @Nullable
+    public static String getString(@NotNull Map<String, Object> conf, @NotNull String key) {
         return (String) conf.get(key);
     }
 
-    public static String getString(Map<String, Object> conf, String key, String defaultValue) {
+    public static String getString(
+            @NotNull Map<String, Object> conf, @NotNull String key, @Nullable String defaultValue) {
         Object ret = conf.get(key);
         if (ret == null) {
             ret = defaultValue;
@@ -74,12 +77,176 @@ public class ConfUtils {
         return (String) ret;
     }
 
+    @Nullable
+    @Contract(value = "_, null -> null")
+    private static <T extends Enum<T>> T convertToEnumOrNull(
+            @NotNull Class<T> enumClass, @Nullable Object toConvert) {
+
+        if (toConvert == null) return null;
+
+        if (toConvert instanceof String) {
+            return Enum.valueOf(enumClass, (String) toConvert);
+        } else if (enumClass.isInstance(toConvert)) {
+            //noinspection unchecked
+            return (T) toConvert;
+        } else {
+            return null;
+        }
+    }
+
+    @NotNull
+    private static <T extends Enum<T>> T convertToEnum(
+            @NotNull Class<T> enumClass, @NotNull Object toConvert) {
+        T retVal = convertToEnumOrNull(enumClass, toConvert);
+        if (retVal == null) {
+            throw new RuntimeException(
+                    String.format("Can not convert %s to %s", toConvert, enumClass.getName()));
+        }
+        return retVal;
+    }
+
+    @NotNull
+    public static <T extends Enum<T>> T getEnum(
+            @NotNull Map<String, Object> conf, @NotNull String key, @NotNull Class<T> enumClass) {
+        Object value = Objects.requireNonNull(conf.get(key));
+        return convertToEnum(enumClass, value);
+    }
+
+    public static <T extends Enum<T>> T getEnumOrDefault(
+            @NotNull Map<String, Object> conf,
+            @NotNull String key,
+            @Nullable T defaultValue,
+            @NotNull Class<T> enumClass) {
+        Object value = conf.get(key);
+        if (value == null) {
+            return defaultValue;
+        } else {
+            return convertToEnumOrNull(enumClass, value);
+        }
+    }
+
+    /**
+     * Returns either a collection of objects or throws a RuntimeException. If there is only one
+     * value it <b>throws a RuntimeException</b>.
+     *
+     * @see ConfUtils {@link ConfUtils#loadCollection(Map, String)} for a single friendly
+     *     alternative.
+     */
+    @NotNull
+    public static Collection<Object> getCollection(
+            @NotNull Map<String, Object> conf, @NotNull String key) {
+        Collection<Object> obj = getCollectionOrNull(conf, key);
+        if (obj == null) {
+            throw new RuntimeException(
+                    String.format("There is no Collection value for the key '%s'.", key));
+        }
+        return obj;
+    }
+
+    /**
+     * Returns either a collection of objects or null. If there is only one value it also returns
+     * null.
+     *
+     * @see ConfUtils {@link ConfUtils#loadCollectionOrNull(Map, String)} for a single friendly
+     *     alternative.
+     */
+    @Nullable
+    public static Collection<Object> getCollectionOrNull(
+            @NotNull Map<String, Object> conf, @NotNull String key) {
+        Object obj = conf.get(key);
+        if (obj == null) {
+            return null;
+        }
+        //noinspection unchecked
+        return (Collection<Object>) obj;
+    }
+
+    /**
+     * Returns either a collection of objects or throws a RuntimeException. If there is only one
+     * value, it will return a SingletonList.
+     */
+    @NotNull
+    public static Collection<Object> loadCollection(
+            @NotNull Map<String, Object> conf, @NotNull String key) {
+        Collection<Object> collection = loadCollectionOrNull(conf, key);
+        if (collection == null) {
+            throw new RuntimeException(
+                    String.format("There is no Collection value for the key '%s'.", key));
+        }
+        return collection;
+    }
+
+    /**
+     * Returns either a collection ob objects or null. If there is only one value, it will return a
+     * SingletonList.
+     */
+    @Nullable
+    public static Collection<Object> loadCollectionOrNull(
+            @NotNull Map<String, Object> conf, @NotNull String key) {
+        Object obj = conf.get(key);
+        if (obj == null) {
+            return null;
+        }
+        if (obj instanceof Collection) {
+            //noinspection unchecked
+            return (Collection<Object>) obj;
+        } else {
+            return Collections.singletonList(obj);
+        }
+    }
+
+    @Nullable
+    public static Map<String, Object> getSubConfig(
+            @NotNull Map<String, Object> conf, @NotNull String key) {
+        Object obj = conf.get(key);
+        if (obj == null) {
+            return null;
+        }
+        //noinspection unchecked
+        return (Map<String, Object>) obj;
+    }
+
+    /**
+     * Returns either a Map or a reference to {@link Collections#EMPTY_MAP}. If {@code key} is not
+     * in {@code conf} it returns null.
+     */
+    @Nullable
+    public static Map<String, Object> loadSubConfigOrNull(
+            @NotNull Map<String, Object> conf, @NotNull String key) {
+        Object obj = conf.get(key);
+        if (obj == null) {
+            return null;
+        }
+        if (obj instanceof Map) {
+            //noinspection unchecked
+            return (Map<String, Object>) obj;
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Returns either a Map or a reference to {@link Collections#EMPTY_MAP}. If {@code key} is not
+     * in {@code conf} it trows a RuntimeCollection.
+     */
+    @NotNull
+    public static Map<String, Object> loadSubConfig(
+            @NotNull Map<String, Object> conf, @NotNull String key) {
+        Map<String, Object> subConfig = loadSubConfigOrNull(conf, key);
+        if (subConfig == null) {
+            throw new RuntimeException(String.format("There is no SubConfig at key '%s'.", key));
+        }
+        return subConfig;
+    }
+
     /**
      * Return one or more Strings regardless of whether they are represented as a single String or a
      * list in the config or an empty List if no value could be found for that key.
      */
-    public static List<String> loadListFromConf(String paramKey, Map stormConf) {
-        Object obj = stormConf.get(paramKey);
+    @NotNull
+    public static List<String> loadListFromConf(
+            @NotNull Map<String, Object> stormConf, @NotNull String key) {
+        Object obj = stormConf.get(key);
         List<String> list = new LinkedList<>();
 
         if (obj == null) return list;
@@ -92,30 +259,33 @@ public class ConfUtils {
         return list;
     }
 
+    @Deprecated
+    @Contract()
     public static Config loadConf(String resource, Config conf) throws FileNotFoundException {
-        Yaml yaml = new Yaml();
-        Map ret =
-                (Map)
-                        yaml.load(
-                                new InputStreamReader(
-                                        new FileInputStream(resource), Charset.defaultCharset()));
-        if (ret == null) {
-            ret = new HashMap();
-        }
-        // contains a single config element ?
-        else {
-            ret = extractConfigElement(ret);
-        }
-        conf.putAll(ret);
+        loadConfigIntoTarget(resource, conf);
         return conf;
     }
 
+    /** Loads the resource at {@code pathToResource} into the given {@code target}. */
+    public static void loadConfigIntoTarget(
+            @NotNull String pathToResource, @NotNull Config target) {
+        Map<String, Object> ret = findAndReadConfigFile(pathToResource);
+
+        if (ret.isEmpty()) {
+            return;
+        }
+
+        // contains a single config element ?
+        ret = extractConfigElement(ret);
+        target.putAll(ret);
+    }
+
     /** If the config consists of a single key 'config', its values are used instead */
-    public static Map extractConfigElement(Map conf) {
+    public static Map<String, Object> extractConfigElement(Map<String, Object> conf) {
         if (conf.size() == 1) {
             Object confNode = conf.get("config");
-            if (confNode != null && confNode instanceof Map) {
-                conf = (Map) confNode;
+            if (confNode instanceof Map) {
+                conf = (Map<String, Object>) confNode;
             }
         }
         return conf;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
@@ -242,6 +242,19 @@ public class ConfUtils {
     /**
      * Return one or more Strings regardless of whether they are represented as a single String or a
      * list in the config or an empty List if no value could be found for that key.
+     *
+     * @deprecated use {@link ConfUtils#loadListFromConf(Map, String)} instead.
+     */
+    @NotNull
+    @Deprecated
+    public static List<String> loadListFromConf(
+            @NotNull String paramKey, @NotNull Map<String, Object> stormConf) {
+        return loadListFromConf(stormConf, paramKey);
+    }
+
+    /**
+     * Return one or more Strings regardless of whether they are represented as a single String or a
+     * list in the config or an empty List if no value could be found for that key.
      */
     @NotNull
     public static List<String> loadListFromConf(

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
@@ -272,14 +272,20 @@ public class ConfUtils {
         return list;
     }
 
+    /**
+     * Loads the resource at {@code resource} into the given {@code conf}.
+     *
+     * @deprecated Use {@link ConfUtils#loadConfigIntoTarget(String, Config)} instead.
+     */
     @Deprecated
-    @Contract()
+    @Contract(value = "_, _ -> param2", mutates = "param2")
     public static Config loadConf(String resource, Config conf) throws FileNotFoundException {
         loadConfigIntoTarget(resource, conf);
         return conf;
     }
 
     /** Loads the resource at {@code pathToResource} into the given {@code target}. */
+    @Contract(mutates = "param2")
     public static void loadConfigIntoTarget(
             @NotNull String pathToResource, @NotNull Config target) {
         Map<String, Object> ret = findAndReadConfigFile(pathToResource);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/MetadataTransfer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/MetadataTransfer.java
@@ -109,8 +109,8 @@ public class MetadataTransfer {
             mdToTransfer.add(maxDepthKeyName);
         }
 
-        mdToTransfer.addAll(ConfUtils.loadListFromConf(metadataTransferParamName, conf));
-        mdToPersistOnly.addAll(ConfUtils.loadListFromConf(metadataPersistParamName, conf));
+        mdToTransfer.addAll(ConfUtils.loadListFromConf(conf, metadataTransferParamName));
+        mdToPersistOnly.addAll(ConfUtils.loadListFromConf(conf, metadataPersistParamName));
         // always add the fetch error count
         mdToPersistOnly.add(Constants.fetchErrorCountParamName);
     }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/URLPartitioner.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/URLPartitioner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
  * file distributed with this work for additional information regarding copyright ownership.
  * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/URLResolver.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/URLResolver.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.digitalpebble.stormcrawler.util;
 
 import java.net.*;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/URLResolver.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/URLResolver.java
@@ -1,0 +1,177 @@
+package com.digitalpebble.stormcrawler.util;
+
+import java.net.*;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Describes the strategies used by the RemoteDriverProtocol to resolve the given addresses. This is
+ * sometimes necessary, when running in a docker container or special environment.
+ */
+// TODO: Right now it only resolves to the first possible target. Maybe we need some kind of
+//  regex-pattern-matching for multiple resolved addresses at some point?
+public enum URLResolver {
+    NOTHING {
+        @NotNull
+        @Override
+        public URL resolveDirect(@NotNull URL url) {
+            return url;
+        }
+
+        @Override
+        public ResolvedUrl resolve(@NotNull URL url) {
+            return ResolvedUrl.of(url);
+        }
+
+        @Contract("_ -> fail")
+        @NotNull
+        @Override
+        protected String resolveHostAddress(@NotNull URL url) throws UnsupportedOperationException {
+            throw new UnsupportedOperationException(
+                    "Nothing does literally nothing else than returning the same value.");
+        }
+    },
+    IP {
+        @NotNull
+        @Override
+        protected String resolveHostAddress(@NotNull URL url) throws UnknownHostException {
+            final InetAddress byName = InetAddress.getByName(url.getHost());
+            return byName.getHostAddress();
+        }
+    },
+    IPv4 {
+        @NotNull
+        @Override
+        protected String resolveHostAddress(@NotNull URL url) throws UnknownHostException {
+            final InetAddress byName = Inet4Address.getByName(url.getHost());
+            return byName.getHostAddress();
+        }
+    },
+    /** Only resolves if IPv6 is possible. Otherwise, uses IPv4. */
+    IPv6 {
+        @NotNull
+        @Override
+        protected String resolveHostAddress(@NotNull URL url) throws UnknownHostException {
+            final InetAddress byName = Inet6Address.getByName(url.getHost());
+            return byName.getHostAddress();
+        }
+    },
+    HOSTNAME {
+        @NotNull
+        @Override
+        protected String resolveHostAddress(@NotNull URL url) throws UnknownHostException {
+            final InetAddress byName = InetAddress.getByName(url.getHost());
+            return byName.getHostName();
+        }
+    },
+    CANONICAL_HOSTNAME {
+        @NotNull
+        @Override
+        protected String resolveHostAddress(@NotNull URL url) throws UnknownHostException {
+            final InetAddress byName = InetAddress.getByName(url.getHost());
+            return byName.getCanonicalHostName();
+        }
+    };
+
+    protected static final org.slf4j.Logger LOG = LoggerFactory.getLogger(URLResolver.class);
+
+    /** A simple pair of original and resolved url. */
+    public static final class ResolvedUrl {
+        private final @NotNull URL origin;
+        private final @Nullable URL resolved;
+
+        public ResolvedUrl(@NotNull URL origin, @Nullable URL resolved) {
+            this.origin = origin;
+            this.resolved = resolved;
+        }
+
+        /**
+         * Creates a {@code URLTuple} with the given {@code origin} as {@code origin} and {@code
+         * resolved}.
+         */
+        @NotNull
+        public static ResolvedUrl of(@NotNull URL origin) {
+            return new ResolvedUrl(origin, origin);
+        }
+
+        /** Creates a {@code URLTuple} with the given {@code origin} and {@code resolved} URL. */
+        @NotNull
+        public static ResolvedUrl of(@NotNull URL origin, @Nullable URL resolved) {
+            return new ResolvedUrl(origin, resolved);
+        }
+
+        @NotNull
+        public URL getOrigin() {
+            return origin;
+        }
+
+        @Nullable
+        public URL getResolved() {
+            return resolved;
+        }
+
+        /**
+         * Returns either the {@link ResolvedUrl#resolved} url or the {@link ResolvedUrl#origin} if
+         * the resolving failed.
+         */
+        @NotNull
+        public URL getResolvedOrOrigin() {
+            if (resolved != null) return resolved;
+            return origin;
+        }
+
+        /** Returns true, if resolved is not null. */
+        @Contract(pure = true)
+        public boolean wasSuccessfullyResolved() {
+            return resolved != null;
+        }
+
+        /** Returns true, if resolved is null due to failed resolving. */
+        @Contract(pure = true)
+        public boolean wasNotSuccessfullyResolved() {
+            return resolved == null;
+        }
+
+        @Override
+        public String toString() {
+            return "ResolvedUrl{" + "origin=" + origin + ", resolved=" + resolved + '}';
+        }
+    }
+
+    /**
+     * Tries to resolve the given {@code url} to a specific target. Returns {@code null} if it can
+     * not resolve the {@code url}.
+     */
+    @Nullable
+    public URL resolveDirect(@NotNull URL url) {
+        String replacement = null;
+        try {
+            replacement = resolveHostAddress(url);
+            return new URL(url.getProtocol(), replacement, url.getPort(), url.getFile());
+        } catch (UnknownHostException e) {
+            LOG.warn("Was not able to resolve the address {} to {}.", url.toExternalForm(), name());
+            return null;
+        } catch (MalformedURLException e) {
+            LOG.warn(
+                    "Was not able to create the new URL from {} with {} in {}.",
+                    url.toExternalForm(),
+                    replacement,
+                    name());
+            return null;
+        }
+    }
+
+    /**
+     * Tries to resolve the given {@code url} to a specific target. Always returns a {@link
+     * ResolvedUrl} instance.
+     */
+    public ResolvedUrl resolve(@NotNull URL url) {
+        return ResolvedUrl.of(url, resolveDirect(url));
+    }
+
+    /** Returns a string used as host-part in the new url. */
+    @NotNull
+    protected abstract String resolveHostAddress(@NotNull URL url) throws UnknownHostException;
+}

--- a/core/src/test/java/com/digitalpebble/stormcrawler/indexer/DummyIndexer.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/indexer/DummyIndexer.java
@@ -17,7 +17,6 @@ package com.digitalpebble.stormcrawler.indexer;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.indexing.AbstractIndexerBolt;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.storm.task.OutputCollector;
@@ -64,9 +63,7 @@ public class DummyIndexer extends AbstractIndexerBolt {
         // which metadata to display?
         Map<String, String[]> keyVals = filterMetadata(metadata);
 
-        Iterator<String> iterator = keyVals.keySet().iterator();
-        while (iterator.hasNext()) {
-            String fieldName = iterator.next();
+        for (String fieldName : keyVals.keySet()) {
             String[] values = keyVals.get(fieldName);
             for (String value : values) {
                 fields.put(fieldName, value);

--- a/core/src/test/java/com/digitalpebble/stormcrawler/protocol/RemoteDriverProtocolTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/protocol/RemoteDriverProtocolTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.digitalpebble.stormcrawler.protocol;
 
 import static org.junit.Assert.fail;

--- a/core/src/test/java/com/digitalpebble/stormcrawler/protocol/RemoteDriverProtocolTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/protocol/RemoteDriverProtocolTest.java
@@ -47,7 +47,7 @@ public class RemoteDriverProtocolTest {
                                 new URL("http://127.0.0.1:4444/"),
                                 new URL("http://127.0.0.1:4444/"),
                                 new URL("http://127.0.0.1:4444/"),
-                                new URL("http://view-localhost:4444"),
+                                new URL("http://localhost:4444"),
                                 new URL("http://localhost:4444/"),
                             }
                         },

--- a/core/src/test/java/com/digitalpebble/stormcrawler/protocol/RemoteDriverProtocolTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/protocol/RemoteDriverProtocolTest.java
@@ -1,0 +1,96 @@
+package com.digitalpebble.stormcrawler.protocol;
+
+import static org.junit.Assert.fail;
+
+import com.digitalpebble.stormcrawler.protocol.selenium.RemoteDriverProtocol;
+import com.digitalpebble.stormcrawler.util.ConfUtils;
+import com.digitalpebble.stormcrawler.util.URLResolver;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.storm.Config;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class RemoteDriverProtocolTest {
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static List<Object> parametersForTesting() {
+        try {
+
+            return Arrays.asList(
+                    new Object[][] {
+                        {
+                            "selenium/selenium_mixed_config.yaml",
+                            new URL[] {
+                                new URL("http://stormcrawler.net/"),
+                                new URL("http://stormcrawler.net/"),
+                                new URL("http://stormcrawler.net/"),
+                                new URL("http://127.0.0.1:4444/"),
+                                new URL("http://127.0.0.1:4444/"),
+                                new URL("http://127.0.0.1:4444/"),
+                                new URL("http://view-localhost:4444"),
+                                new URL("http://localhost:4444/"),
+                            }
+                        },
+                        {
+                            "selenium/selenium_single_simple_config.yaml",
+                            new URL[] {
+                                new URL("http://stormcrawler.net/"),
+                            }
+                        },
+                        {
+                            "selenium/selenium_multiple_simple_config.yaml",
+                            new URL[] {
+                                new URL("http://stormcrawler.net/"),
+                                new URL("https://google.de/"),
+                                new URL("https://amazon.de/"),
+                            }
+                        },
+                        {
+                            "selenium/selenium_single_complex_config.yaml",
+                            new URL[] {
+                                new URL("http://127.0.0.1:9000/"),
+                            }
+                        },
+                        {
+                            "selenium/selenium_multiple_complex_config.yaml",
+                            new URL[] {
+                                new URL("http://127.0.0.1:9000/"),
+                                new URL("http://stormcrawler.net/"),
+                                new URL("http://127.0.0.1:5555/"),
+                            }
+                        },
+                    });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Parameterized.Parameter public String pathToConfig;
+
+    @Parameterized.Parameter(1)
+    public Object[] expected;
+
+    @Test
+    public void test_configs() {
+        Config config = new Config();
+        ConfUtils.loadConfigIntoTarget(pathToConfig, config);
+        List<URLResolver.ResolvedUrl> urls;
+        try {
+            urls = RemoteDriverProtocol.loadURLsFromConfig(config);
+        } catch (MalformedURLException e) {
+            fail("There shouldn't be any malformed urls.");
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertNotNull(urls);
+
+        Assert.assertArrayEquals(
+                expected, urls.stream().map(URLResolver.ResolvedUrl::getResolved).toArray());
+    }
+}

--- a/core/src/test/java/com/digitalpebble/stormcrawler/util/InitialisationUtilTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/util/InitialisationUtilTest.java
@@ -101,15 +101,6 @@ public class InitialisationUtilTest {
                 RuntimeException.class,
                 () ->
                         InitialisationUtil.initializeFromQualifiedName(
-                                ITestInterface.class.getName(), ITestInterface.class));
-    }
-
-    @Test
-    public void fails_if_class_to_initialize_is_abstract() {
-        Assert.assertThrows(
-                RuntimeException.class,
-                () ->
-                        InitialisationUtil.initializeFromQualifiedName(
                                 AbstractClass.class.getName(), AbstractClass.class));
     }
 

--- a/core/src/test/resources/selenium/selenium_mixed_config.yaml
+++ b/core/src/test/resources/selenium/selenium_mixed_config.yaml
@@ -1,0 +1,16 @@
+selenium.addresses:
+  # Similar to the second address
+  - http://stormcrawler.net/
+  - address: http://stormcrawler.net/
+  - address: http://stormcrawler.net/
+    resolve: NOTHING
+  - address: http://localhost:4444/
+    resolve: IP
+  - address: http://localhost:4444/
+    resolve: IPv4
+  - address: http://localhost:4444/
+    resolve: IPv6
+  - address: http://127.0.0.1:4444
+    resolve: HOSTNAME
+  - address: http://localhost:4444/
+    resolve: CANONICAL_HOSTNAME

--- a/core/src/test/resources/selenium/selenium_multiple_complex_config.yaml
+++ b/core/src/test/resources/selenium/selenium_multiple_complex_config.yaml
@@ -1,0 +1,9 @@
+selenium.addresses:
+  # Similar to the second address
+  - address: http://localhost:9000/
+    resolve: IPv4
+
+  - address: http://stormcrawler.net/
+
+  - address: http://localhost:5555/
+    resolve: IPv4

--- a/core/src/test/resources/selenium/selenium_multiple_simple_config.yaml
+++ b/core/src/test/resources/selenium/selenium_multiple_simple_config.yaml
@@ -1,0 +1,5 @@
+selenium.addresses:
+  # Similar to the second address
+  - http://stormcrawler.net/
+  - https://google.de/
+  - https://amazon.de/

--- a/core/src/test/resources/selenium/selenium_single_complex_config.yaml
+++ b/core/src/test/resources/selenium/selenium_single_complex_config.yaml
@@ -1,0 +1,4 @@
+selenium.addresses:
+  # Similar to the second address
+  - address: http://localhost:9000/
+    resolve: IPv4

--- a/core/src/test/resources/selenium/selenium_single_simple_config.yaml
+++ b/core/src/test/resources/selenium/selenium_single_simple_config.yaml
@@ -1,0 +1,3 @@
+selenium.addresses:
+  # Similar to the second address
+  - http://stormcrawler.net/

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/ElasticSearchConnection.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/ElasticSearchConnection.java
@@ -77,7 +77,7 @@ public class ElasticSearchConnection {
     public static RestHighLevelClient getClient(Map stormConf, String boltType) {
 
         List<String> confighosts =
-                ConfUtils.loadListFromConf("es." + boltType + ".addresses", stormConf);
+                ConfUtils.loadListFromConf(stormConf, "es." + boltType + ".addresses");
 
         List<HttpHost> hosts = new ArrayList<>();
 

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/persistence/AbstractSpout.java
@@ -146,7 +146,7 @@ public abstract class AbstractSpout extends AbstractQueryingSpout {
 
         partitionField = ConfUtils.getString(stormConf, ESStatusBucketFieldParamName, "key");
 
-        bucketSortField = ConfUtils.loadListFromConf(ESStatusBucketSortFieldParamName, stormConf);
+        bucketSortField = ConfUtils.loadListFromConf(stormConf, ESStatusBucketSortFieldParamName);
 
         totalSortField = ConfUtils.getString(stormConf, ESStatusGlobalSortFieldParamName);
 
@@ -155,7 +155,7 @@ public abstract class AbstractSpout extends AbstractQueryingSpout {
 
         queryTimeout = ConfUtils.getInt(stormConf, ESStatusQueryTimeoutParamName, -1);
 
-        filterQueries = ConfUtils.loadListFromConf(ESStatusFilterParamName, stormConf);
+        filterQueries = ConfUtils.loadListFromConf(stormConf, ESStatusFilterParamName);
     }
 
     /** Builds a query and use it retrieve the results from ES * */

--- a/external/tika/src/main/java/com/digitalpebble/stormcrawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/com/digitalpebble/stormcrawler/tika/ParserBolt.java
@@ -119,7 +119,7 @@ public class ParserBolt extends BaseRichBolt {
             throw e;
         }
 
-        mimeTypeWhiteList = ConfUtils.loadListFromConf("parser.mimetype.whitelist", conf);
+        mimeTypeWhiteList = ConfUtils.loadListFromConf(conf, "parser.mimetype.whitelist");
 
         protocolMDprefix = ConfUtils.getString(conf, ProtocolResponse.PROTOCOL_MD_PREFIX_PARAM, "");
 


### PR DESCRIPTION
Hello @jnioche,

while working with docker and SC I recognized, that the SeleniumProtocol has sometimes problems with resolving the name of the SeleniumHub like `http://seleniumhub:4444` to an IP-address.
To fix that unwanted behaviour of failing to resolve the host, I wrote a backwards-compatible extension for the `selenium.addresses` config part. (Old configs should have no problem with the new extension, you can check that in the unit tests.)

Furthermore I cleaned up the ConfUtils and cleaned the irregular method interfaces (before that it was a mix of `<method>(String, Config)` and `<method>(Config, String)`). I also added some additional helper methods that should improve the ease of use of the config in general.

Best Regards

Felix

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'
* The code is properly formatted with 'mvn git-code-format:format-code -Dgcf.globPattern=**/*'

Thanks!

