### PR TITLE
Centralize partitioning, fix RobotRules

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/URLPartitionerBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/URLPartitionerBolt.java
@@ -14,10 +14,9 @@
  */
 package com.digitalpebble.stormcrawler.bolt;
 
-import com.digitalpebble.stormcrawler.Constants;
 import com.digitalpebble.stormcrawler.Metadata;
-import com.digitalpebble.stormcrawler.util.ConfUtils;
-import crawlercommons.domains.PaidLevelDomain;
+import com.digitalpebble.stormcrawler.util.PartitionMode;
+import com.digitalpebble.stormcrawler.util.PartitionUtil;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -47,36 +46,33 @@ public class URLPartitionerBolt extends BaseRichBolt {
 
     private Map<String, String> cache;
 
-    private String mode = Constants.PARTITION_MODE_HOST;
+    private PartitionMode mode;
 
     @Override
     public void execute(Tuple tuple) {
         String url = tuple.getStringByField("url");
-        Metadata metadata = null;
 
+        Metadata metadata;
         if (tuple.contains("metadata")) metadata = (Metadata) tuple.getValueByField("metadata");
-
-        // maybe there is a field metadata but it can be null
-        // or there was no field at all
-        if (metadata == null) metadata = Metadata.empty;
+        else metadata = Metadata.empty;
 
         String partitionKey = null;
-        String host = "";
 
-        // IP in metadata?
-        if (mode.equalsIgnoreCase(Constants.PARTITION_MODE_IP)) {
+        if (mode == PartitionMode.QUEUE_MODE_IP) {
             String ip_provided = metadata.getFirstValue("ip");
+            // IP in metadata?
             if (StringUtils.isNotBlank(ip_provided)) {
                 partitionKey = ip_provided;
                 eventCounter.scope("provided").incrBy(1);
             }
         }
 
+        // Either not ip or still not assigned
         if (partitionKey == null) {
+            // try to parse
             URL u;
             try {
                 u = new URL(url);
-                host = u.getHost();
             } catch (MalformedURLException e1) {
                 eventCounter.scope("Invalid URL").incrBy(1);
                 LOG.warn("Invalid URL: {}", url);
@@ -84,39 +80,32 @@ public class URLPartitionerBolt extends BaseRichBolt {
                 _collector.ack(tuple);
                 return;
             }
-        }
 
-        // partition by hostname
-        if (mode.equalsIgnoreCase(Constants.PARTITION_MODE_HOST)) partitionKey = host;
-
-        // partition by domain : needs fixing
-        else if (mode.equalsIgnoreCase(Constants.PARTITION_MODE_DOMAIN)) {
-            partitionKey = PaidLevelDomain.getPLD(host);
-        }
-
-        // partition by IP
-        if (mode.equalsIgnoreCase(Constants.PARTITION_MODE_IP) && partitionKey == null) {
-            // try to get it from cache first
-            partitionKey = cache.get(host);
-            if (partitionKey != null) {
-                eventCounter.scope("from cache").incrBy(1);
-            } else {
-                try {
-                    long start = System.currentTimeMillis();
-                    final InetAddress addr = InetAddress.getByName(host);
-                    partitionKey = addr.getHostAddress();
-                    long end = System.currentTimeMillis();
-                    LOG.debug("Resolved IP {} in {} msec for : {}", partitionKey, end - start, url);
-
-                    // add to cache
-                    cache.put(host, partitionKey);
-
-                } catch (final Exception e) {
-                    eventCounter.scope("Unable to resolve IP").incrBy(1);
-                    LOG.warn("Unable to resolve IP for: {}", host);
-                    _collector.ack(tuple);
-                    return;
+            // TODO: Maybe use the getPartitionKeyByMode without the cache? IP address of host could
+            // change over time.
+            if (mode == PartitionMode.QUEUE_MODE_IP) {
+                String host = u.getHost();
+                // try to get it from cache first
+                partitionKey = cache.get(host);
+                if (partitionKey != null) {
+                    eventCounter.scope("from cache").incrBy(1);
+                } else {
+                    try {
+                        final InetAddress addr = InetAddress.getByName(host);
+                        partitionKey = addr.getHostAddress();
+                        // add to cache
+                        cache.put(host, partitionKey);
+                    } catch (final Exception e) {
+                        eventCounter.scope("Unable to resolve IP").incrBy(1);
+                        LOG.warn("Unable to resolve IP for: {}", host);
+                        _collector.ack(tuple);
+                        return;
+                    }
                 }
+            } else {
+                // Always skips the PartitionMode.QUEUE_MODE_IP, but that is okay. We only need to
+                // cover the other cases.
+                partitionKey = PartitionUtil.getPartitionKeyByMode(u, mode);
             }
         }
 
@@ -135,19 +124,7 @@ public class URLPartitionerBolt extends BaseRichBolt {
     public void prepare(
             Map<String, Object> stormConf, TopologyContext context, OutputCollector collector) {
 
-        mode =
-                ConfUtils.getString(
-                        stormConf,
-                        Constants.PARTITION_MODEParamName,
-                        Constants.PARTITION_MODE_HOST);
-
-        // check that the mode is known
-        if (!mode.equals(Constants.PARTITION_MODE_IP)
-                && !mode.equals(Constants.PARTITION_MODE_DOMAIN)
-                && !mode.equals(Constants.PARTITION_MODE_HOST)) {
-            LOG.error("Unknown partition mode : {} - forcing to byHost", mode);
-            mode = Constants.PARTITION_MODE_HOST;
-        }
+        mode = PartitionUtil.readPartitionModeForPartitioner(stormConf);
 
         LOG.info("Using partition mode : {}", mode);
 
@@ -161,7 +138,7 @@ public class URLPartitionerBolt extends BaseRichBolt {
 
         final int MAX_ENTRIES = 500;
         cache =
-                new LinkedHashMap(MAX_ENTRIES + 1, .75F, true) {
+                new LinkedHashMap<String, String>(MAX_ENTRIES + 1, .75F, true) {
                     // This method is called just after a new entry has been added
                     @Override
                     public boolean removeEldestEntry(Map.Entry eldest) {

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/DomainParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/DomainParseFilter.java
@@ -14,15 +14,17 @@
  */
 package com.digitalpebble.stormcrawler.parse.filter;
 
-import com.digitalpebble.stormcrawler.Constants;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.PartitionMode;
+import com.digitalpebble.stormcrawler.util.PartitionUtil;
 import com.digitalpebble.stormcrawler.util.URLPartitioner;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.HashMap;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.DocumentFragment;
 
 /** Adds domain (or host) to metadata - can be used later on for indexing * */
@@ -38,23 +40,27 @@ public class DomainParseFilter extends ParseFilter {
             mdKey = node.asText("domain");
         }
 
-        String partitionMode = Constants.PARTITION_MODE_DOMAIN;
+        PartitionMode partitionMode = PartitionMode.QUEUE_MODE_DOMAIN;
 
-        node = filterParams.get("byHost");
+        node = filterParams.get(PartitionMode.QUEUE_MODE_HOST.label);
         if (node != null && node.asBoolean()) {
-            partitionMode = Constants.PARTITION_MODE_HOST;
+            partitionMode = PartitionMode.QUEUE_MODE_HOST;
         }
 
         partitioner = new URLPartitioner();
-        Map config = new HashMap();
-        config.put(Constants.PARTITION_MODEParamName, partitionMode);
+        Map<String, Object> config = new HashMap<>();
+        config.put(PartitionUtil.PARTITION_MODE_PARAM_NAME, partitionMode);
         partitioner.configure(config);
     }
 
     @Override
-    public void filter(String URL, byte[] content, DocumentFragment doc, ParseResult parse) {
-        Metadata metadata = parse.get(URL).getMetadata();
-        String value = partitioner.getPartition(URL, metadata);
+    public void filter(
+            @NotNull String url,
+            byte[] content,
+            @Nullable DocumentFragment doc,
+            @NotNull ParseResult parse) {
+        Metadata metadata = parse.get(url).getMetadata();
+        String value = partitioner.getPartition(url, metadata);
         metadata.setValue(mdKey, value);
     }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/RobotRules.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/RobotRules.java
@@ -15,7 +15,9 @@
 package com.digitalpebble.stormcrawler.protocol;
 
 import crawlercommons.robots.BaseRobotRules;
+import crawlercommons.robots.SimpleRobotRules;
 import java.util.List;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * Wrapper for BaseRobotRules which tracks the number of requests and length of the responses needed
@@ -78,7 +80,17 @@ public class RobotRules extends crawlercommons.robots.BaseRobotRules {
 
     @Override
     public boolean equals(Object obj) {
-        return base.equals(obj);
+        if (obj == null) return false;
+        if (!(obj instanceof BaseRobotRules)) return false;
+
+        BaseRobotRules instance = (BaseRobotRules) obj;
+
+        if (instance instanceof RobotRules) {
+            // unwrapp the robot rules to assure that equals works.
+            instance = ((RobotRules) instance).base;
+        }
+
+        return base.equals(instance);
     }
 
     @Override
@@ -94,5 +106,13 @@ public class RobotRules extends crawlercommons.robots.BaseRobotRules {
     @Override
     public void addSitemap(String sitemap) {
         base.addSitemap(sitemap);
+    }
+
+    @TestOnly
+    public static void main(String[] args) {
+        SimpleRobotRules wrappee = new SimpleRobotRules();
+        RobotRules a = new RobotRules(wrappee);
+        RobotRules b = new RobotRules(wrappee);
+        System.out.println(a.equals(b));
     }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/PartitionMode.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/PartitionMode.java
@@ -14,16 +14,21 @@
  */
 package com.digitalpebble.stormcrawler.util;
 
+import java.util.HashMap;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.LoggerFactory;
 
 public enum PartitionMode {
     QUEUE_MODE_HOST("byHost"),
     QUEUE_MODE_DOMAIN("byDomain"),
     QUEUE_MODE_IP("byIP");
 
-    public final String label;
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(PartitionMode.class);
+
+    /** The label of the mode */
+    public final @NotNull String label;
 
     PartitionMode(@NotNull String label) {
         this.label = label;
@@ -33,12 +38,7 @@ public enum PartitionMode {
     @Contract("null -> null")
     public static PartitionMode parseQueueModeLabel(@Nullable String label) {
         if (label == null) return null;
-        for (PartitionMode tmp : PartitionMode.values()) {
-            if (tmp.label.equalsIgnoreCase(label) || tmp.toString().equalsIgnoreCase(label)) {
-                return tmp;
-            }
-        }
-        return null;
+        return lookup.get(label.toLowerCase());
     }
 
     @NotNull
@@ -49,5 +49,56 @@ public enum PartitionMode {
             return defaultValue;
         }
         return parsed;
+    }
+
+    /*
+     * A size of 16 with a load-factor of 1.0 is enough for a HashMap to contain the hashes of the
+     * three name() and label values without collision.
+     * You can check by this:
+     *
+     * // Code from java.util.HashMap 10.02.2022
+     * static int hash(Object key) {
+     *     int h;
+     *     return (key == null) ? 0 : (h = key.hashCode()) ^ (h >>> 16);
+     * }
+     * public static void main(String[] args){
+     *     int internalArrayLength = 16;
+     *     int[] hits = new int[internalArrayLength];
+     *     for (PartitionMode value : PartitionMode.values()) {
+     *         hits[(hits.length - 1) & hash(value.label.toLowerCase())]++;
+     *         hits[(hits.length - 1) & hash(value.name().toLowerCase())]++;
+     *     }
+     *     for (int i = 0; i < hits.length; i++) {
+     *         System.out.println(i+": "+hits[i]);
+     *     }
+     *     int expectedNumberOfHits = PartitionMode.values().length*2;
+     *     int actualNumberOfUniqueHits = (int) java.util.Arrays.stream(hits).filter(value -> value == 1).count();
+     *     int expectedNumberOfNoHits = hits.length - expectedNumberOfHits;
+     *     int actualNumberOfNoHits = (int) java.util.Arrays.stream(hits).filter(value -> value == 0).count();
+     *     System.out.println("Got "+actualNumberOfUniqueHits+" out of "+ expectedNumberOfHits + " expected hits.");
+     *     System.out.println("Got "+actualNumberOfNoHits+" out of "+ expectedNumberOfNoHits + " expected non hits.");
+     * }
+     */
+    private static final HashMap<String, PartitionMode> lookup = new HashMap<>(16, 1.0f);
+
+    static {
+        PartitionMode[] values = PartitionMode.values();
+        PartitionMode tmp;
+        for (PartitionMode mode : values) {
+            if ((tmp = lookup.put(mode.name().toLowerCase(), mode)) != null) {
+                LOG.warn(
+                        "Replaces {} with {} due to same key value of the name {}",
+                        tmp,
+                        mode,
+                        mode.name().toLowerCase());
+            }
+            if ((tmp = lookup.put(mode.label.toLowerCase(), mode)) != null) {
+                LOG.warn(
+                        "Replaces {} with {} due to same key value of the label {}",
+                        tmp,
+                        mode,
+                        mode.label.toLowerCase());
+            }
+        }
     }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/PartitionMode.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/PartitionMode.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.util;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public enum PartitionMode {
+    QUEUE_MODE_HOST("byHost"),
+    QUEUE_MODE_DOMAIN("byDomain"),
+    QUEUE_MODE_IP("byIP");
+
+    public final String label;
+
+    PartitionMode(@NotNull String label) {
+        this.label = label;
+    }
+
+    @Nullable
+    @Contract("null -> null")
+    public static PartitionMode parseQueueModeLabel(@Nullable String label) {
+        if (label == null) return null;
+        for (PartitionMode tmp : PartitionMode.values()) {
+            if (tmp.label.equalsIgnoreCase(label) || tmp.toString().equalsIgnoreCase(label)) {
+                return tmp;
+            }
+        }
+        return null;
+    }
+
+    @NotNull
+    public static PartitionMode parseQueueModeLabelOrDefault(
+            @Nullable String label, @NotNull PartitionMode defaultValue) {
+        PartitionMode parsed = parseQueueModeLabel(label);
+        if (parsed == null) {
+            return defaultValue;
+        }
+        return parsed;
+    }
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/PartitionUtil.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/PartitionUtil.java
@@ -33,8 +33,10 @@ public final class PartitionUtil {
 
     /** Default config key for the queue mode of partitioner */
     public static final String PARTITION_MODE_PARAM_NAME = "partition.url.mode";
+
     /** Default config key for the queue mode of fetcher */
     public static final String DEFAULT_PARTITION_MODE_FOR_FETCHER_KEY = "fetcher.queue.mode";
+
     /** Default fallback value for the queue mode */
     public static final PartitionMode DEFAULT_FALLBACK_PARTITION_MODE =
             PartitionMode.QUEUE_MODE_HOST;
@@ -58,10 +60,11 @@ public final class PartitionUtil {
 
         PartitionMode partitionMode;
 
-        // In some cases the partitionmode is set as enum value
+        // In some cases the partition mode might be set as enum value in the config
         if (partitionModeValue instanceof PartitionMode) {
             partitionMode = (PartitionMode) partitionModeValue;
         } else {
+            // Stay compatible with old configs.
             partitionMode = PartitionMode.parseQueueModeLabel((String) partitionModeValue);
         }
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/PartitionUtil.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/PartitionUtil.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.util;
+
+import crawlercommons.domains.PaidLevelDomain;
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Locale;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.LoggerFactory;
+
+public final class PartitionUtil {
+
+    // TODO: Cache for IP resolver? What about changing IP over time?
+
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(PartitionUtil.class);
+
+    private PartitionUtil() {}
+
+    /** Default config key for the queue mode of partitioner */
+    public static final String PARTITION_MODE_PARAM_NAME = "partition.url.mode";
+    /** Default config key for the queue mode of fetcher */
+    public static final String DEFAULT_PARTITION_MODE_FOR_FETCHER_KEY = "fetcher.queue.mode";
+    /** Default fallback value for the queue mode */
+    public static final PartitionMode DEFAULT_FALLBACK_PARTITION_MODE =
+            PartitionMode.QUEUE_MODE_HOST;
+
+    /**
+     * Reads the {@link PartitionMode} from the given {@code stormConf} with the provided {@code
+     * partitionModeKey}. If the value at {@code partitionModeKey} is null or invalid it returns the
+     * {@code fallback}.
+     *
+     * @param stormConf reference to the config.
+     * @param partitionModeKey config key to the queue mode.
+     * @param fallback fallback value if the value at {@code partitionModeKey} is not valid.
+     * @return the extracted {@link PartitionMode}
+     */
+    @NotNull
+    public static PartitionMode readPartitionMode(
+            @NotNull Map<String, Object> stormConf,
+            @NotNull String partitionModeKey,
+            @NotNull PartitionMode fallback) {
+        Object partitionModeValue = stormConf.get(partitionModeKey);
+
+        PartitionMode partitionMode;
+
+        // In some cases the partitionmode is set as enum value
+        if (partitionModeValue instanceof PartitionMode) {
+            partitionMode = (PartitionMode) partitionModeValue;
+        } else {
+            partitionMode = PartitionMode.parseQueueModeLabel((String) partitionModeValue);
+        }
+
+        if (partitionMode == null) {
+            LOG.error(
+                    "Unknown partition mode : {} - forcing to {}",
+                    partitionModeValue,
+                    fallback.label);
+            partitionMode = fallback;
+        }
+
+        return partitionMode;
+    }
+
+    /**
+     * Reads the {@link PartitionMode} from the given {@code stormConf} with the default value
+     * {@value DEFAULT_PARTITION_MODE_FOR_FETCHER_KEY} and {@code defaultFallbackQueueMode}.
+     *
+     * @param stormConf reference to the config
+     * @return the extracted {@link PartitionMode}
+     */
+    @NotNull
+    public static PartitionMode readPartitionModeForFetcher(
+            @NotNull Map<String, Object> stormConf) {
+        return readPartitionMode(
+                stormConf, DEFAULT_PARTITION_MODE_FOR_FETCHER_KEY, DEFAULT_FALLBACK_PARTITION_MODE);
+    }
+
+    /**
+     * Reads the {@link PartitionMode} from the given {@code stormConf} with the default value
+     * {@value DEFAULT_PARTITION_MODE_FOR_FETCHER_KEY} and {@code defaultFallbackQueueMode}.
+     *
+     * @param stormConf reference to the config
+     * @return the extracted {@link PartitionMode}
+     */
+    @NotNull
+    public static PartitionMode readPartitionModeForPartitioner(
+            @NotNull Map<String, Object> stormConf) {
+        return readPartitionMode(
+                stormConf, PARTITION_MODE_PARAM_NAME, DEFAULT_FALLBACK_PARTITION_MODE);
+    }
+
+    /**
+     * Gets the key for the fetcher queue from the given {@code url} by the provided {@code
+     * queueMode}.
+     *
+     * @param url used for the key extraction.
+     * @param partitionMode describing the required key information
+     * @return a string value from the {@code url} for a queue.
+     */
+    @NotNull
+    public static String getPartitionKeyByMode(
+            @NotNull URL url, @NotNull PartitionMode partitionMode) {
+        // Origin: FetchItem.create
+
+        String key = null;
+
+        switch (partitionMode) {
+            case QUEUE_MODE_IP:
+                try {
+                    final InetAddress addr = InetAddress.getByName(url.getHost());
+                    key = addr.getHostAddress();
+                } catch (final UnknownHostException e) {
+                    LOG.warn("Unable to resolve IP for {}, using hostname as key.", url.getHost());
+                    key = url.getHost();
+                }
+                break;
+            case QUEUE_MODE_DOMAIN:
+                key = PaidLevelDomain.getPLD(url.getHost());
+                if (key == null) {
+                    LOG.warn("Unknown domain for url: {}, using hostname as key.", url);
+                    key = url.getHost();
+                }
+                break;
+            case QUEUE_MODE_HOST:
+                key = url.getHost();
+                break;
+        }
+
+        if (key == null) {
+            LOG.warn("Unknown host for url: {}, using URL string as key", url);
+            key = url.toExternalForm();
+        }
+
+        return key.toLowerCase(Locale.ROOT);
+    }
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/URLPartitioner.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/URLPartitioner.java
@@ -32,7 +32,7 @@ public final class URLPartitioner {
 
     private static final Logger LOG = LoggerFactory.getLogger(URLPartitioner.class);
 
-    private PartitionMode mode = PartitionMode.QUEUE_MODE_DOMAIN;
+    private PartitionMode mode = PartitionMode.QUEUE_MODE_HOST;
 
     /**
      * Returns the host, domain, IP of a URL so that it can be partitioned for politeness, depending
@@ -67,6 +67,7 @@ public final class URLPartitioner {
         return partitionKey;
     }
 
+    /** Configure the partitioner with the given */
     public void configure(Map<String, Object> stormConf) {
         mode = PartitionUtil.readPartitionModeForPartitioner(stormConf);
         LOG.info("Using partition mode : {}", mode);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/URLStreamGrouping.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/URLStreamGrouping.java
@@ -14,7 +14,6 @@
  */
 package com.digitalpebble.stormcrawler.util;
 
-import com.digitalpebble.stormcrawler.Constants;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
@@ -25,6 +24,7 @@ import org.apache.storm.generated.GlobalStreamId;
 import org.apache.storm.grouping.CustomStreamGrouping;
 import org.apache.storm.shade.org.apache.commons.lang.StringUtils;
 import org.apache.storm.task.WorkerTopologyContext;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,18 +65,20 @@ public class URLStreamGrouping implements CustomStreamGrouping, Serializable {
 
     @Override
     public void prepare(
-            WorkerTopologyContext context, GlobalStreamId stream, List<Integer> targetTasks) {
+            WorkerTopologyContext context,
+            GlobalStreamId stream,
+            @NotNull List<Integer> targetTasks) {
         this.targetTask = targetTasks;
         partitioner = new URLPartitioner();
         if (StringUtils.isNotBlank(partitionMode)) {
-            Map<String, String> conf = new HashMap<>();
-            conf.put(Constants.PARTITION_MODEParamName, partitionMode);
+            Map<String, Object> conf = new HashMap<>();
+            conf.put(PartitionUtil.PARTITION_MODE_PARAM_NAME, partitionMode);
             partitioner.configure(conf);
         }
     }
 
     @Override
-    public List<Integer> chooseTasks(int taskId, List<Object> values) {
+    public List<Integer> chooseTasks(int taskId, @NotNull List<Object> values) {
         // optimisation : single target
         if (targetTask.size() == 1) {
             return targetTask;


### PR DESCRIPTION
Hello @jnioche,

I hope I don't overdo it with my PRs, but I really did a lot in the last few months. ^^'
So many thanks in advance for your patience, support and help. :)

As the title says this PR aims to clean up the decentralized handling of the partitioning keys and parsing logic.
In order to reach that goal I removed 3 different parsing/handling implementations of the very same feature and unified it in a single implementation in `PartitionMode` and `PartitionUtil`.

The syntax of the config doesn't change, only the places where it is parsed and handled. Furthermore I improved the way we handle the interpretation of the values because I copied the most stable implementation of the three and used it as a base for the new one.

The pros of this PR are:
- Removes multiple implementations for the same logic and replaces it with a single, reliable one.
- Remove redeclaration of the same constant string values (`byHost` etc.) in multiple files.
- Reduces the overall loc and makes the rest of the functions clearer to the reader.
- Improve security and stability of code by unifying the interpretation of the partitioning keys.

Furthermore I fixed a bug where the `equals` method of `RobotRules` always fails.

Best Regards

Felix

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
