### PR TITLE
Rewrote LinkParseFUlter + added XPathFilter + tests for JSOUPFilters

### DIFF
--- a/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -56,6 +56,7 @@ config:
 
   parsefilters.config.file: "parsefilters.json"
   urlfilters.config.file: "urlfilters.json"
+  jsoup.filters.config.file: "jsoupfilters.json"
 
   # revisit a page daily (value in minutes)
   # set it to -1 to never refetch a page

--- a/archetype/src/main/resources/archetype-resources/src/main/resources/jsoupfilters.json
+++ b/archetype/src/main/resources/archetype-resources/src/main/resources/jsoupfilters.json
@@ -1,7 +1,7 @@
 {
   "com.digitalpebble.stormcrawler.parse.JSoupFilters": [
     {
-      "class": "com.digitalpebble.stormcrawler.parse.filter.XPathFilter",
+      "class": "com.digitalpebble.stormcrawler.jsoup.XPathFilter",
       "name": "XPathFilter",
       "params": {
         "canonical": "//*[@rel=\"canonical\"]/@href",

--- a/archetype/src/main/resources/archetype-resources/src/main/resources/jsoupfilters.json
+++ b/archetype/src/main/resources/archetype-resources/src/main/resources/jsoupfilters.json
@@ -1,0 +1,27 @@
+{
+  "com.digitalpebble.stormcrawler.parse.JSoupFilters": [
+    {
+      "class": "com.digitalpebble.stormcrawler.parse.filter.XPathFilter",
+      "name": "XPathFilter",
+      "params": {
+        "canonical": "//*[@rel=\"canonical\"]/@href",
+        "parse.description": [
+          "//*[@name=\"description\"]/@content",
+          "//*[@name=\"Description\"]/@content"
+        ],
+        "parse.title": [
+          "//TITLE/tidyText()",
+          "//META[@name=\"title\"]/@content"
+        ],
+        "parse.keywords": "//META[@name=\"keywords\"]/@content"
+      }
+    },
+    {
+      "class": "com.digitalpebble.stormcrawler.jsoup.LinkParseFilter",
+      "name": "LinkParseFilter",
+      "params": {
+        "pattern": "//FRAME/@src"
+      }
+    }
+  ]
+}

--- a/archetype/src/main/resources/archetype-resources/src/main/resources/parsefilters.json
+++ b/archetype/src/main/resources/archetype-resources/src/main/resources/parsefilters.json
@@ -1,29 +1,6 @@
 {
   "com.digitalpebble.stormcrawler.parse.ParseFilters": [
     {
-      "class": "com.digitalpebble.stormcrawler.parse.filter.XPathFilter",
-      "name": "XPathFilter",
-      "params": {
-        "canonical": "//*[@rel=\"canonical\"]/@href",
-        "parse.description": [
-            "//*[@name=\"description\"]/@content",
-            "//*[@name=\"Description\"]/@content"
-         ],
-        "parse.title": [
-            "//TITLE",
-            "//META[@name=\"title\"]/@content"
-         ],
-         "parse.keywords": "//META[@name=\"keywords\"]/@content"
-      }
-    },
-    {
-      "class": "com.digitalpebble.stormcrawler.parse.filter.LinkParseFilter",
-      "name": "LinkParseFilter",
-      "params": {
-         "pattern": "//FRAME/@src"
-       }
-    },
-    {
       "class": "com.digitalpebble.stormcrawler.parse.filter.DomainParseFilter",
       "name": "DomainParseFilter",
       "params": {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,6 +30,7 @@
 		<cli.version>1.5.0</cli.version>
 		<okhttp.version>4.9.3</okhttp.version>
 		<caffeine.version>2.9.3</caffeine.version>
+		<xsoup.version>0.3.2</xsoup.version>
 	</properties>
 
 	<build>
@@ -209,10 +210,17 @@
 		</dependency>
 
 		<dependency>
+			<groupId>us.codecraft</groupId>
+			<artifactId>xsoup</artifactId>
+			<version>${xsoup.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
 			<version>${okhttp.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp-brotli</artifactId>

--- a/core/src/main/java/com/digitalpebble/stormcrawler/jsoup/XPathFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/jsoup/XPathFilter.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.jsoup;
+
+import com.digitalpebble.stormcrawler.Metadata;
+import com.digitalpebble.stormcrawler.parse.JSoupFilter;
+import com.digitalpebble.stormcrawler.parse.ParseData;
+import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import us.codecraft.xsoup.XPathEvaluator;
+import us.codecraft.xsoup.Xsoup;
+
+/** Reads a XPATH patterns and stores the value found in web page as metadata */
+public class XPathFilter extends JSoupFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(XPathFilter.class);
+
+    protected final Map<String, List<LabelledExpression>> expressions = new HashMap<>();
+
+    class LabelledExpression {
+
+        String key;
+
+        private XPathEvaluator expression;
+        private String xpath;
+
+        private LabelledExpression(String key, String xpath) {
+            this.key = key;
+            this.xpath = xpath;
+            this.expression = Xsoup.compile(xpath);
+        }
+
+        List<String> evaluate(org.jsoup.nodes.Document doc) throws IOException {
+            return expression.evaluate(doc).list();
+        }
+
+        public String toString() {
+            return key + ":" + xpath;
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public void configure(@NotNull Map stormConf, @NotNull JsonNode filterParams) {
+        super.configure(stormConf, filterParams);
+        java.util.Iterator<Entry<String, JsonNode>> iter = filterParams.fields();
+        while (iter.hasNext()) {
+            Entry<String, JsonNode> entry = iter.next();
+            String key = entry.getKey();
+            JsonNode node = entry.getValue();
+            if (node.isArray()) {
+                for (JsonNode expression : node) {
+                    addExpression(key, expression);
+                }
+            } else {
+                addExpression(key, entry.getValue());
+            }
+        }
+    }
+
+    private void addExpression(String key, JsonNode expression) {
+        String xpathvalue = expression.asText();
+        try {
+            expressions
+                    .computeIfAbsent(key, k -> new ArrayList<>())
+                    .add(new LabelledExpression(key, xpathvalue));
+        } catch (Exception e) {
+            throw new RuntimeException("Can't compile expression : " + xpathvalue, e);
+        }
+    }
+
+    @Override
+    public void filter(
+            String URL, byte[] content, org.jsoup.nodes.Document doc, ParseResult parse) {
+
+        ParseData parseData = parse.get(URL);
+        Metadata metadata = parseData.getMetadata();
+
+        // applies the XPATH expression in the order in which they are produced
+        java.util.Iterator<List<LabelledExpression>> iter = expressions.values().iterator();
+        while (iter.hasNext()) {
+            List<LabelledExpression> leList = iter.next();
+            for (LabelledExpression le : leList) {
+                try {
+                    List<String> values = le.evaluate(doc);
+                    if (values != null && !values.isEmpty()) {
+                        metadata.addValues(le.key, values);
+                        break;
+                    }
+                } catch (IOException e) {
+                    LOG.error("Error evaluating {}: {}", le.key, e);
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/jsoup/XPathFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/jsoup/XPathFilter.java
@@ -38,7 +38,7 @@ public class XPathFilter extends JSoupFilter {
 
     protected final Map<String, List<LabelledExpression>> expressions = new HashMap<>();
 
-    class LabelledExpression {
+    static class LabelledExpression {
 
         String key;
 

--- a/core/src/test/java/com/digitalpebble/stormcrawler/jsoup/JSoupFiltersTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/jsoup/JSoupFiltersTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.jsoup;
+
+import com.digitalpebble.stormcrawler.Metadata;
+import com.digitalpebble.stormcrawler.TestUtil;
+import com.digitalpebble.stormcrawler.bolt.JSoupParserBolt;
+import com.digitalpebble.stormcrawler.parse.ParsingTester;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.storm.task.OutputCollector;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test the JSoup filters * */
+public class JSoupFiltersTest extends ParsingTester {
+
+    @Before
+    public void setupParserBolt() {
+        bolt = new JSoupParserBolt();
+        setupParserBolt(bolt);
+    }
+
+    protected void prepareParserBolt(String configFile, Map parserConfig) {
+        parserConfig.put("jsoup.filters.config.file", configFile);
+        bolt.prepare(
+                parserConfig, TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+    }
+
+    @Test
+    public void testBasicExtraction() throws IOException {
+
+        prepareParserBolt("test.jsoupfilters.json");
+
+        parse("http://www.digitalpebble.com", "digitalpebble.com.html");
+
+        Assert.assertEquals(1, output.getEmitted().size());
+        List<Object> parsedTuple = output.getEmitted().get(0);
+        Metadata metadata = (Metadata) parsedTuple.get(2);
+        Assert.assertNotNull(metadata);
+        String concept = metadata.getFirstValue("concept");
+        Assert.assertNotNull(concept);
+
+        concept = metadata.getFirstValue("concept2");
+        Assert.assertNotNull(concept);
+    }
+
+    @Test
+    // https://github.com/DigitalPebble/storm-crawler/issues/219
+    public void testScriptExtraction() throws IOException {
+
+        prepareParserBolt("test.jsoupfilters.json");
+
+        parse("http://www.digitalpebble.com", "digitalpebble.com.html");
+
+        Assert.assertEquals(1, output.getEmitted().size());
+        List<Object> parsedTuple = output.getEmitted().get(0);
+        Metadata metadata = (Metadata) parsedTuple.get(2);
+        Assert.assertNotNull(metadata);
+        String[] scripts = metadata.getValues("js");
+        Assert.assertNotNull(scripts);
+        // should be 2 of them
+        Assert.assertEquals(2, scripts.length);
+        Assert.assertEquals("", scripts[0].trim());
+        Assert.assertTrue(scripts[1].contains("urchinTracker();"));
+    }
+
+    @Test
+    public void testLDJsonExtraction() throws IOException {
+
+        prepareParserBolt("test.jsoupfilters.json");
+
+        parse("http://www.digitalpebble.com", "digitalpebble.com.html");
+
+        Assert.assertEquals(1, output.getEmitted().size());
+        List<Object> parsedTuple = output.getEmitted().get(0);
+        Metadata metadata = (Metadata) parsedTuple.get(2);
+        Assert.assertNotNull(metadata);
+        String[] scripts = metadata.getValues("streetAddress");
+        Assert.assertNotNull(scripts);
+    }
+
+    @Test
+    public void testExtraLink() throws IOException {
+
+        prepareParserBolt("test.jsoupfilters.json");
+
+        parse("http://www.digitalpebble.com", "digitalpebble.com.html");
+
+        Assert.assertEquals(16, output.getEmitted("status").size());
+    }
+}

--- a/core/src/test/resources/test.jsoupfilters.json
+++ b/core/src/test/resources/test.jsoupfilters.json
@@ -1,10 +1,21 @@
 {
   "com.digitalpebble.stormcrawler.parse.JSoupFilters" : [ 
   {
+      "class": "com.digitalpebble.stormcrawler.jsoup.XPathFilter",
+      "name": "XPathFilter",
+      "params": {
+        "concept": "//SPAN[@class=\"concept\"]/tidyText()",
+        "concept2": "//*[@class=\"concept\"]/tidyText()",
+        "js": "//SCRIPT[@type='text/javascript']/html()",
+        "keywords": "//META[@name=\"keywords\"]/@content",
+        "title": "//TITLE/tidyText()"
+      }
+    },
+  {
     "class": "com.digitalpebble.stormcrawler.jsoup.LinkParseFilter",
     "name": "LinkParseFilter",
     "params": {
-       "pattern": "img[src]"
+       "pattern": "//IMG/@src"
      }
   },
   {

--- a/external/elasticsearch/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/external/elasticsearch/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -56,6 +56,7 @@ config:
 
   parsefilters.config.file: "parsefilters.json"
   urlfilters.config.file: "urlfilters.json"
+  jsoup.filters.config.file: "jsoupfilters.json"
 
   # revisit a page daily (value in minutes)
   # set it to -1 to never refetch a page

--- a/external/elasticsearch/archetype/src/main/resources/archetype-resources/src/main/resources/jsoupfilters.json
+++ b/external/elasticsearch/archetype/src/main/resources/archetype-resources/src/main/resources/jsoupfilters.json
@@ -1,7 +1,7 @@
 {
   "com.digitalpebble.stormcrawler.parse.JSoupFilters": [
     {
-      "class": "com.digitalpebble.stormcrawler.parse.filter.XPathFilter",
+      "class": "com.digitalpebble.stormcrawler.jsoup.XPathFilter",
       "name": "XPathFilter",
       "params": {
         "canonical": "//*[@rel=\"canonical\"]/@href",

--- a/external/elasticsearch/archetype/src/main/resources/archetype-resources/src/main/resources/jsoupfilters.json
+++ b/external/elasticsearch/archetype/src/main/resources/archetype-resources/src/main/resources/jsoupfilters.json
@@ -1,0 +1,27 @@
+{
+  "com.digitalpebble.stormcrawler.parse.JSoupFilters": [
+    {
+      "class": "com.digitalpebble.stormcrawler.parse.filter.XPathFilter",
+      "name": "XPathFilter",
+      "params": {
+        "canonical": "//*[@rel=\"canonical\"]/@href",
+        "parse.description": [
+          "//*[@name=\"description\"]/@content",
+          "//*[@name=\"Description\"]/@content"
+        ],
+        "parse.title": [
+          "//TITLE/tidyText()",
+          "//META[@name=\"title\"]/@content"
+        ],
+        "parse.keywords": "//META[@name=\"keywords\"]/@content"
+      }
+    },
+    {
+      "class": "com.digitalpebble.stormcrawler.jsoup.LinkParseFilter",
+      "name": "LinkParseFilter",
+      "params": {
+        "pattern": "//FRAME/@src"
+      }
+    }
+  ]
+}

--- a/external/elasticsearch/archetype/src/main/resources/archetype-resources/src/main/resources/parsefilters.json
+++ b/external/elasticsearch/archetype/src/main/resources/archetype-resources/src/main/resources/parsefilters.json
@@ -1,29 +1,6 @@
 {
   "com.digitalpebble.stormcrawler.parse.ParseFilters": [
     {
-      "class": "com.digitalpebble.stormcrawler.parse.filter.XPathFilter",
-      "name": "XPathFilter",
-      "params": {
-        "canonical": "//*[@rel=\"canonical\"]/@href",
-        "parse.description": [
-            "//*[@name=\"description\"]/@content",
-            "//*[@name=\"Description\"]/@content"
-         ],
-        "parse.title": [
-            "//TITLE",
-            "//META[@name=\"title\"]/@content"
-         ],
-         "parse.keywords": "//META[@name=\"keywords\"]/@content"
-      }
-    },
-    {
-      "class": "com.digitalpebble.stormcrawler.parse.filter.LinkParseFilter",
-      "name": "LinkParseFilter",
-      "params": {
-         "pattern": "//FRAME/@src"
-       }
-    },
-    {
       "class": "com.digitalpebble.stormcrawler.parse.filter.DomainParseFilter",
       "name": "DomainParseFilter",
       "params": {


### PR DESCRIPTION
The parsing bolts can become the botteneck on some crawls if parsefilters requiring xpath are in the configuration.
This is due to the fact that this triggers a conversion from the JSoup document to a DOM representation which is then used with Xpath. This can become costly.

We recently added JsoupFilters (#847) so that we can implement ParseFIlters straight onto the JSoup documents. This PR uses the [Xsoup](https://github.com/code4craft/xsoup) library so that we can keep similar XPath based extraction patterns without needing the costly conversion to DOM.

Please note that there are slight differences in the way the patterns should be written, see https://github.com/code4craft/xsoup#syntax-supported

For instance, if the text content of a node should be used as value, the pattern should end in _/text()_.

We have noticed substantial improvements to the speed of the parsing without any losses in content. 

This also adds some unit tests for JSoupFilters.

I will modify the configuration of the parse filters in the archetypes so that future users get them by default.

This PR is generously donated by @sam-ulrich1 and https://www.gagepiracy.com/.