### PR TITLE
Overhaul urlfrontier-bolts, add tests, find problem with URLFrontier

### DIFF
--- a/external/urlfrontier/pom.xml
+++ b/external/urlfrontier/pom.xml
@@ -22,6 +22,23 @@
 			<artifactId>urlfrontier-API</artifactId>
 			<version>2.1</version>
 		</dependency>
+
+		<dependency>
+			<groupId>com.digitalpebble.stormcrawler</groupId>
+			<artifactId>storm-crawler-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
+
+
 
 </project>

--- a/external/urlfrontier/src/main/java/com/digitalpebble/stormcrawler/urlfrontier/ChannelManager.java
+++ b/external/urlfrontier/src/main/java/com/digitalpebble/stormcrawler/urlfrontier/ChannelManager.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.urlfrontier;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+/** Manages the connections on a single machine. Use */
+final class ChannelManager {
+
+    private static final Logger LOG = LogManager.getLogger(ChannelManager.class);
+
+    private ChannelManager() {}
+
+    private static final Object lock = new Object();
+
+    private static final HashMap<String, ManagedChannelTuple> channels = new HashMap<>();
+
+    @Contract("null -> false")
+    private static boolean validChannelInTuple(@Nullable ManagedChannelTuple tuple) {
+        return tuple != null && !tuple.channel.isShutdown() && !tuple.channel.isShutdown();
+    }
+
+    @NotNull
+    private static ManagedChannel getOrCreateChannel(@NotNull String address) {
+        ManagedChannelTuple result = channels.get(address);
+        if (validChannelInTuple(result)) {
+            LOG.debug("Found a channel with {} uses.", result.get());
+            result.inc();
+            return result.channel;
+        }
+        synchronized (lock) {
+            result = channels.get(address);
+            if (validChannelInTuple(result)) {
+                LOG.debug("Found a channel with {} uses.", result.get());
+                result.inc();
+                return result.channel;
+            }
+            result =
+                    new ManagedChannelTuple(
+                            ManagedChannelBuilder.forTarget(address).usePlaintext().build());
+            channels.put(address, result);
+            LOG.debug("Created a new channel.");
+            result.inc();
+            return result.channel;
+        }
+    }
+
+    /** Gets a channel for the given host and post. */
+    @NotNull
+    static ManagedChannel getChannel(@NotNull String host, @Range(from = 0, to = 65535) int port) {
+        return getOrCreateChannel(host + ":" + port);
+    }
+
+    /** Gets a channel for the given address. */
+    @NotNull
+    static ManagedChannel getChannel(@NotNull String address) {
+        return getOrCreateChannel(address);
+    }
+
+    /** Returns the channel and probably closes it. */
+    static void returnChannel(@NotNull ManagedChannel channel) {
+        for (var entry : channels.entrySet()) {
+            var value = entry.getValue();
+            if (channel == value.channel) {
+                if (value.dec() == 0) {
+                    synchronized (lock) {
+                        if (value.get() == 0) {
+                            if (!value.channel.isShutdown()) {
+                                LOG.info("Shutting down channel {}", channel);
+                                value.channel.shutdown();
+                            } else {
+                                LOG.warn(
+                                        "The channel {} was already shut down but should not.",
+                                        channel);
+                            }
+                            LOG.debug("Removing channel for address {}", entry.getKey());
+                            channels.remove(entry.getKey());
+                        }
+                    }
+                }
+                return;
+            }
+        }
+        LOG.warn(
+                "The returned channel {} was not managed by the ChannelManager. Was it already closed?",
+                channel);
+    }
+
+    /** Closes all managed channels */
+    static void closeAll() {
+        synchronized (lock) {
+            for (var entry : channels.entrySet()) {
+                var value = entry.getValue();
+                var state = value.get();
+                LOG.info(
+                        "Shutting down and removing channel {} with address {}",
+                        value,
+                        entry.getKey());
+                value.channel.shutdown();
+                channels.remove(entry.getKey());
+                if (state != 0) {
+                    LOG.warn(
+                            "The channel {} with address {} was shut down but is used by {} other objects.",
+                            value,
+                            entry.getKey(),
+                            value.get());
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    private static class ManagedChannelTuple {
+        @NotNull ManagedChannel channel;
+        @NotNull private final AtomicInteger usedBy = new AtomicInteger(0);
+
+        public ManagedChannelTuple(@NotNull ManagedChannel channel) {
+            this.channel = channel;
+        }
+
+        int get() {
+            return usedBy.get();
+        }
+
+        int inc() {
+            return usedBy.incrementAndGet();
+        }
+
+        int dec() {
+            return usedBy.decrementAndGet();
+        }
+    }
+}

--- a/external/urlfrontier/src/main/java/com/digitalpebble/stormcrawler/urlfrontier/Constants.java
+++ b/external/urlfrontier/src/main/java/com/digitalpebble/stormcrawler/urlfrontier/Constants.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.urlfrontier;
+
+public final class Constants {
+    private Constants() {}
+
+    // General
+    public static final String URLFRONTIER_ADDRESS_KEY = "urlfrontier.address";
+    public static final String URLFRONTIER_HOST_KEY = "urlfrontier.host";
+    public static final String URLFRONTIER_PORT_KEY = "urlfrontier.port";
+    public static final String URLFRONTIER_DEFAULT_HOST = "localhost";
+    public static final int URLFRONTIER_DEFAULT_PORT = 7071;
+
+    // Spout
+    public static final String URLFRONTIER_MAX_URLS_PER_BUCKET_KEY =
+            "urlfrontier.max.urls.per.bucket";
+    public static final String URLFRONTIER_MAX_BUCKETS_KEY = "urlfrontier.max.buckets";
+    public static final String URLFRONTIER_DELAY_REQUESTABLE_KEY = "urlfrontier.delay.requestable";
+
+    // StatusUpdater
+    public static final String URLFRONTIER_CACHE_EXPIREAFTER_MS_KEY =
+            "urlfrontier.cache.expireafterms";
+    public static final String URLFRONTIER_MAX_MESSAGES_IN_FLIGHT_KEY =
+            "urlfrontier.max.messages.in.flight";
+    public static final String URLFRONTIER_THROTTLING_TIME_MS_KEY =
+            "urlfrontier.throttling.time.msec";
+    public static final String URLFRONTIER_UPDATER_MAX_MESSAGES_KEY =
+            "urlfrontier.updater.max.messages";
+    public static final String URLFRONTIER_CRAWL_ID_KEY = "urlfrontier.crawlid";
+}

--- a/external/urlfrontier/src/main/java/com/digitalpebble/stormcrawler/urlfrontier/Spout.java
+++ b/external/urlfrontier/src/main/java/com/digitalpebble/stormcrawler/urlfrontier/Spout.java
@@ -14,6 +14,8 @@
  */
 package com.digitalpebble.stormcrawler.urlfrontier;
 
+import static com.digitalpebble.stormcrawler.urlfrontier.Constants.*;
+
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.persistence.AbstractQueryingSpout;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
@@ -22,21 +24,20 @@ import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierStub;
 import crawlercommons.urlfrontier.Urlfrontier.GetParams;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.storm.Config;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Spout extends AbstractQueryingSpout {
 
-    public static final Logger LOG = LoggerFactory.getLogger(Spout.class);
+    private static final Logger LOG = LogManager.getLogger(Spout.class);
 
     private ManagedChannel channel;
 
@@ -51,11 +52,10 @@ public class Spout extends AbstractQueryingSpout {
     @Override
     public void open(
             Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
-
         super.open(conf, context, collector);
 
         // host and port of URL Frontier(s)
-        List<String> addresses = ConfUtils.loadListFromConf("urlfrontier.address", conf);
+        List<String> addresses = ConfUtils.loadListFromConf(URLFRONTIER_ADDRESS_KEY, conf);
 
         String address = null;
 
@@ -71,17 +71,19 @@ public class Spout extends AbstractQueryingSpout {
             int nodeIndex = context.getThisTaskIndex();
             Collections.sort(addresses);
             address = addresses.get(nodeIndex);
+        } else if (addresses.size() == 1) {
+            LOG.warn("urlfrontier.address with a size of one is not used!");
         }
 
         if (address == null) {
-            String host = ConfUtils.getString(conf, "urlfrontier.host", "localhost");
-            int port = ConfUtils.getInt(conf, "urlfrontier.port", 7071);
+            String host = ConfUtils.getString(conf, URLFRONTIER_HOST_KEY, URLFRONTIER_DEFAULT_HOST);
+            int port = ConfUtils.getInt(conf, URLFRONTIER_PORT_KEY, URLFRONTIER_DEFAULT_PORT);
             address = host + ":" + port;
         }
 
-        maxURLsPerBucket = ConfUtils.getInt(conf, "urlfrontier.max.urls.per.bucket", 10);
+        maxURLsPerBucket = ConfUtils.getInt(conf, URLFRONTIER_MAX_URLS_PER_BUCKET_KEY, 10);
 
-        maxBucketNum = ConfUtils.getInt(conf, "urlfrontier.max.buckets", 10);
+        maxBucketNum = ConfUtils.getInt(conf, URLFRONTIER_MAX_BUCKETS_KEY, 10);
 
         // initialise the delay requestable with the timeout for messages
         delayRequestable =
@@ -89,7 +91,7 @@ public class Spout extends AbstractQueryingSpout {
 
         // then override with any user specified config
         delayRequestable =
-                ConfUtils.getInt(conf, "urlfrontier.delay.requestable", delayRequestable);
+                ConfUtils.getInt(conf, URLFRONTIER_DELAY_REQUESTABLE_KEY, delayRequestable);
 
         LOG.info("Initialisation of connection to URLFrontier service on {}", address);
 
@@ -98,8 +100,9 @@ public class Spout extends AbstractQueryingSpout {
             address += ":7071";
         }
 
-        channel = ManagedChannelBuilder.forTarget(address).usePlaintext().build();
-        frontier = URLFrontierGrpc.newStub(channel);
+        channel = ChannelManager.getChannel(address);
+        frontier = URLFrontierGrpc.newStub(channel).withWaitForReady();
+        LOG.debug("State of Channel: {}", channel.getState(false));
     }
 
     @Override
@@ -121,7 +124,7 @@ public class Spout extends AbstractQueryingSpout {
         final long start = System.currentTimeMillis();
 
         StreamObserver<URLInfo> responseObserver =
-                new StreamObserver<URLInfo>() {
+                new StreamObserver<>() {
 
                     @Override
                     public void onNext(URLInfo item) {
@@ -141,7 +144,23 @@ public class Spout extends AbstractQueryingSpout {
 
                     @Override
                     public void onError(Throwable t) {
-                        LOG.error("Exception caught", t);
+
+                        if (t instanceof io.grpc.StatusRuntimeException) {
+                            io.grpc.StatusRuntimeException e = (io.grpc.StatusRuntimeException) t;
+
+                            StringBuilder sb =
+                                    new StringBuilder("StatusRuntimeException: ")
+                                            .append(e.getStatus().toString());
+
+                            io.grpc.Metadata trailers = e.getTrailers();
+                            if (trailers != null) {
+                                sb.append(" ").append(trailers);
+                            }
+                            LOG.error(sb.toString(), e);
+                        } else {
+                            LOG.error("Exception caught", t);
+                        }
+
                         markQueryReceivedNow();
                     }
 
@@ -156,7 +175,7 @@ public class Spout extends AbstractQueryingSpout {
                     }
                 };
 
-        LOG.trace("{} isInquery set to true");
+        LOG.trace("isInquery set to true");
         isInQuery.set(true);
 
         frontier.getURLs(request, responseObserver);
@@ -177,7 +196,6 @@ public class Spout extends AbstractQueryingSpout {
     @Override
     public void close() {
         super.close();
-        LOG.info("Shutting down connection to URLFrontier service");
-        channel.shutdown();
+        ChannelManager.returnChannel(channel);
     }
 }

--- a/external/urlfrontier/src/test/java/com/digitalpebble/stormcrawler/urlfrontier/StatusBoldTest.java
+++ b/external/urlfrontier/src/test/java/com/digitalpebble/stormcrawler/urlfrontier/StatusBoldTest.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.urlfrontier;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.digitalpebble.stormcrawler.Metadata;
+import com.digitalpebble.stormcrawler.TestOutputCollector;
+import com.digitalpebble.stormcrawler.TestUtil;
+import com.digitalpebble.stormcrawler.persistence.Status;
+import io.grpc.ManagedChannel;
+import java.util.HashMap;
+import java.util.concurrent.*;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.tuple.Tuple;
+import org.junit.*;
+import org.junit.rules.Timeout;
+
+public class StatusBoldTest {
+    private StatusUpdaterBolt bolt;
+    private TestOutputCollector output;
+    private URLFrontierContainer urlFrontierContainer;
+
+    private ManagedChannel managedChannel;
+
+    private static final String persistedKey = "somePersistedKey";
+
+    private static ExecutorService executorService;
+
+    @Rule public Timeout globalTimeout = Timeout.seconds(60);
+
+    @BeforeClass
+    public static void beforeClass() {
+        executorService = Executors.newFixedThreadPool(2);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        executorService.shutdown();
+        executorService = null;
+    }
+
+    @Before
+    public void before() {
+
+        urlFrontierContainer = new URLFrontierContainer("crawlercommons/url-frontier:2.1");
+        urlFrontierContainer.start();
+
+        bolt = new StatusUpdaterBolt();
+
+        var connection = urlFrontierContainer.getFrontierConnection();
+        managedChannel = ChannelManager.getChannel(connection.getAddress());
+
+        final var config = new HashMap<String, Object>();
+        config.put(
+                "urlbuffer.class",
+                "com.digitalpebble.stormcrawler.persistence.urlbuffer.SimpleURLBuffer");
+        config.put(Constants.URLFRONTIER_HOST_KEY, connection.getHost());
+        config.put(Constants.URLFRONTIER_PORT_KEY, connection.getPort());
+        config.put(
+                "scheduler.class", "com.digitalpebble.stormcrawler.persistence.DefaultScheduler");
+        config.put("status.updater.cache.spec", "maximumSize=10000,expireAfterAccess=1h");
+        config.put("metadata.persist", persistedKey);
+
+        output = new TestOutputCollector();
+        bolt.prepare(config, TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+    }
+
+    @After
+    public void after() {
+        bolt.cleanup();
+        urlFrontierContainer.close();
+        ChannelManager.returnChannel(managedChannel);
+        output = null;
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private Future<Integer> store(String url, Status status, Metadata metadata) {
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getValueByField("status")).thenReturn(status);
+        when(tuple.getStringByField("url")).thenReturn(url);
+        when(tuple.getValueByField("metadata")).thenReturn(metadata);
+        bolt.execute(tuple);
+
+        return executorService.submit(
+                () -> {
+                    var outputSize = output.getAckedTuples().size();
+                    while (outputSize == 0) {
+                        Thread.sleep(100);
+                        outputSize = output.getAckedTuples().size();
+                    }
+                    return outputSize;
+                });
+    }
+
+    @Test
+    public void canAckASimpleTuple()
+            throws ExecutionException, InterruptedException, TimeoutException {
+
+        Configurator.setLevel(StatusUpdaterBolt.class, Level.ALL);
+
+        final var url = "https://www.url.net/something";
+        final var meta = new Metadata();
+        meta.setValue(persistedKey, "somePersistedMetaInfo");
+        meta.setValue("someNotPersistedKey", "someNotPersistedMetaInfo");
+
+        var future = store(url, Status.DISCOVERED, meta);
+
+        int numberOfAckedTuples = future.get(5, TimeUnit.SECONDS);
+
+        Assert.assertEquals(1, numberOfAckedTuples);
+    }
+}

--- a/external/urlfrontier/src/test/java/com/digitalpebble/stormcrawler/urlfrontier/URLFrontierContainer.java
+++ b/external/urlfrontier/src/test/java/com/digitalpebble/stormcrawler/urlfrontier/URLFrontierContainer.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.urlfrontier;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/** A container for "crawlercommons/url-frontier". */
+public class URLFrontierContainer extends GenericContainer<URLFrontierContainer>
+        implements URLFrontierContainerConfig {
+    public static final DockerImageName DEFAULT_IMAGE_NAME =
+            DockerImageName.parse("crawlercommons/url-frontier");
+    public static final String DEFAULT_TAG = "2.1";
+    public static final int INTERNAL_FRONTIER_PORT = 7071;
+
+    @Nullable private String rocksPath;
+    private int prometheusPort = -1;
+
+    @Deprecated
+    public URLFrontierContainer() {
+        this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG));
+    }
+
+    public URLFrontierContainer(String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    public URLFrontierContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        setExposedPorts(List.of(INTERNAL_FRONTIER_PORT));
+        setWaitStrategy(Wait.forLogMessage(".*Started URLFrontierServer.*\\n", 1));
+    }
+
+    @Override
+    @Nullable
+    public String getRocksPath() {
+        return rocksPath;
+    }
+
+    @Override
+    public void setRocksPath(@NotNull String rocksPath) {
+        this.rocksPath = rocksPath;
+    }
+
+    @Override
+    @Range(from = 0, to = 65535)
+    public int getPrometheusPort() {
+        return prometheusPort;
+    }
+
+    @Override
+    public void setPrometheusPort(@Range(from = 0, to = 65535) int prometheusPort) {
+        this.prometheusPort = prometheusPort;
+    }
+
+    public URLFrontierContainer withPrometheusPort(
+            @Range(from = 0, to = 65535) int prometheusPort) {
+        setPrometheusPort(prometheusPort);
+        return this;
+    }
+
+    public URLFrontierContainer withRocksPath(@NotNull String rocksPath) {
+        setRocksPath(rocksPath);
+        return this;
+    }
+
+    @Override
+    protected void configure() {
+        ArrayList<String> args = new ArrayList<>(2);
+        if (rocksPath != null) {
+            args.add("rocksdb.path=" + rocksPath);
+        }
+        if (prometheusPort != -1) {
+            setExposedPorts(List.of(INTERNAL_FRONTIER_PORT, prometheusPort));
+            args.add("-s " + prometheusPort);
+        }
+        setCommandParts(args.toArray(new String[0]));
+    }
+
+    @NotNull
+    public ConnectionInfo.URLFrontier getFrontierConnection() {
+        return new ConnectionInfo.URLFrontier(getHost(), getMappedPort(INTERNAL_FRONTIER_PORT));
+    }
+
+    @Nullable
+    public ConnectionInfo.Prometheus getPrometheusConnection() {
+        if (prometheusPort == -1) return null;
+        return new ConnectionInfo.Prometheus(getHost(), getMappedPort(prometheusPort));
+    }
+
+    public abstract static class ConnectionInfo {
+        public abstract String getHost();
+
+        public abstract int getPort();
+
+        @NotNull
+        public String getAddress() {
+            return getHost() + ":" + getPort();
+        }
+
+        static final class URLFrontier extends ConnectionInfo {
+            private final String host;
+            private final int port;
+
+            public URLFrontier(String host, int port) {
+                this.host = host;
+                this.port = port;
+            }
+
+            @Override
+            public String getHost() {
+                return host;
+            }
+
+            @Override
+            public int getPort() {
+                return port;
+            }
+        }
+
+        static final class Prometheus extends ConnectionInfo {
+            private final String host;
+            private final int port;
+
+            public Prometheus(String host, int port) {
+                this.host = host;
+                this.port = port;
+            }
+
+            @Override
+            public String getHost() {
+                return host;
+            }
+
+            @Override
+            public int getPort() {
+                return port;
+            }
+        }
+    }
+}

--- a/external/urlfrontier/src/test/java/com/digitalpebble/stormcrawler/urlfrontier/URLFrontierContainerConfig.java
+++ b/external/urlfrontier/src/test/java/com/digitalpebble/stormcrawler/urlfrontier/URLFrontierContainerConfig.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.urlfrontier;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+public interface URLFrontierContainerConfig {
+    void setRocksPath(@NotNull String path);
+
+    @Nullable
+    String getRocksPath();
+
+    void setPrometheusPort(@Range(from = 0, to = 65535) int port);
+
+    @Range(from = 0, to = 65535)
+    int getPrometheusPort();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
 		<mockito.version>4.6.1</mockito.version>
 		<jetbrains.annotations.version>23.0.0</jetbrains.annotations.version>
 		<log4j2.version>2.17.2</log4j2.version>
+		<testcontainer.version>1.17.3</testcontainer.version>
 	</properties>
 
 	<distributionManagement>
@@ -262,6 +263,13 @@
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>${junit.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>testcontainers</artifactId>
+				<version>${testcontainer.version}</version>
 				<scope>test</scope>
 			</dependency>
 


### PR DESCRIPTION
Hi @jnioche,

we switched our URL and Status handling from a custom bolt to URL-frontier. But I recognized, that the Status-Bold is not acking any tuple. After going into the code, adding some log-events and cleaning up the async-code and improving the state-management, my unit test shows the following log:

```
12:35:05.187 [Time-limited test] INFO  c.d.s.u.StatusUpdaterBolt - Initialisation of connection to URLFrontier service on localhost:53770
12:35:05.187 [Time-limited test] INFO  c.d.s.u.StatusUpdaterBolt - Allowing up to 100000 message in flight
12:35:05.194 [Time-limited test] ERROR c.d.s.u.PartitionUtil - Unknown partition mode : null - forcing to byHost
12:35:05.194 [Time-limited test] INFO  c.d.s.u.URLPartitioner - Using partition mode : QUEUE_MODE_HOST
12:35:05.263 [Time-limited test] TRACE c.d.s.u.StatusUpdaterBolt - Added to waitAck https://www.url.net/something with ID https://www.url.net/something total 1 - sent to localhost:53770
12:35:05.751 [grpc-default-executor-1] WARN  c.d.s.u.StatusUpdaterBolt - Could not find unacked tuple for blank id ``. (Ack: )
12:35:05.752 [grpc-default-executor-1] TRACE c.d.s.u.StatusUpdaterBolt - Trace for unpacked tuple for blank id: 
12:35:10.787 [Time-limited test] INFO  c.d.s.u.ChannelManager - Shutting down channel ManagedChannelOrphanWrapper{delegate=ManagedChannelImpl{logId=1, target=localhost:53770}}
```

It looks like URL-Frontier does not provide an ID when responding to a put, this is an error that can not be fixed on the SC side.

List of changes:
- Prevent starving of tuple by using a fair RW-lock for ack-queue reads and writes
- Prevent starving by only locking what needs to be locked
- Use semaphore instead of busy-waiting for limiting the number of URLItems to be sent. 
- Remove starving busy-waiting for acquiring a permit
- Add URL-Frontier test container (To be removed when the complete container mapped and added to the testcontainers repo)
- Add single Unit-Test for testing if acking in status-bold works. (Adding further Unit tests not necessary until URL-Frontier is fixed)
- Extend LOG-messaging

Best Regards
Felix

Signed-off-by: Felix Engl <felix.engl@uni-bamberg.de>

Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'
* The code is properly formatted with 'mvn git-code-format:format-code -Dgcf.globPattern=**/*'

Thanks!

