### PR TITLE
Fix error when spaces in path to test-resources of StatusBoltTest in ElasticSearch-Module

### DIFF
--- a/external/elasticsearch/src/test/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/StatusBoltTest.java
+++ b/external/elasticsearch/src/test/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/StatusBoltTest.java
@@ -24,11 +24,15 @@ import com.digitalpebble.stormcrawler.TestOutputCollector;
 import com.digitalpebble.stormcrawler.TestUtil;
 import com.digitalpebble.stormcrawler.elasticsearch.persistence.StatusUpdaterBolt;
 import com.digitalpebble.stormcrawler.persistence.Status;
-import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -100,11 +104,17 @@ public class StatusBoltTest {
 
         CreateIndexRequest request = new CreateIndexRequest("status");
 
-        File file = new File(getClass().getClassLoader().getResource("status.mapping").getFile());
+        URI uriToFile;
+        try {
+            uriToFile =
+                    Objects.requireNonNull(
+                                    getClass().getClassLoader().getResource("status.mapping"))
+                            .toURI();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
 
-        String mappingSource =
-                new String(
-                        java.nio.file.Files.readAllBytes(file.toPath()), Charset.defaultCharset());
+        String mappingSource = Files.readString(Path.of(uriToFile), Charset.defaultCharset());
 
         request.source(mappingSource, XContentType.JSON);
 


### PR DESCRIPTION
When running the unit-tests for the ElasticSearch module the file "status.mapping" is not found when a space is in the path, due to wrong conversion from URL to File. 
This changes fix this wrong behavior.

Signed-off-by: Felix Engl <felix.engl@uni-bamberg.de>

Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'
* The code is properly formatted with 'mvn git-code-format:format-code -Dgcf.globPattern=**/*'

Thanks!

