### PR TITLE
HttpProtocol use the md protocol.set-headers to add custom header by url

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/AbstractHttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/AbstractHttpProtocol.java
@@ -52,6 +52,8 @@ public abstract class AbstractHttpProtocol implements Protocol {
 
     protected static final String RESPONSE_COOKIES_HEADER = "set-cookie";
 
+    protected static final String SET_HEADER_BY_REQUEST = "set-header";
+
     protected String protocolMDprefix = "";
 
     public ProxyManager proxyManager;
@@ -76,7 +78,7 @@ public abstract class AbstractHttpProtocol implements Protocol {
             this.v = v;
         }
 
-        static KeyValue build(String h) {
+        public static KeyValue build(String h) {
             int pos = h.indexOf("=");
             if (pos == -1) return new KeyValue(h.trim(), "");
             if (pos + 1 == h.length()) return new KeyValue(h.trim(), "");

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/httpclient/HttpProtocol.java
@@ -197,6 +197,9 @@ public class HttpProtocol extends AbstractHttpProtocol
         ResponseHandler<ProtocolResponse> responseHandler = this;
 
         if (md != null) {
+
+            addHeadersToRequest(request, md);
+
             String useHead = md.getFirstValue("http.method.head");
             if (Boolean.parseBoolean(useHead)) {
                 request = new HttpHead(url);
@@ -256,6 +259,16 @@ public class HttpProtocol extends AbstractHttpProtocol
                     request.addHeader("Cookie", c.getName() + "=" + c.getValue());
                 }
             } catch (MalformedURLException e) { // Bad url , nothing to do
+            }
+        }
+    }
+
+    private void addHeadersToRequest(HttpRequestBase request, Metadata md) {
+        String[] headerStrings = md.getValues(SET_HEADER_BY_REQUEST, protocolMDprefix);
+        if ((headerStrings != null) && (headerStrings.length > 0)) {
+            for (String hs : headerStrings) {
+                KeyValue h = KeyValue.build(hs);
+                request.addHeader(h.getKey(), h.getValue());
             }
         }
     }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -256,6 +256,17 @@ public class HttpProtocol extends AbstractHttpProtocol {
         }
     }
 
+    private void addHeadersToRequest(Builder rb, Metadata md) {
+        String[] headerStrings = md.getValues(SET_HEADER_BY_REQUEST, protocolMDprefix);
+
+        if (headerStrings != null && headerStrings.length > 0) {
+            for (String hs : headerStrings) {
+                KeyValue h = KeyValue.build(hs);
+                rb.addHeader(h.getKey(), h.getValue());
+            }
+        }
+    }
+
     @Override
     public ProtocolResponse getProtocolOutput(String url, final Metadata metadata)
             throws Exception {
@@ -316,6 +327,8 @@ public class HttpProtocol extends AbstractHttpProtocol {
         int pageMaxContent = globalMaxContent;
 
         if (metadata != null) {
+            addHeadersToRequest(rb, metadata);
+
             String lastModified = metadata.getFirstValue(HttpHeaders.LAST_MODIFIED);
             if (StringUtils.isNotBlank(lastModified)) {
                 rb.header("If-Modified-Since", HttpHeaders.formatHttpDate(lastModified));


### PR DESCRIPTION
Hi @jnioche !

We need to provide some headers at the request level (instead of the topology level). The protocols are now able to add some headers specified in metadata.

To complete the documentation : https://github.com/DigitalPebble/storm-crawler/wiki/HTTPProtocol
> protocol.set-headers: If this key is present in metadata, the protocol add the specified headers to the request.
> Md example :
> "protocol%2Eset-header": [
>       "header1=value1",
>       "header2=value2"
> ]

Signed-off-by: Mathieu Bret <mikwiss00@gmail.com>

Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'
* The code is properly formatted with 'mvn git-code-format:format-code -Dgcf.globPattern=**/*'

Thanks!

