### PR TITLE
Fix MalformedURLException in JsoupParserBolt

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/JSoupParserBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/JSoupParserBolt.java
@@ -279,12 +279,22 @@ public class JSoupParserBolt extends StatusEmitterBolt {
                         noFollow = true;
                     }
 
-                    // abs:href tells jsoup to return fully qualified domains
-                    // for relative urls
-                    // but it is very slow as it builds intermediate URL objects
-                    // and normalises the URL of the document every time
-                    final String targetURL =
-                            StringUtil.resolve(baseURL, link.attr("href")).toExternalForm();
+                    String targetURL = null;
+
+                    try {
+                        // abs:href tells jsoup to return fully qualified domains
+                        // for relative urls
+                        // but it is very slow as it builds intermediate URL objects
+                        // and normalises the URL of the document every time
+                        targetURL = StringUtil.resolve(baseURL, link.attr("href")).toExternalForm();
+                    } catch (MalformedURLException e) {
+                        LOG.debug(
+                                "Cannot resolve URL with baseURL : {} and href : {}",
+                                baseURL,
+                                link.attr("href"),
+                                e);
+                    }
+
                     if (StringUtils.isBlank(targetURL)) {
                         continue;
                     }

--- a/core/src/test/java/com/digitalpebble/stormcrawler/bolt/JSoupParserBoltTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/bolt/JSoupParserBoltTest.java
@@ -18,6 +18,7 @@ import com.digitalpebble.stormcrawler.Constants;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.TestUtil;
 import com.digitalpebble.stormcrawler.parse.ParsingTester;
+import com.digitalpebble.stormcrawler.persistence.Status;
 import com.digitalpebble.stormcrawler.util.RobotsTags;
 import java.io.IOException;
 import java.util.HashMap;
@@ -249,5 +250,18 @@ public class JSoupParserBoltTest extends ParsingTester {
 
         // outlinks NOT being limited by property, since is disabled with -1
         Assert.assertEquals(10, statusTuples.size());
+    }
+
+    @Test
+    public void testExecuteWithJavascriptLink() throws IOException {
+        bolt.prepare(stormConf, TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+
+        parse("http://www.javascriptlinks.com", "javascriptLinks.html");
+
+        List<List<Object>> statusTuples = output.getEmitted(Constants.StatusStreamName);
+
+        Assert.assertEquals(1, statusTuples.size());
+        Assert.assertEquals(Status.DISCOVERED, statusTuples.get(0).get(2));
+        Assert.assertEquals("http://www.javascriptlinks.com/mylink", statusTuples.get(0).get(0));
     }
 }

--- a/core/src/test/resources/javascriptLinks.html
+++ b/core/src/test/resources/javascriptLinks.html
@@ -1,0 +1,8 @@
+<html>
+  <p>
+    <a href="javascript:void(0)" role="button">link2</a> is a button.
+  </p>
+  <p>
+    <a href="mylink">link1</a> is a link.
+  </p>
+</html>


### PR DESCRIPTION
Hi @jnioche 

Since #999, our bots failed to parse some page. A malformed exception is raised and the status page is set to **ERROR : "content parsing"** : 

> 2022-10-19 14:30:10.784 c.d.s.b.JSoupParserBolt Thread-27-parser-executor[11, 11] [ERROR] Exception while parsing https://www.myurl.com/example: java.net.MalformedURLException: unknown protocol: javascript

As you can see in unit test, the following link raised an exception : `<a href="javascript:void(0)">`.

I propose to use a try catch. Let me know if it's ok for you.

Regards.

Signed-off-by: Mathieu Bret <mikwiss00@gmail.com>

Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'
* The code is properly formatted with 'mvn git-code-format:format-code -Dgcf.globPattern=**/*'

Thanks!

