### PR TITLE
Create an AbstractFilter

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/jsoup/LDJsonParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/jsoup/LDJsonParseFilter.java
@@ -18,6 +18,7 @@ import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.parse.JSoupFilter;
 import com.digitalpebble.stormcrawler.parse.ParseData;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * Extracts data from JSON-LD representation (https://json-ld.org/). Illustrates how to use the
  * JSoupFilters
  */
-public class LDJsonParseFilter extends JSoupFilter {
+public class LDJsonParseFilter extends AbstractFilter implements JSoupFilter {
 
     public static final Logger LOG = LoggerFactory.getLogger(LDJsonParseFilter.class);
 
@@ -107,7 +108,7 @@ public class LDJsonParseFilter extends JSoupFilter {
             }
 
         } catch (Exception e) {
-            LOG.error("Exception caught when extracting json", e);
+            LOG.error("{} - Exception caught when extracting json", getName(), e);
         }
     }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/jsoup/XPathFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/jsoup/XPathFilter.java
@@ -18,6 +18,7 @@ import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.parse.JSoupFilter;
 import com.digitalpebble.stormcrawler.parse.ParseData;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +33,7 @@ import us.codecraft.xsoup.XPathEvaluator;
 import us.codecraft.xsoup.Xsoup;
 
 /** Reads a XPATH patterns and stores the value found in web page as metadata */
-public class XPathFilter extends JSoupFilter {
+public class XPathFilter extends AbstractFilter implements JSoupFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(XPathFilter.class);
 
@@ -63,7 +64,6 @@ public class XPathFilter extends JSoupFilter {
     @SuppressWarnings("rawtypes")
     @Override
     public void configure(@NotNull Map stormConf, @NotNull JsonNode filterParams) {
-        super.configure(stormConf, filterParams);
         java.util.Iterator<Entry<String, JsonNode>> iter = filterParams.fields();
         while (iter.hasNext()) {
             Entry<String, JsonNode> entry = iter.next();
@@ -109,7 +109,7 @@ public class XPathFilter extends JSoupFilter {
                         break;
                     }
                 } catch (IOException e) {
-                    LOG.error("Error evaluating {}: {}", le.key, e);
+                    LOG.error("{} - Error evaluating {}: {}", getName(), le.key, e);
                 }
             }
         }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/JSoupFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/JSoupFilter.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
  * content. They are used exclusively by {@link
  * com.digitalpebble.stormcrawler.bolt.JSoupParserBolt}.
  */
-public abstract class JSoupFilter implements Configurable {
+public interface JSoupFilter extends Configurable {
 
     /**
      * Called when parsing a specific page
@@ -32,7 +32,7 @@ public abstract class JSoupFilter implements Configurable {
      * @param doc document produced by JSoup's parsingF
      * @param parse the metadata to be updated with the resulting of the parsing
      */
-    public abstract void filter(
+    void filter(
             @NotNull String url,
             byte[] content,
             @NotNull org.jsoup.nodes.Document doc,

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/JSoupFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/JSoupFilters.java
@@ -39,7 +39,7 @@ import org.jsoup.nodes.Document;
 import org.slf4j.LoggerFactory;
 
 /** Wrapper for the JSoupFilters defined in a JSON configuration */
-public class JSoupFilters extends JSoupFilter implements JSONResource {
+public class JSoupFilters implements JSoupFilter, JSONResource {
 
     public static final JSoupFilters emptyParseFilter = new JSoupFilters();
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/ParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/ParseFilter.java
@@ -23,7 +23,7 @@ import org.w3c.dom.DocumentFragment;
  * com.digitalpebble.stormcrawler.bolt.JSoupParserBolt} or {@link
  * com.digitalpebble.stormcrawler.bolt.SiteMapParserBolt}.
  */
-public abstract class ParseFilter implements Configurable {
+public interface ParseFilter extends Configurable {
 
     /**
      * Called when parsing a specific page
@@ -34,8 +34,7 @@ public abstract class ParseFilter implements Configurable {
      *     #needsDOM()} returns <code>false</code>
      * @param parse the metadata to be updated with the resulting of the parsing
      */
-    public abstract void filter(
-            String URL, byte[] content, DocumentFragment doc, ParseResult parse);
+    void filter(String URL, byte[] content, DocumentFragment doc, ParseResult parse);
 
     /**
      * Specifies whether this filter requires a DOM representation of the document
@@ -43,7 +42,7 @@ public abstract class ParseFilter implements Configurable {
      * @return <code>true</code>if this needs a DOM representation of the document, <code>false
      *     </code> otherwise.
      */
-    public boolean needsDOM() {
+    default boolean needsDOM() {
         return false;
     }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/ParseFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/ParseFilters.java
@@ -46,7 +46,7 @@ import org.w3c.dom.DocumentFragment;
  *
  * @see Configurable#createConfiguredInstance(Class, Class, Map, JsonNode) for more information.
  */
-public class ParseFilters extends ParseFilter implements JSONResource {
+public class ParseFilters implements ParseFilter, JSONResource {
 
     public static final ParseFilters emptyParseFilter = new ParseFilters();
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/CollectionTagger.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/CollectionTagger.java
@@ -17,6 +17,7 @@ package com.digitalpebble.stormcrawler.parse.filter;
 import com.digitalpebble.stormcrawler.JSONResource;
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import com.digitalpebble.stormcrawler.util.ConfUtils;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -63,7 +64,7 @@ import org.w3c.dom.DocumentFragment;
  *     <p>This resources was kindly donated by the Government of Northwestern Territories in Canada
  *     (http://www.gov.nt.ca/).
  */
-public class CollectionTagger extends ParseFilter implements JSONResource {
+public class CollectionTagger extends AbstractFilter implements ParseFilter, JSONResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(CollectionTagger.class);
 
@@ -100,7 +101,7 @@ public class CollectionTagger extends ParseFilter implements JSONResource {
         try {
             loadJSONResources();
         } catch (Exception e) {
-            LOG.error("Exception while loading JSON resources from jar", e);
+            LOG.error("{} - Exception while loading JSON resources from jar", getName(), e);
             throw new RuntimeException(e);
         }
     }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadata.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadata.java
@@ -17,6 +17,7 @@ package com.digitalpebble.stormcrawler.parse.filter;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -29,7 +30,7 @@ import org.w3c.dom.DocumentFragment;
  * Rewrites single metadata containing comma separated values into multiple values for the same key,
  * useful for instance for keyword tags.
  */
-public class CommaSeparatedToMultivaluedMetadata extends ParseFilter {
+public class CommaSeparatedToMultivaluedMetadata extends AbstractFilter implements ParseFilter {
 
     private final Set<String> keys = new HashSet<>();
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/DebugParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/DebugParseFilter.java
@@ -16,6 +16,7 @@ package com.digitalpebble.stormcrawler.parse.filter;
 
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.DocumentFragment;
 
 /** Dumps the DOM representation of a document into a file */
-public class DebugParseFilter extends ParseFilter {
+public class DebugParseFilter extends AbstractFilter implements ParseFilter {
 
     private OutputStream os;
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/DomainParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/DomainParseFilter.java
@@ -18,6 +18,7 @@ import com.digitalpebble.stormcrawler.Constants;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import com.digitalpebble.stormcrawler.util.URLPartitioner;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.HashMap;
@@ -26,7 +27,7 @@ import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.DocumentFragment;
 
 /** Adds domain (or host) to metadata - can be used later on for indexing * */
-public class DomainParseFilter extends ParseFilter {
+public class DomainParseFilter extends AbstractFilter implements ParseFilter {
 
     private URLPartitioner partitioner;
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/LDJsonParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/LDJsonParseFilter.java
@@ -18,6 +18,7 @@ import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.parse.ParseData;
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,7 +37,7 @@ import org.w3c.dom.DocumentFragment;
 import org.w3c.dom.Node;
 
 /** Extracts data from JSON-LD representation (https://json-ld.org/) */
-public class LDJsonParseFilter extends ParseFilter {
+public class LDJsonParseFilter extends AbstractFilter implements ParseFilter {
 
     public static final Logger LOG = LoggerFactory.getLogger(LDJsonParseFilter.class);
 
@@ -71,7 +72,7 @@ public class LDJsonParseFilter extends ParseFilter {
             }
 
         } catch (Exception e) {
-            LOG.error("Exception caught when extracting json", e);
+            LOG.error("{} - Exception caught when extracting json", getName(), e);
         }
     }
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/MD5SignatureParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/MD5SignatureParseFilter.java
@@ -18,6 +18,7 @@ import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.parse.ParseData;
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -43,7 +44,7 @@ import org.w3c.dom.DocumentFragment;
  *       signature is not copied.
  * </dl>
  */
-public class MD5SignatureParseFilter extends ParseFilter {
+public class MD5SignatureParseFilter extends AbstractFilter implements ParseFilter {
 
     private String key_name = "signature";
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/MimeTypeNormalization.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/MimeTypeNormalization.java
@@ -17,6 +17,7 @@ package com.digitalpebble.stormcrawler.parse.filter;
 import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import org.apache.storm.shade.org.apache.commons.lang.StringUtils;
 import org.w3c.dom.DocumentFragment;
 
@@ -25,7 +26,7 @@ import org.w3c.dom.DocumentFragment;
  * creates a new entry with a key 'format' in the metadata. Requires the JSoupParserBolt to be used
  * with the configuration _detect.mimetype_ set to true.
  */
-public class MimeTypeNormalization extends ParseFilter {
+public class MimeTypeNormalization extends AbstractFilter implements ParseFilter {
 
     @Override
     public void filter(String url, byte[] content, DocumentFragment doc, ParseResult parse) {

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/XPathFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/filter/XPathFilter.java
@@ -18,6 +18,7 @@ import com.digitalpebble.stormcrawler.Metadata;
 import com.digitalpebble.stormcrawler.parse.ParseData;
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -50,7 +51,7 @@ import org.w3c.dom.NodeList;
  * Simple ParseFilter to illustrate and test the interface. Reads a XPATH pattern from the config
  * file and stores the value as metadata
  */
-public class XPathFilter extends ParseFilter {
+public class XPathFilter extends AbstractFilter implements ParseFilter {
 
     private enum EvalFunction {
         NONE,
@@ -168,9 +169,9 @@ public class XPathFilter extends ParseFilter {
                         break;
                     }
                 } catch (XPathExpressionException e) {
-                    LOG.error("Error evaluating {}: {}", le.key, e);
+                    LOG.error("{} - Error evaluating {}: {}", getName(), le.key, e);
                 } catch (IOException e) {
-                    LOG.error("Error evaluating {}: {}", le.key, e);
+                    LOG.error("{} - Error evaluating {}: {}", getName(), le.key, e);
                 }
             }
         }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/AbstractFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/AbstractFilter.java
@@ -1,0 +1,29 @@
+package com.digitalpebble.stormcrawler.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+
+/** */
+public abstract class AbstractFilter implements Configurable {
+
+    private String name;
+
+    @Override
+    public void configure(
+            @NotNull Map<String, Object> stormConf,
+            @NotNull String filterName,
+            @NotNull JsonNode filtersConf) {
+        this.name = filterName;
+        configure(stormConf, filtersConf);
+    }
+
+    /**
+     * Get filter name.
+     *
+     * @return a {@link String}.
+     */
+    public String getName() {
+        return this.name;
+    }
+}

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/Configurable.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/Configurable.java
@@ -29,6 +29,20 @@ public interface Configurable {
      * Called when this filter is being initialized
      *
      * @param stormConf The Storm configuration used for the configurable
+     * @param filterName The filter name.
+     * @param filterParams the filter specific configuration. Never null
+     */
+    default void configure(
+            @NotNull Map<String, Object> stormConf,
+            @NotNull String filterName,
+            @NotNull JsonNode filterParams) {
+        configure(stormConf, filterParams);
+    }
+
+    /**
+     * Called when this filter is being initialized
+     *
+     * @param stormConf The Storm configuration used for the configurable
      * @param filterParams the filter specific configuration. Never null
      */
     default void configure(

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfigurableHelper.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfigurableHelper.java
@@ -111,10 +111,10 @@ final class ConfigurableHelper {
 
                 JsonNode paramNode = afilterConf.get("params");
                 if (paramNode != null) {
-                    filterInstance.configure(stormConf, paramNode);
+                    filterInstance.configure(stormConf, filterName, paramNode);
                 } else {
                     // Pass in a nullNode if missing
-                    filterInstance.configure(stormConf, NullNode.getInstance());
+                    filterInstance.configure(stormConf, filterName, NullNode.getInstance());
                 }
 
                 filterLists.add(filterInstance);

--- a/core/src/test/java/com/digitalpebble/stormcrawler/parse/filter/SubDocumentsParseFilter.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/parse/filter/SubDocumentsParseFilter.java
@@ -17,6 +17,7 @@ package com.digitalpebble.stormcrawler.parse.filter;
 import com.digitalpebble.stormcrawler.parse.ParseData;
 import com.digitalpebble.stormcrawler.parse.ParseFilter;
 import com.digitalpebble.stormcrawler.parse.ParseResult;
+import com.digitalpebble.stormcrawler.util.AbstractFilter;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -31,7 +32,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-public class SubDocumentsParseFilter extends ParseFilter {
+public class SubDocumentsParseFilter extends AbstractFilter implements ParseFilter {
     private static final org.slf4j.Logger LOG =
             LoggerFactory.getLogger(SubDocumentsParseFilter.class);
 
@@ -66,7 +67,7 @@ public class SubDocumentsParseFilter extends ParseFilter {
                 }
             }
         } catch (Exception e) {
-            LOG.error("Error processing sitemap from {}: {}", URL, e);
+            LOG.error("{} - Error processing sitemap from {}: {}", getName(), URL, e);
         }
     }
 

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/parse/filter/JSONResourceWrapper.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/parse/filter/JSONResourceWrapper.java
@@ -62,7 +62,7 @@ import org.w3c.dom.DocumentFragment;
  *  curl -XPUT "$ESHOST/config/_create/collections.json" -H 'Content-Type: application/json' -d @src/main/resources/collections.json
  * </pre>
  */
-public class JSONResourceWrapper extends ParseFilter {
+public class JSONResourceWrapper implements ParseFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(JSONResourceWrapper.class);
 

--- a/external/langid/src/main/java/com/digitalpebble/stormcrawler/parse/filter/LanguageID.java
+++ b/external/langid/src/main/java/com/digitalpebble/stormcrawler/parse/filter/LanguageID.java
@@ -49,7 +49,7 @@ import org.w3c.dom.DocumentFragment;
  * _extracted_ will be normalised and stored in the metadata, otherwise the languages above the
  * probability will be used.
  */
-public class LanguageID extends ParseFilter {
+public class LanguageID implements ParseFilter {
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(LanguageID.class);
 


### PR DESCRIPTION
Hello all, 

Our parseFilters.json configuration are more and more complex. We use same filter class many times to achieve specific behavior. Futhermore, we create a JsonParserBolt (to handle application/json response) and a FormatterBolt (used for example to format a price like "123 , 45" into "123.45"). So we have a lot of custom filter.

All those filters can log, a thousand times (our bots parse millions of url). So, having the filter name in log we'll help us to debug ! Currently it is only use on the setup : 

> 2022-10-26 13:23:16.080 c.d.s.u.ConfigurableHelper Thread-27-parser-executor[11, 11] [INFO] Setup MyNameFilter[com.mycompany.crawler.storm.bolt.parser.jsoup.filter.MyFilterClass]

In this PR, I also change the JsoupFilter abstract class to an interface. So we can use in the same way the new AbstractFilter :

`public class MyJsoupParseFilter extends AbstractFilter implements JSoupFilter { }`
`public class MyJsonParseFilter extends AbstractFilter implements JSonFilter { }`
`public class MyFormatterFilter extends AbstractFilter implements FormatterFilter { }`

I know the last point can affect a lot of project, so I'm open to feedback 👍 

Regards.

Signed-off-by: Mathieu Bret <mikwiss00@gmail.com>

Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'
* The code is properly formatted with 'mvn git-code-format:format-code -Dgcf.globPattern=**/*'

Thanks!

