### PR TITLE
Can disable MaxDepthFilter

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/depth/MaxDepthFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/depth/MaxDepthFilter.java
@@ -58,10 +58,9 @@ public class MaxDepthFilter implements URLFilter {
             return filter(depth, customMax, url);
         }
         // rely on the default max otherwise
-        else if (maxDepth >= 0) {
+        else {
             return filter(depth, maxDepth, url);
         }
-        return url;
     }
 
     private String filter(final int depth, final int max, final String url) {

--- a/core/src/test/java/com/digitalpebble/stormcrawler/filtering/MaxDepthFilterTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/filtering/MaxDepthFilterTest.java
@@ -38,6 +38,15 @@ public class MaxDepthFilterTest {
     }
 
     @Test
+    public void testDepthNegative() throws MalformedURLException {
+        URLFilter filter = this.createFilter("maxDepth", -1);
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assert.assertNull(filterResult);
+    }
+
+    @Test
     public void testDepthZero() throws MalformedURLException {
         URLFilter filter = createFilter("maxDepth", 0);
         URL url = new URL("http://www.sourcedomain.com/");


### PR DESCRIPTION
Hi all !

We spotted another border side. Our team recently upgrade StormCrawler version (2.2 to 2.5). The MaxDepthFilter was configured to `maxDepth : 0`, and no links was emitted (correct behavior).
After the upgrade, the first link (so with no `depth` in metadata) has emitted a hundred unwanted links. So in order to disable it, I propose to remove a condition in order to handle the `maxDepth : -1` parameter (equals to a disable). 

Let me know if it's ok for you.

Regards.

Signed-off-by: Mathieu Bret <mikwiss00@gmail.com>

Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'
* The code is properly formatted with 'mvn git-code-format:format-code -Dgcf.globPattern=**/*'

Thanks!

