### PR TITLE
Added AbstractConfigurable + URLFilter becomes an abstract class. Nam…

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/URLFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/URLFilter.java
@@ -15,7 +15,7 @@
 package com.digitalpebble.stormcrawler.filtering;
 
 import com.digitalpebble.stormcrawler.Metadata;
-import com.digitalpebble.stormcrawler.util.Configurable;
+import com.digitalpebble.stormcrawler.util.AbstractConfigurable;
 import java.net.URL;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @see URLFilters for more information.
  */
-public interface URLFilter extends Configurable {
+public abstract class URLFilter extends AbstractConfigurable {
 
     /**
      * Returns null if the URL is to be removed or a normalised representation which can correspond
@@ -39,7 +39,7 @@ public interface URLFilter extends Configurable {
      *     to the input URL
      */
     @Nullable
-    String filter(
+    public abstract String filter(
             @Nullable URL sourceUrl,
             @Nullable Metadata sourceMetadata,
             @NotNull String urlToFilter);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/URLFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/URLFilters.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see Configurable#createConfiguredInstance(Class, Class, Map, JsonNode) for more information.
  */
-public class URLFilters implements URLFilter, JSONResource {
+public class URLFilters extends URLFilter implements JSONResource {
 
     public static final URLFilters emptyURLFilters = new URLFilters();
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLFilter.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** Simple URL filters : can be used early in the filtering chain */
-public class BasicURLFilter implements URLFilter {
+public class BasicURLFilter extends URLFilter {
 
     private int maxPathRepetition = 3;
     private int maxLength = -1;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLNormalizer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLNormalizer.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class BasicURLNormalizer implements URLFilter {
+public class BasicURLNormalizer extends URLFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(BasicURLNormalizer.class);
     /** Nutch 1098 - finds URL encoded parts of the URL */

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/SelfURLFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/SelfURLFilter.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** Filters links to self * */
-public class SelfURLFilter implements URLFilter {
+public class SelfURLFilter extends URLFilter {
 
     @Override
     public @Nullable String filter(

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/depth/MaxDepthFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/depth/MaxDepthFilter.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * Filter out URLs whose depth is greater than maxDepth. If its value is set to 0 then no outlinks
  * are followed at all.
  */
-public class MaxDepthFilter implements URLFilter {
+public class MaxDepthFilter extends URLFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(MaxDepthFilter.class);
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/host/HostURLFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/host/HostURLFilter.java
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
  *       from the source's domain are filtered out
  * </ul>
  */
-public class HostURLFilter implements URLFilter {
+public class HostURLFilter extends URLFilter {
 
     private boolean ignoreOutsideHost;
     private boolean ignoreOutsideDomain;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/metadata/MetadataFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/metadata/MetadataFilter.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Filter out URLs based on metadata in the source document */
-public class MetadataFilter implements URLFilter {
+public class MetadataFilter extends URLFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(MetadataFilter.class);
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/regex/FastURLFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/regex/FastURLFilter.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
  * Partly inspired by https://github.com/commoncrawl/nutch/blob/cc-fast-url-filter
  * /src/plugin/urlfilter -fast/src/java/org/apache/nutch/urlfilter/fast/FastURLFilter.java
  */
-public class FastURLFilter implements URLFilter, JSONResource {
+public class FastURLFilter extends URLFilter implements JSONResource {
 
     public static final Logger LOG = LoggerFactory.getLogger(FastURLFilter.class);
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/regex/RegexURLFilterBase.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/regex/RegexURLFilterBase.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** An abstract class for implementing Regex URL filtering. Adapted from Apache Nutch 1.9 */
-public abstract class RegexURLFilterBase implements URLFilter {
+public abstract class RegexURLFilterBase extends URLFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(RegexURLFilterBase.class);
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/regex/RegexURLNormalizer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/regex/RegexURLNormalizer.java
@@ -52,7 +52,7 @@ import org.xml.sax.InputSource;
  *
  * <p>Adapted from Apache Nutch 1.9.
  */
-public class RegexURLNormalizer implements URLFilter {
+public class RegexURLNormalizer extends URLFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(RegexURLNormalizer.class);
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/robots/RobotsFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/robots/RobotsFilter.java
@@ -45,7 +45,7 @@ import org.jetbrains.annotations.Nullable;
  *  }
  * </pre>
  */
-public class RobotsFilter implements URLFilter {
+public class RobotsFilter extends URLFilter {
 
     private com.digitalpebble.stormcrawler.protocol.HttpRobotRulesParser robots;
     private ProtocolFactory factory;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/sitemap/SitemapFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/sitemap/SitemapFilter.java
@@ -39,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @since 1.14
  */
-public class SitemapFilter implements URLFilter {
+public class SitemapFilter extends URLFilter {
 
     @Override
     public @Nullable String filter(

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/JSoupFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/JSoupFilter.java
@@ -14,7 +14,7 @@
  */
 package com.digitalpebble.stormcrawler.parse;
 
-import com.digitalpebble.stormcrawler.util.Configurable;
+import com.digitalpebble.stormcrawler.util.AbstractConfigurable;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
  * content. They are used exclusively by {@link
  * com.digitalpebble.stormcrawler.bolt.JSoupParserBolt}.
  */
-public abstract class JSoupFilter implements Configurable {
+public abstract class JSoupFilter extends AbstractConfigurable {
 
     /**
      * Called when parsing a specific page

--- a/core/src/main/java/com/digitalpebble/stormcrawler/parse/ParseFilter.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/parse/ParseFilter.java
@@ -14,7 +14,7 @@
  */
 package com.digitalpebble.stormcrawler.parse;
 
-import com.digitalpebble.stormcrawler.util.Configurable;
+import com.digitalpebble.stormcrawler.util.AbstractConfigurable;
 import org.w3c.dom.DocumentFragment;
 
 /**
@@ -23,7 +23,7 @@ import org.w3c.dom.DocumentFragment;
  * com.digitalpebble.stormcrawler.bolt.JSoupParserBolt} or {@link
  * com.digitalpebble.stormcrawler.bolt.SiteMapParserBolt}.
  */
-public abstract class ParseFilter implements Configurable {
+public abstract class ParseFilter extends AbstractConfigurable {
 
     /**
      * Called when parsing a specific page

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/AbstractConfigurable.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/AbstractConfigurable.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
-public class AbstractConfigurable implements Configurable {
+public abstract class AbstractConfigurable implements Configurable {
 
     private String name;
 

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/AbstractConfigurable.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/AbstractConfigurable.java
@@ -12,17 +12,25 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.digitalpebble.stormcrawler.protocol.selenium;
+package com.digitalpebble.stormcrawler.util;
 
-import com.digitalpebble.stormcrawler.Metadata;
-import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
-import com.digitalpebble.stormcrawler.util.AbstractConfigurable;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.openqa.selenium.remote.RemoteWebDriver;
 
-public abstract class NavigationFilter extends AbstractConfigurable {
-    /** The end result comes from the first filter to return non-null * */
-    public abstract @Nullable ProtocolResponse filter(
-            @NotNull RemoteWebDriver driver, @NotNull Metadata metadata);
+public class AbstractConfigurable implements Configurable {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void configure(
+            @NotNull Map<String, Object> stormConf,
+            @NotNull JsonNode filtersConf,
+            @NotNull String name) {
+        this.name = name;
+        configure(stormConf, filtersConf);
+    }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/Configurable.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/Configurable.java
@@ -25,6 +25,9 @@ import org.jetbrains.annotations.NotNull;
  * <b>HAS</b> to implement an empty constructor.
  */
 public interface Configurable {
+
+    public String getName();
+
     /**
      * Called when this filter is being initialized
      *
@@ -42,7 +45,7 @@ public interface Configurable {
      *     information.
      */
     @NotNull
-    static <T extends Configurable> List<@NotNull T> createConfiguredInstance(
+    static <T extends AbstractConfigurable> List<@NotNull T> createConfiguredInstance(
             @NotNull Class<?> caller,
             @NotNull Class<T> filterClass,
             @NotNull Map<String, Object> stormConf,
@@ -94,7 +97,7 @@ public interface Configurable {
      * }</pre>
      */
     @NotNull
-    static <T extends Configurable> List<@NotNull T> createConfiguredInstance(
+    static <T extends AbstractConfigurable> List<@NotNull T> createConfiguredInstance(
             @NotNull String configName,
             @NotNull Class<T> filterClass,
             @NotNull Map<String, Object> stormConf,
@@ -109,7 +112,7 @@ public interface Configurable {
      */
     @Deprecated
     @NotNull
-    static <T extends Configurable> List<@NotNull T> configure(
+    static <T extends AbstractConfigurable> List<@NotNull T> configure(
             @NotNull Map<String, Object> stormConf,
             @NotNull JsonNode filtersConf,
             @NotNull Class<T> filterClass,

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfigurableHelper.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfigurableHelper.java
@@ -72,7 +72,7 @@ final class ConfigurableHelper {
      * }</pre>
      */
     @NotNull
-    static <T extends Configurable> List<@NotNull T> createConfiguredInstance(
+    static <T extends AbstractConfigurable> List<@NotNull T> createConfiguredInstance(
             @NotNull String configName,
             @NotNull Class<T> filterClass,
             @NotNull Map<String, Object> stormConf,
@@ -111,10 +111,10 @@ final class ConfigurableHelper {
 
                 JsonNode paramNode = afilterConf.get("params");
                 if (paramNode != null) {
-                    filterInstance.configure(stormConf, paramNode);
+                    filterInstance.configure(stormConf, paramNode, filterName);
                 } else {
                     // Pass in a nullNode if missing
-                    filterInstance.configure(stormConf, NullNode.getInstance());
+                    filterInstance.configure(stormConf, NullNode.getInstance(), filterName);
                 }
 
                 filterLists.add(filterInstance);

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/filtering/JSONURLFilterWrapper.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/filtering/JSONURLFilterWrapper.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  *  curl -XPUT 'localhost:9200/config/config/fast.urlfilter.json?pretty' -H 'Content-Type: application/json' -d @fast.urlfilter.json
  * </pre>
  */
-public class JSONURLFilterWrapper implements URLFilter {
+public class JSONURLFilterWrapper extends URLFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(JSONURLFilterWrapper.class);
 


### PR DESCRIPTION
See discussion in #1002

This creates an _AbstractConfigurable_ class and changes _URLFilter_ from being an interface to becoming an abstract class extending _AbstractConfigurable_. _Configurable_ now has a 

`    public String getName();
` 

which _AbstractConfigurable_ handles.

This allows extensions to access the name of the configurable e.g. for logging.