### PR TITLE
[WARC] Backward compatible storage of HTTP/2 headers

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/ProtocolResponse.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/ProtocolResponse.java
@@ -33,6 +33,11 @@ public class ProtocolResponse {
     /** Key which holds the request time (begin of request) in metadata. */
     public static final String REQUEST_TIME_KEY = "_request.time_";
     /**
+     * Key which holds the protocol version(s) used for this request (for layered protocols this
+     * field may hold multiple comma-separated values)
+     */
+    public static final String PROTOCOL_VERSIONS_KEY = "_protocol_versions_";
+    /**
      * Metadata key which holds a boolean value in metadata whether the response content is trimmed
      * or not.
      */

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -43,6 +43,7 @@ import okhttp3.ConnectionPool;
 import okhttp3.Credentials;
 import okhttp3.EventListener;
 import okhttp3.EventListener.Factory;
+import okhttp3.Handshake;
 import okhttp3.Headers;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -570,12 +571,20 @@ public class HttpProtocol extends AbstractHttpProtocol {
             byte[] encodedBytesRequest =
                     Base64.getEncoder().encode(requestverbatim.toString().getBytes());
 
+            StringBuilder protocols = new StringBuilder(response.protocol().toString());
+            Handshake handshake = connection.handshake();
+            if (handshake != null) {
+                protocols.append(',').append(handshake.tlsVersion());
+                protocols.append(',').append(handshake.cipherSuite());
+            }
+
             // returns a modified version of the response
             return response.newBuilder()
                     .header(ProtocolResponse.REQUEST_HEADERS_KEY, new String(encodedBytesRequest))
                     .header(ProtocolResponse.RESPONSE_HEADERS_KEY, new String(encodedBytesResponse))
                     .header(ProtocolResponse.RESPONSE_IP_KEY, ipAddress)
                     .header(ProtocolResponse.REQUEST_TIME_KEY, Long.toString(startFetchTime))
+                    .header(ProtocolResponse.PROTOCOL_VERSIONS_KEY, protocols.toString())
                     .build();
         }
     }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -571,8 +571,8 @@ public class HttpProtocol extends AbstractHttpProtocol {
             byte[] encodedBytesRequest =
                     Base64.getEncoder().encode(requestverbatim.toString().getBytes());
 
-            StringBuilder protocols = new StringBuilder(response.protocol().toString());
-            Handshake handshake = connection.handshake();
+            final StringBuilder protocols = new StringBuilder(response.protocol().toString());
+            final Handshake handshake = connection.handshake();
             if (handshake != null) {
                 protocols.append(',').append(handshake.tlsVersion());
                 protocols.append(',').append(handshake.cipherSuite());

--- a/core/src/test/java/com/digitalpebble/stormcrawler/TestOutputCollector.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/TestOutputCollector.java
@@ -24,14 +24,19 @@ import org.apache.storm.spout.ISpoutOutputCollector;
 import org.apache.storm.task.IOutputCollector;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.Utils;
+import org.slf4j.LoggerFactory;
 
 public class TestOutputCollector implements IOutputCollector, ISpoutOutputCollector {
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(TestOutputCollector.class);
+
     private List<Tuple> acked = new ArrayList<>();
     private List<Tuple> failed = new ArrayList<>();
     private Map<String, List<List<Object>>> emitted = new HashMap<>();
 
     @Override
-    public void reportError(Throwable error) {}
+    public void reportError(Throwable error) {
+        LOG.error("Got exception", error);
+    }
 
     @Override
     public List<Integer> emit(String streamId, Collection<Tuple> anchors, List<Object> tuples) {

--- a/external/warc/README.md
+++ b/external/warc/README.md
@@ -153,11 +153,12 @@ Writing complete and valid WARC requires that HTTP headers, IP address and captu
   https.protocol.implementation: com.digitalpebble.stormcrawler.protocol.okhttp.HttpProtocol
 ```
 
-Until the WARC bolt can write HTTP/2 requests and response in a way compatible with most WARC readers (see #828), HTTP/1.1 should be used by setting:
-```
-  http.protocol.versions:
-  - "http/1.1"
-```
+A note on the recording of HTTP requests and responses with StormCrawler and the WARC module:
+- the WARC file format is derived from the HTTP message format ([RFC 2616](https://www.ietf.org/rfc/rfc2616.txt)) and the WARC format as well as WARC readers require that HTTP requests and responses are recorded as HTTP/1.1 or HTTP/1.0 do. Therefor, the WARC WARCHdfsBolt writes binary HTTP formats (eg. [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2)) as if they were HTTP/1.1. There is no need to limit the supported HTTP protocol versions to HTTP/1.0 or HTTP/1.1.
+- HTTP transfer and content encodings are not preserved in WARC records. In order to avoid that WARC readers fail on parsing HTTP messages,
+  - the HTTP reponse headers `Transfer-Encoding`, `Content-Encoding` and `Content-Length` are masked with the prefix `X-Crawler-`
+  - a new `Content-Length` header is always appended with the actual payload length.
+
 
 
 ## Consuming WARC files

--- a/external/warc/README.md
+++ b/external/warc/README.md
@@ -154,9 +154,9 @@ Writing complete and valid WARC requires that HTTP headers, IP address and captu
 ```
 
 A note on the recording of HTTP requests and responses with StormCrawler and the WARC module:
-- the WARC file format is derived from the HTTP message format ([RFC 2616](https://www.ietf.org/rfc/rfc2616.txt)) and the WARC format as well as WARC readers require that HTTP requests and responses are recorded as HTTP/1.1 or HTTP/1.0 do. Therefor, the WARC WARCHdfsBolt writes binary HTTP formats (eg. [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2)) as if they were HTTP/1.1. There is no need to limit the supported HTTP protocol versions to HTTP/1.0 or HTTP/1.1.
+- the WARC file format is derived from the HTTP message format ([RFC 2616](https://www.ietf.org/rfc/rfc2616.txt)) and the WARC format as well as WARC readers require that HTTP requests and responses are recorded as HTTP/1.1 or HTTP/1.0. Therefore, the WARC WARCHdfsBolt writes binary HTTP formats (eg. [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2)) as if they were HTTP/1.1. There is no need to limit the supported HTTP protocol versions to HTTP/1.0 or HTTP/1.1.
 - HTTP transfer and content encodings are not preserved in WARC records. In order to avoid that WARC readers fail on parsing HTTP messages,
-  - the HTTP reponse headers `Transfer-Encoding`, `Content-Encoding` and `Content-Length` are masked with the prefix `X-Crawler-`
+  - the HTTP response headers `Transfer-Encoding`, `Content-Encoding` and `Content-Length` are masked with the prefix `X-Crawler-`
   - a new `Content-Length` header is always appended with the actual payload length.
 
 

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/GzipHdfsBolt.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/GzipHdfsBolt.java
@@ -15,30 +15,21 @@
 package com.digitalpebble.stormcrawler.warc;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.storm.hdfs.bolt.AbstractHdfsBolt;
-import org.apache.storm.hdfs.bolt.format.FileNameFormat;
+import org.apache.storm.hdfs.bolt.HdfsBolt;
 import org.apache.storm.hdfs.bolt.format.RecordFormat;
-import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
-import org.apache.storm.hdfs.bolt.sync.SyncPolicy;
 import org.apache.storm.hdfs.common.AbstractHDFSWriter;
 import org.apache.storm.hdfs.common.HDFSWriter;
-import org.apache.storm.hdfs.common.rotation.RotationAction;
-import org.apache.storm.task.OutputCollector;
-import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Unlike the standard HdfsBolt this one writes to a gzipped stream with per-record compression. */
-public class GzipHdfsBolt extends AbstractHdfsBolt {
+public class GzipHdfsBolt extends HdfsBolt {
 
     private static final Logger LOG = LoggerFactory.getLogger(GzipHdfsBolt.class);
 
@@ -105,21 +96,6 @@ public class GzipHdfsBolt extends AbstractHdfsBolt {
         }
     }
 
-    public GzipHdfsBolt withFsUrl(String fsUrl) {
-        this.fsUrl = fsUrl;
-        return this;
-    }
-
-    public GzipHdfsBolt withConfigKey(String configKey) {
-        this.configKey = configKey;
-        return this;
-    }
-
-    public GzipHdfsBolt withFileNameFormat(FileNameFormat fileNameFormat) {
-        this.fileNameFormat = fileNameFormat;
-        return this;
-    }
-
     /** Sets the record format, overwriting the existing one(s) */
     public GzipHdfsBolt withRecordFormat(RecordFormat format) {
         this.format = new GzippedRecordFormat(format);
@@ -149,28 +125,6 @@ public class GzipHdfsBolt extends AbstractHdfsBolt {
         return this;
     }
 
-    public GzipHdfsBolt withSyncPolicy(SyncPolicy syncPolicy) {
-        this.syncPolicy = syncPolicy;
-        return this;
-    }
-
-    public GzipHdfsBolt withRotationPolicy(FileRotationPolicy rotationPolicy) {
-        this.rotationPolicy = rotationPolicy;
-        return this;
-    }
-
-    public GzipHdfsBolt addRotationAction(RotationAction action) {
-        this.rotationActions.add(action);
-        return this;
-    }
-
-    @Override
-    public void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector)
-            throws IOException {
-        LOG.info("Preparing HDFS Bolt...");
-        this.fs = FileSystem.get(URI.create(this.fsUrl), hdfsConfig);
-    }
-
     @Override
     public void cleanup() {
         LOG.info("Cleanup called on bolt");
@@ -184,11 +138,6 @@ public class GzipHdfsBolt extends AbstractHdfsBolt {
         } catch (IOException e) {
             LOG.error("Exception while calling cleanup");
         }
-    }
-
-    @Override
-    protected String getWriterKey(Tuple tuple) {
-        return "CONSTANT";
     }
 
     @Override

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCFileNameFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCFileNameFormat.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.digitalpebble.stormcrawler.warc;
 
 import java.text.SimpleDateFormat;

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
@@ -46,7 +46,8 @@ public class WARCHdfsBolt extends GzipHdfsBolt {
     }
 
     @Override
-    public void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector)
+    public void doPrepare(
+            Map<String, Object> conf, TopologyContext topologyContext, OutputCollector collector)
             throws IOException {
         super.doPrepare(conf, topologyContext, collector);
         protocolMDprefix = ConfUtils.getString(conf, ProtocolResponse.PROTOCOL_MD_PREFIX_PARAM, "");

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.digitalpebble.stormcrawler.warc;
 
 import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
@@ -15,8 +29,12 @@ import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WARCHdfsBolt extends GzipHdfsBolt {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WARCHdfsBolt.class);
 
     private Map<String, String> header_fields = new HashMap<>();
 
@@ -66,6 +84,8 @@ public class WARCHdfsBolt extends GzipHdfsBolt {
         // overrides the filename and creation date in the headers
         header_fields.put("WARC-Date", WARCRecordFormat.WARC_DF.format(now));
         header_fields.put("WARC-Filename", path.getName());
+
+        LOG.info("Opening WARC file {}", path);
 
         byte[] header = WARCRecordFormat.generateWARCInfo(header_fields);
 

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.digitalpebble.stormcrawler.warc;
 
 import static com.digitalpebble.stormcrawler.protocol.ProtocolResponse.REQUEST_TIME_KEY;

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
@@ -390,10 +390,10 @@ public class WARCRecordFormat implements RecordFormat {
             buffer.append("Content-Type: ").append(ct).append(CRLF);
         }
 
-        String truncated = metadata.getFirstValue("http.trimmed");
+        String truncated = metadata.getFirstValue(ProtocolResponse.TRIMMED_RESPONSE_KEY);
         if (truncated != null) {
             // content is truncated
-            truncated = metadata.getFirstValue("http.trimmed.reason");
+            truncated = metadata.getFirstValue(ProtocolResponse.TRIMMED_RESPONSE_REASON_KEY);
             if (truncated == null) {
                 truncated =
                         ProtocolResponse.TrimmedContentReason.UNSPECIFIED
@@ -401,6 +401,10 @@ public class WARCRecordFormat implements RecordFormat {
                                 .toLowerCase(Locale.ROOT);
             }
             buffer.append("WARC-Truncated").append(": ").append(truncated).append(CRLF);
+        }
+        String protocolVersions = metadata.getFirstValue(ProtocolResponse.PROTOCOL_VERSIONS_KEY);
+        if (protocolVersions != null) {
+            buffer.append("WARC-Protocol: ").append(protocolVersions).append(CRLF);
         }
 
         buffer.append("WARC-Payload-Digest").append(": ").append(payloadDigest).append(CRLF);

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
@@ -379,7 +379,7 @@ public class WARCRecordFormat implements RecordFormat {
         buffer.append("WARC-Type").append(": ").append(WARCTypeValue).append(CRLF);
 
         // "WARC-IP-Address" if present
-        String IP = metadata.getFirstValue(RESPONSE_IP_KEY);
+        String IP = metadata.getFirstValue(RESPONSE_IP_KEY, this.protocolMDprefix);
         if (StringUtils.isNotBlank(IP)) {
             buffer.append("WARC-IP-Address").append(": ").append(IP).append(CRLF);
         }
@@ -400,17 +400,21 @@ public class WARCRecordFormat implements RecordFormat {
         }
         // for resources just use the content type provided by the server if any
         else {
-            String ct = metadata.getFirstValue(HttpHeaders.CONTENT_TYPE);
+            String ct = metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
             if (StringUtils.isBlank(ct)) {
                 ct = "application/octet-stream";
             }
             buffer.append("Content-Type: ").append(ct).append(CRLF);
         }
 
-        String truncated = metadata.getFirstValue(ProtocolResponse.TRIMMED_RESPONSE_KEY);
+        String truncated =
+                metadata.getFirstValue(
+                        ProtocolResponse.TRIMMED_RESPONSE_KEY, this.protocolMDprefix);
         if (truncated != null) {
             // content is truncated
-            truncated = metadata.getFirstValue(ProtocolResponse.TRIMMED_RESPONSE_REASON_KEY);
+            truncated =
+                    metadata.getFirstValue(
+                            ProtocolResponse.TRIMMED_RESPONSE_REASON_KEY, this.protocolMDprefix);
             if (truncated == null) {
                 truncated =
                         ProtocolResponse.TrimmedContentReason.UNSPECIFIED
@@ -420,7 +424,8 @@ public class WARCRecordFormat implements RecordFormat {
             buffer.append("WARC-Truncated").append(": ").append(truncated).append(CRLF);
         }
         final String protocolVersions =
-                metadata.getFirstValue(ProtocolResponse.PROTOCOL_VERSIONS_KEY);
+                metadata.getFirstValue(
+                        ProtocolResponse.PROTOCOL_VERSIONS_KEY, this.protocolMDprefix);
         if (protocolVersions != null) {
             buffer.append("WARC-Protocol: ").append(protocolVersions).append(CRLF);
         }

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormat.java
@@ -168,7 +168,7 @@ public class WARCRecordFormat implements RecordFormat {
      */
     public static String fixHttpHeaders(String headers, int contentLength) {
         int start = 0, lineEnd = 0, last = 0, trailingCrLf = 0;
-        StringBuilder replace = new StringBuilder();
+        final StringBuilder replacement = new StringBuilder();
         while (start < headers.length()) {
             lineEnd = headers.indexOf(CRLF, start);
             trailingCrLf = 1;
@@ -187,9 +187,9 @@ public class WARCRecordFormat implements RecordFormat {
                 boolean valid = true;
                 if (start == 0) {
                     // status line (without colon)
-                    String statusLine = headers.substring(0, lineEnd);
+                    final String statusLine = headers.substring(0, lineEnd);
                     if (!STATUS_LINE_PATTERN.matcher(statusLine).matches()) {
-                        String[] parts = WS_PATTERN.split(headers.substring(0, lineEnd), 3);
+                        final String[] parts = WS_PATTERN.split(headers.substring(0, lineEnd), 3);
                         if (parts.length < 2
                                 || !HTTP_STATUS_CODE_PATTERN.matcher(parts[1]).matches()) {
                             // nothing we can do here, leave status line as is
@@ -198,17 +198,17 @@ public class WARCRecordFormat implements RecordFormat {
                                     statusLine);
                         } else {
                             if (HTTP_VERSION_PATTERN.matcher(parts[0]).matches()) {
-                                replace.append(parts[0]);
+                                replacement.append(parts[0]);
                             } else {
-                                replace.append(HTTP_VERSION_FALLBACK);
+                                replacement.append(HTTP_VERSION_FALLBACK);
                             }
-                            replace.append(' ');
-                            replace.append(parts[1]); // status code
-                            replace.append(' ');
+                            replacement.append(' ');
+                            replacement.append(parts[1]); // status code
+                            replacement.append(' ');
                             if (parts.length == 3) {
-                                replace.append(parts[2]); // message
+                                replacement.append(parts[2]); // message
                             }
-                            replace.append(CRLF);
+                            replacement.append(CRLF);
                             last = lineEnd + 2 * trailingCrLf;
                         }
                     }
@@ -224,7 +224,7 @@ public class WARCRecordFormat implements RecordFormat {
                 }
                 if (!valid) {
                     if (last < start) {
-                        replace.append(headers.substring(last, start));
+                        replacement.append(headers.substring(last, start));
                     }
                     last = lineEnd + 2 * trailingCrLf;
                 }
@@ -251,19 +251,21 @@ public class WARCRecordFormat implements RecordFormat {
                 }
                 if (needsFix) {
                     if (last < start) {
-                        replace.append(headers.substring(last, start));
+                        replacement.append(headers.substring(last, start));
                     }
                     last = lineEnd + 2 * trailingCrLf;
-                    replace.append(X_HIDE_HEADER)
+                    replacement
+                            .append(X_HIDE_HEADER)
                             .append(headers.substring(start, lineEnd + 2 * trailingCrLf));
                     if (trailingCrLf == 0) {
-                        replace.append(CRLF);
+                        replacement.append(CRLF);
                         trailingCrLf = 1;
                     }
                     if (name.equalsIgnoreCase("content-length")) {
                         // add effective uncompressed and unchunked length of
                         // content
-                        replace.append("Content-Length")
+                        replacement
+                                .append("Content-Length")
                                 .append(": ")
                                 .append(contentLength)
                                 .append(CRLF);
@@ -275,13 +277,13 @@ public class WARCRecordFormat implements RecordFormat {
         if (last > 0 || trailingCrLf != 2) {
             if (last < headers.length()) {
                 // append trailing headers
-                replace.append(headers.substring(last));
+                replacement.append(headers.substring(last));
             }
             while (trailingCrLf < 2) {
-                replace.append(CRLF);
+                replacement.append(CRLF);
                 trailingCrLf++;
             }
-            return replace.toString();
+            return replacement.toString();
         }
         return headers;
     }
@@ -417,7 +419,8 @@ public class WARCRecordFormat implements RecordFormat {
             }
             buffer.append("WARC-Truncated").append(": ").append(truncated).append(CRLF);
         }
-        String protocolVersions = metadata.getFirstValue(ProtocolResponse.PROTOCOL_VERSIONS_KEY);
+        final String protocolVersions =
+                metadata.getFirstValue(ProtocolResponse.PROTOCOL_VERSIONS_KEY);
         if (protocolVersions != null) {
             buffer.append("WARC-Protocol: ").append(protocolVersions).append(CRLF);
         }

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.digitalpebble.stormcrawler.warc;
 
 import static com.digitalpebble.stormcrawler.protocol.ProtocolResponse.REQUEST_HEADERS_KEY;

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.apache.storm.tuple.Tuple;
 import org.slf4j.Logger;
@@ -22,6 +23,9 @@ public class WARCRequestRecordFormat extends WARCRecordFormat {
 
     private static final Logger LOG = LoggerFactory.getLogger(WARCRequestRecordFormat.class);
 
+    protected static final Pattern REQUEST_LINE_PATTERN =
+            Pattern.compile("^\\S+ \\S+ HTTP/1\\.[01]$");
+
     public WARCRequestRecordFormat(String protocolMDprefix) {
         super(protocolMDprefix);
     }
@@ -33,18 +37,12 @@ public class WARCRequestRecordFormat extends WARCRecordFormat {
         Metadata metadata = (Metadata) tuple.getValueByField("metadata");
 
         String headersVerbatim = metadata.getFirstValue(REQUEST_HEADERS_KEY, this.protocolMDprefix);
-        byte[] httpheaders = new byte[0];
         if (StringUtils.isBlank(headersVerbatim)) {
             // no request header: return empty record
             LOG.warn("No request header for {}", url);
             return new byte[] {};
-        } else {
-            // check that header ends with an empty line
-            while (!headersVerbatim.endsWith(CRLF + CRLF)) {
-                headersVerbatim += CRLF;
-            }
-            httpheaders = headersVerbatim.getBytes();
         }
+        byte[] httpheaders = fixHttpHeaders(headersVerbatim).getBytes();
 
         StringBuilder buffer = new StringBuilder();
         buffer.append(WARC_VERSION);
@@ -103,5 +101,79 @@ public class WARCRequestRecordFormat extends WARCRecordFormat {
         bytebuffer.put(CRLF_BYTES);
 
         return bytebuffer.array();
+    }
+
+    private static String fixHttpHeaders(String headers) {
+        int start = 0, lineEnd = 0, last = 0, trailingCrLf = 0;
+        StringBuilder replace = new StringBuilder();
+        while (start < headers.length()) {
+            boolean valid = true;
+            lineEnd = headers.indexOf(CRLF, start);
+            trailingCrLf = 1;
+            if (lineEnd == -1) {
+                lineEnd = headers.length();
+                trailingCrLf = 0;
+            }
+            if (start == 0) {
+                String requestLine = headers.substring(0, lineEnd);
+                if (!REQUEST_LINE_PATTERN.matcher(requestLine).matches()) {
+                    String[] parts = WS_PATTERN.split(requestLine, 3);
+                    if (parts.length < 2) {
+                        LOG.warn(
+                                "WARC parsers may fail on non-standard HTTP 1.0 / 1.1 request line: {}",
+                                requestLine);
+                    } else if (parts.length < 3
+                            || !HTTP_VERSION_PATTERN.matcher(parts[2]).matches()) {
+                        LOG.info(requestLine);
+                        // append HTTP version string accepted by most WARC parsers
+                        replace.append(parts[0]);
+                        replace.append(' ');
+                        replace.append(parts[1]); // status code
+                        replace.append(' ');
+                        replace.append(HTTP_VERSION_FALLBACK);
+                        replace.append(CRLF);
+                        last = lineEnd + 2 * trailingCrLf;
+                    }
+                }
+            } else if ((lineEnd + 4) == headers.length() && headers.endsWith(CRLF + CRLF)) {
+                // ok, trailing empty line
+                trailingCrLf = 2;
+            } else if (start == lineEnd) {
+                // skip/remove empty line
+                valid = false;
+            } else {
+                int colonPos = -1;
+                for (int i = start; i < lineEnd; i++) {
+                    if (headers.charAt(i) == ':') {
+                        colonPos = i;
+                        break;
+                    }
+                }
+                if (colonPos == -1) {
+                    LOG.warn("Invalid header line: {}", headers.substring(start, lineEnd));
+                    valid = false;
+                }
+                // no headers to replace in requests
+            }
+            if (!valid) {
+                if (last < start) {
+                    replace.append(headers.substring(last, start));
+                }
+                last = lineEnd + 2 * trailingCrLf;
+            }
+            start = lineEnd + 2 * trailingCrLf;
+        }
+        if (last > 0 || trailingCrLf != 2) {
+            if (last < headers.length()) {
+                // append trailing headers
+                replace.append(headers.substring(last));
+            }
+            while (trailingCrLf < 2) {
+                replace.append(CRLF);
+                trailingCrLf++;
+            }
+            return replace.toString();
+        }
+        return headers;
     }
 }

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
@@ -56,7 +56,7 @@ public class WARCRequestRecordFormat extends WARCRecordFormat {
             LOG.warn("No request header for {}", url);
             return new byte[] {};
         }
-        byte[] httpheaders = fixHttpHeaders(headersVerbatim).getBytes();
+        final byte[] httpheaders = fixHttpHeaders(headersVerbatim).getBytes();
 
         StringBuilder buffer = new StringBuilder();
         buffer.append(WARC_VERSION);

--- a/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
+++ b/external/warc/src/main/java/com/digitalpebble/stormcrawler/warc/WARCRequestRecordFormat.java
@@ -119,7 +119,7 @@ public class WARCRequestRecordFormat extends WARCRecordFormat {
 
     private static String fixHttpHeaders(String headers) {
         int start = 0, lineEnd = 0, last = 0, trailingCrLf = 0;
-        StringBuilder replace = new StringBuilder();
+        final StringBuilder replacement = new StringBuilder();
         while (start < headers.length()) {
             boolean valid = true;
             lineEnd = headers.indexOf(CRLF, start);
@@ -140,12 +140,12 @@ public class WARCRequestRecordFormat extends WARCRecordFormat {
                             || !HTTP_VERSION_PATTERN.matcher(parts[2]).matches()) {
                         LOG.info(requestLine);
                         // append HTTP version string accepted by most WARC parsers
-                        replace.append(parts[0]);
-                        replace.append(' ');
-                        replace.append(parts[1]); // status code
-                        replace.append(' ');
-                        replace.append(HTTP_VERSION_FALLBACK);
-                        replace.append(CRLF);
+                        replacement.append(parts[0]);
+                        replacement.append(' ');
+                        replacement.append(parts[1]); // status code
+                        replacement.append(' ');
+                        replacement.append(HTTP_VERSION_FALLBACK);
+                        replacement.append(CRLF);
                         last = lineEnd + 2 * trailingCrLf;
                     }
                 }
@@ -171,7 +171,7 @@ public class WARCRequestRecordFormat extends WARCRecordFormat {
             }
             if (!valid) {
                 if (last < start) {
-                    replace.append(headers.substring(last, start));
+                    replacement.append(headers.substring(last, start));
                 }
                 last = lineEnd + 2 * trailingCrLf;
             }
@@ -180,13 +180,13 @@ public class WARCRequestRecordFormat extends WARCRecordFormat {
         if (last > 0 || trailingCrLf != 2) {
             if (last < headers.length()) {
                 // append trailing headers
-                replace.append(headers.substring(last));
+                replacement.append(headers.substring(last));
             }
             while (trailingCrLf < 2) {
-                replace.append(CRLF);
+                replacement.append(CRLF);
                 trailingCrLf++;
             }
-            return replace.toString();
+            return replacement.toString();
         }
         return headers;
     }

--- a/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBoltTest.java
+++ b/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBoltTest.java
@@ -15,6 +15,7 @@
 package com.digitalpebble.stormcrawler.warc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -106,6 +107,12 @@ public class WARCHdfsBoltTest {
         assertEquals("response", records.get(2).type());
         WarcResponse response = (WarcResponse) records.get(2);
         assertEquals(MessageVersion.HTTP_1_1, response.http().version());
+        assertTrue(
+                "WARC response record is expected to include WARC header \"WARC-Protocol\"",
+                response.headers().first("WARC-Protocol").isPresent());
+        assertTrue(
+                "WARC response record is expected to include WARC header \"WARC-IP-Address\"",
+                response.headers().first("WARC-IP-Address").isPresent());
     }
 
     @Test
@@ -123,6 +130,12 @@ public class WARCHdfsBoltTest {
         assertEquals("response", records.get(2).type());
         WarcResponse response = (WarcResponse) records.get(2);
         assertEquals(MessageVersion.HTTP_1_1, response.http().version());
+        assertTrue(
+                "WARC response record is expected to include WARC header \"WARC-Protocol\"",
+                response.headers().first("WARC-Protocol").isPresent());
+        assertTrue(
+                "WARC response record is expected to include WARC header \"WARC-IP-Address\"",
+                response.headers().first("WARC-IP-Address").isPresent());
     }
 
     private static Stream<WarcRecord> readWARCs(Path warcDir) {
@@ -195,6 +208,10 @@ public class WARCHdfsBoltTest {
                         + "Content-Encoding: gzip\r\n" //
                         + "Content-Length: 26\r\n" //
                         + "Connection: close\r\n\r\n");
+        metadata.addValue(
+                protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY,
+                httpVersionString + ",TLS_1_3,TLS_AES_256_GCM_SHA384");
+        metadata.addValue(protocolMDprefix + ProtocolResponse.RESPONSE_IP_KEY, "123.123.123.123");
         Tuple tuple = mock(Tuple.class);
         when(tuple.getBinaryByField("content")).thenReturn(content);
         when(tuple.getStringByField("url")).thenReturn("https://www.example.org/");

--- a/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBoltTest.java
+++ b/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBoltTest.java
@@ -1,0 +1,204 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.warc;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.digitalpebble.stormcrawler.Metadata;
+import com.digitalpebble.stormcrawler.TestOutputCollector;
+import com.digitalpebble.stormcrawler.TestUtil;
+import com.digitalpebble.stormcrawler.protocol.ProtocolResponse;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.storm.hdfs.bolt.HdfsBolt;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.tuple.Tuple;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.netpreserve.jwarc.MessageVersion;
+import org.netpreserve.jwarc.WarcReader;
+import org.netpreserve.jwarc.WarcRecord;
+import org.netpreserve.jwarc.WarcRequest;
+import org.netpreserve.jwarc.WarcResponse;
+
+public class WARCHdfsBoltTest {
+
+    private String protocolMDprefix = "protocol.";
+    private Path warcDir = Path.of("target", "warc");
+
+    private TestOutputCollector output;
+    private HdfsBolt bolt;
+    private Map<String, Object> conf;
+
+    @Before
+    public void setup() throws IOException {
+        output = new TestOutputCollector();
+
+        // create directory for WARC files and cleanup
+        Files.createDirectories(warcDir);
+        Files.walk(warcDir)
+                .forEach(
+                        t -> {
+                            try {
+                                Files.delete(t);
+                            } catch (IOException e) {
+                            }
+                        });
+
+        bolt = makeBolt();
+
+        // configure RawLocalFileSystem so that WARC files are immediately flushed
+        bolt.withConfigKey("warc");
+        Map<String, Object> hdfsConf = new HashMap<>();
+        hdfsConf.put("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
+        conf = new HashMap<String, Object>();
+        conf.put("warc", hdfsConf);
+
+        conf.put(ProtocolResponse.PROTOCOL_MD_PREFIX_PARAM, protocolMDprefix);
+
+        bolt.prepare(conf, TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+    }
+
+    @After
+    public void cleanup() {
+        bolt.cleanup();
+        output = null;
+    }
+
+    @Test
+    public void test() throws IOException {
+        // write page into WARC file
+        bolt.execute(getPage());
+
+        // ensure the WARC file is written
+        bolt.cleanup();
+
+        // read WARC file
+        List<WarcRecord> records = readWARCs(warcDir).collect(Collectors.toList());
+
+        // expected 3 records (warcinfo, request, response)
+        assertEquals(3, records.size());
+        assertEquals("warcinfo", records.get(0).type());
+        assertEquals("request", records.get(1).type());
+        assertEquals("response", records.get(2).type());
+        WarcResponse response = (WarcResponse) records.get(2);
+        assertEquals(MessageVersion.HTTP_1_1, response.http().version());
+    }
+
+    @Test
+    public void testHttp2() throws IOException {
+        bolt.execute(getPage("HTTP/2"));
+        bolt.cleanup();
+        List<WarcRecord> records = readWARCs(warcDir).collect(Collectors.toList());
+
+        // expected 3 records (warcinfo, request, response)
+        assertEquals(3, records.size());
+        assertEquals("warcinfo", records.get(0).type());
+        assertEquals("request", records.get(1).type());
+        WarcRequest request = (WarcRequest) records.get(1);
+        assertEquals(MessageVersion.HTTP_1_1, request.http().version());
+        assertEquals("response", records.get(2).type());
+        WarcResponse response = (WarcResponse) records.get(2);
+        assertEquals(MessageVersion.HTTP_1_1, response.http().version());
+    }
+
+    private static Stream<WarcRecord> readWARCs(Path warcDir) {
+        try {
+            return Files.walk(warcDir)
+                    .filter(Files::isRegularFile)
+                    .flatMap(WARCHdfsBoltTest::readWARC);
+        } catch (IOException e) {
+            return Stream.empty();
+        }
+    }
+
+    private static Stream<WarcRecord> readWARC(Path warcFile) {
+        try (WarcReader warcReader = new WarcReader(FileChannel.open(warcFile))) {
+            List<WarcRecord> records =
+                    warcReader
+                            .records()
+                            .map(WARCHdfsBoltTest::readWARCrecord)
+                            .collect(Collectors.toList());
+            return records.stream();
+        } catch (IOException e) {
+            return Stream.empty();
+        }
+    }
+
+    private static WarcRecord readWARCrecord(WarcRecord record) {
+        try {
+            // need to read the HTTP header, so that it gets parsed
+            if (record instanceof WarcResponse) ((WarcResponse) record).http();
+            if (record instanceof WarcRequest) ((WarcRequest) record).http();
+        } catch (IOException e) {
+        }
+        return record;
+    }
+
+    private HdfsBolt makeBolt() {
+        WARCHdfsBolt bolt = new WARCHdfsBolt();
+        bolt.withFileNameFormat(
+                new WARCFileNameFormat().withPath(warcDir.toAbsolutePath().toString()));
+        bolt.withRecordFormat(new WARCRecordFormat(protocolMDprefix));
+        bolt.addRecordFormat(new WARCRequestRecordFormat(protocolMDprefix), 0);
+        bolt.withRequestRecords();
+        return bolt;
+    }
+
+    private Tuple getPage() {
+        return getPage("HTTP/1.1");
+    }
+
+    private Tuple getPage(String httpVersionString) {
+        String txt = "abcdef";
+        byte[] content = txt.getBytes(StandardCharsets.UTF_8);
+        Metadata metadata = new Metadata();
+        metadata.addValue(
+                protocolMDprefix + ProtocolResponse.REQUEST_HEADERS_KEY, //
+                "GET / "
+                        + httpVersionString
+                        + "\r\n" //
+                        + "User-Agent: myBot/1.0 (https://example.org/bot/; bot@example.org)\r\n" //
+                        + "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n" //
+                        + "Accept-Language: en-us,en-gb,en;q=0.7,*;q=0.3\r\n" //
+                        + "Accept-Encoding: br,gzip\r\n" //
+                        + "Host: example.org\r\n" //
+                        + "Connection: Keep-Alive\r\n\r\n");
+        metadata.addValue(
+                protocolMDprefix + ProtocolResponse.RESPONSE_HEADERS_KEY, //
+                httpVersionString
+                        + " 200 OK\r\n" //
+                        + "Content-Type: text/html\r\n" //
+                        + "Content-Encoding: gzip\r\n" //
+                        + "Content-Length: 26\r\n" //
+                        + "Connection: close\r\n\r\n");
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getBinaryByField("content")).thenReturn(content);
+        when(tuple.getStringByField("url")).thenReturn("https://www.example.org/");
+        when(tuple.getValueByField("metadata")).thenReturn(metadata);
+        return tuple;
+    }
+}

--- a/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormatTest.java
+++ b/external/warc/src/test/java/com/digitalpebble/stormcrawler/warc/WARCRecordFormatTest.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.digitalpebble.stormcrawler.warc;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
This PR addresses #828:
- the Okhttp protocol stores HTTP and TLS versions (if HTTP headers are stored)
- the WARC record formats normalize HTTP request and response status lines
  - replace HTTP version strings other than "HTTP/1.0" and "HTTP/1.1" 
- HTTP and TLS/SSL protocol versions are stored in the WARC header "WARC-Protocol" following roughly /iipc/warc-specifications#42 (protcol versions are stored as received from the protocol implementation in a single comma-separated value (no multiple headers)

Further improvements of the WARC module:
- add unit test for WARCHdfsBolt
  - write WARC file with info, request and response record
  - read and verify WARC file using [jwarc](/iipc/jwarc)
- extend GzipHdfsBolt from HdfsBolt (instead of AbstractHdfsBolt) and remove overridden methods with identical implementation in HdfsBolt
- add missing license headers