### PR TITLE
Ignore empty fields indexer

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/indexing/AbstractIndexerBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/indexing/AbstractIndexerBolt.java
@@ -67,6 +67,9 @@ public abstract class AbstractIndexerBolt extends BaseRichBolt {
     /** Field name to use for reading the canonical property of the metadata */
     public static final String canonicalMetadataParamName = "indexer.canonical.name";
 
+    /** Indicates that empty field values should not be emitted at all. */
+    public static final String ignoreEmptyFieldValueParamName = "indexer.ignore.empty.fields";
+
     private String[] filterKeyValue = null;
 
     private Map<String, String> metadata2field = new HashMap<>();
@@ -78,6 +81,8 @@ public abstract class AbstractIndexerBolt extends BaseRichBolt {
     private String fieldNameForURL = null;
 
     private String canonicalMetadataName = null;
+
+    private boolean ignoreEmptyFields = false;
 
     @Override
     public void prepare(
@@ -117,6 +122,9 @@ public abstract class AbstractIndexerBolt extends BaseRichBolt {
                 LOG.info("Mapping key {} to field {}", mapping, mapping);
             }
         }
+
+        ignoreEmptyFields =
+                ConfUtils.getBoolean(conf, ignoreEmptyFieldValueParamName, ignoreEmptyFields);
     }
 
     /**
@@ -218,8 +226,9 @@ public abstract class AbstractIndexerBolt extends BaseRichBolt {
      * configuration.
      */
     protected String trimText(String text) {
+        if (text == null) return null;
+        text = text.trim();
         if (maxLengthText == -1) return text;
-        if (text == null) return text;
         if (text.length() <= maxLengthText) return text;
         return text.substring(0, maxLengthText);
     }
@@ -227,6 +236,10 @@ public abstract class AbstractIndexerBolt extends BaseRichBolt {
     /** Returns the field name to use for the URL or null if the URL must not be indexed */
     protected String fieldNameForURL() {
         return fieldNameForURL;
+    }
+
+    protected boolean ignoreEmptyFields() {
+        return ignoreEmptyFields;
     }
 
     @Override

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -242,6 +242,7 @@ config:
 
   # configuration for the classes extending AbstractIndexerBolt
   # indexer.md.filter: "someKey=aValue"
+  indexer.ignore.empty.fields: false
   indexer.url.fieldname: "url"
   indexer.text.fieldname: "content"
   indexer.text.maxlength: -1

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/IndexerBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/IndexerBolt.java
@@ -204,7 +204,6 @@ public class IndexerBolt extends AbstractIndexerBolt
                     if (!ignoreEmptyFields() || StringUtils.isNotBlank(values[0])) {
                         builder.field(fieldName, values[0]);
                     }
-                    builder.field(fieldName, values[0]);
                 } else if (values.length > 1) {
                     builder.array(fieldName, values);
                 }

--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/IndexerBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/IndexerBolt.java
@@ -184,8 +184,10 @@ public class IndexerBolt extends AbstractIndexerBolt
 
             // display text of the document?
             if (StringUtils.isNotBlank(fieldNameForText())) {
-                String text = tuple.getStringByField("text");
-                builder.field(fieldNameForText(), trimText(text));
+                final String text = trimText(tuple.getStringByField("text"));
+                if (!ignoreEmptyFields() || StringUtils.isNotBlank(text)) {
+                    builder.field(fieldNameForText(), trimText(text));
+                }
             }
 
             // send URL as field?
@@ -199,6 +201,9 @@ public class IndexerBolt extends AbstractIndexerBolt
             for (String fieldName : keyVals.keySet()) {
                 String[] values = keyVals.get(fieldName);
                 if (values.length == 1) {
+                    if (!ignoreEmptyFields() || StringUtils.isNotBlank(values[0])) {
+                        builder.field(fieldName, values[0]);
+                    }
                     builder.field(fieldName, values[0]);
                 } else if (values.length > 1) {
                     builder.array(fieldName, values);

--- a/external/opensearch/src/main/java/com/digitalpebble/stormcrawler/opensearch/bolt/IndexerBolt.java
+++ b/external/opensearch/src/main/java/com/digitalpebble/stormcrawler/opensearch/bolt/IndexerBolt.java
@@ -200,8 +200,10 @@ public class IndexerBolt extends AbstractIndexerBolt
 
             // display text of the document?
             if (StringUtils.isNotBlank(fieldNameForText())) {
-                String text = tuple.getStringByField("text");
-                builder.field(fieldNameForText(), trimText(text));
+                final String text = trimText(tuple.getStringByField("text"));
+                if (!ignoreEmptyFields() || StringUtils.isNotBlank(text)) {
+                    builder.field(fieldNameForText(), trimText(text));
+                }
             }
 
             // send URL as field?
@@ -214,7 +216,10 @@ public class IndexerBolt extends AbstractIndexerBolt
 
             for (Entry<String, String[]> entry : keyVals.entrySet()) {
                 if (entry.getValue().length == 1) {
-                    builder.field(entry.getKey(), entry.getValue()[0]);
+                    final String value = entry.getValue()[0];
+                    if (!ignoreEmptyFields() || StringUtils.isNotBlank(value)) {
+                        builder.field(entry.getKey(), value);
+                    }
                 } else if (entry.getValue().length > 1) {
                     builder.array(entry.getKey(), entry.getValue());
                 }

--- a/external/solr/src/main/java/com/digitalpebble/stormcrawler/solr/bolt/IndexerBolt.java
+++ b/external/solr/src/main/java/com/digitalpebble/stormcrawler/solr/bolt/IndexerBolt.java
@@ -93,8 +93,10 @@ public class IndexerBolt extends AbstractIndexerBolt {
 
             // index text content
             if (StringUtils.isNotBlank(fieldNameForText())) {
-                String text = tuple.getStringByField("text");
-                doc.addField(fieldNameForText(), trimText(text));
+                final String text = trimText(tuple.getStringByField("text"));
+                if (!ignoreEmptyFields() || StringUtils.isNotBlank(text)) {
+                    doc.addField(fieldNameForText(), text);
+                }
             }
 
             // url
@@ -113,7 +115,9 @@ public class IndexerBolt extends AbstractIndexerBolt {
                 String fieldName = iterator.next();
                 String[] values = keyVals.get(fieldName);
                 for (String value : values) {
-                    doc.addField(fieldName, value);
+                    if (!ignoreEmptyFields() || StringUtils.isNotBlank(value)) {
+                        doc.addField(fieldName, value);
+                    }
                 }
             }
 


### PR DESCRIPTION
The indexers currently generate fields where the value can be empty. This PR introduces a new configuration

_indexer.ignore.empty.fields_ with a default value of _false_.

If set to true, the indexing classes will not generate a field if its value is empty or null.