### PR TITLE
Fix #1027: Ensure SC can be build with Java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,24 +3,29 @@
 
 name: Java CI with Maven
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java: [ 11, 17 ]
+        experimental: [false]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - uses: actions/cache@v2.1.7
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
-        distribution: 'adopt'
-        cache: maven
+        distribution: adopt
+        java-version: ${{ matrix.java }}
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B --no-transfer-progress package --file pom.xml

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
 		<jetbrains.annotations.version>23.1.0</jetbrains.annotations.version>
 		<log4j2.version>2.19.0</log4j2.version>
 		<testcontainer.version>1.17.6</testcontainer.version>
+		<git-code-format-maven-plugin.version>4.2</git-code-format-maven-plugin.version>
 	</properties>
 
 	<distributionManagement>
@@ -119,7 +120,7 @@
 			<plugin>
 				<groupId>com.cosium.code</groupId>
 				<artifactId>git-code-format-maven-plugin</artifactId>
-				<version>3.4</version>
+				<version>${git-code-format-maven-plugin.version}</version>
 				<executions>
 					<!-- On commit, format the modified java files -->
 					<execution>
@@ -137,13 +138,21 @@
 						</goals>
 					</execution>
 				</executions>
+				<dependencies>
+					<!-- Enable https://github.com/google/google-java-format -->
+					<dependency>
+						<groupId>com.cosium.code</groupId>
+						<artifactId>google-java-format</artifactId>
+						<version>${git-code-format-maven-plugin.version}</version>
+					</dependency>
+				</dependencies>
 				<configuration>
-					<googleJavaFormatOptions>
-						<aosp>true</aosp>
-						<fixImportsOnly>false</fixImportsOnly>
-						<skipSortingImports>false</skipSortingImports>
-						<skipRemovingUnusedImports>false</skipRemovingUnusedImports>
-					</googleJavaFormatOptions>
+					<formatterOptions>
+						<googleJavaFormat.aosp>true</googleJavaFormat.aosp>
+						<googleJavaFormat.fixImportsOnly>false</googleJavaFormat.fixImportsOnly>
+						<googleJavaFormat.skipSortingImports>false</googleJavaFormat.skipSortingImports>
+						<googleJavaFormat.skipRemovingUnusedImports>false</googleJavaFormat.skipRemovingUnusedImports>
+					</formatterOptions>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

- Enables Matrix Build for Java 11 + Java 17 via GitHub actions
- Updates Code Format to 4.2
- If building with Java 17 locally, it might be required to setup `.mvn/jvm.config`, see https://github.com/Cosium/git-code-format-maven-plugin#jdk-16-peculiarities
- Maven Blocker did not happen locally for me on this machine, so might not be an issue.