### PR TITLE
okhttp.httpprotocol : Replace User Agent if specified into Metadata

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -71,6 +71,10 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
     private final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
+    private static final String HEADER_USER_AGENT = "User-Agent";
+
+    protected static final String SET_USER_AGENT_BY_REQUEST = "set-user-agent";
+
     private OkHttpClient client;
 
     private int globalMaxContent;
@@ -176,7 +180,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
         final String userAgent = getAgentString(conf);
         if (StringUtils.isNotBlank(userAgent)) {
-            customRequestHeaders.add(new KeyValue("User-Agent", userAgent));
+            customRequestHeaders.add(new KeyValue(HEADER_USER_AGENT, userAgent));
         }
 
         final String accept = ConfUtils.getString(conf, "http.accept");
@@ -258,7 +262,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
         }
     }
 
-    private void addHeadersToRequest(Builder rb, Metadata md) {
+    protected void addHeadersToRequest(Builder rb, Metadata md) {
         final String[] headerStrings = md.getValues(SET_HEADER_BY_REQUEST, protocolMDprefix);
 
         if (headerStrings != null && headerStrings.length > 0) {
@@ -266,6 +270,13 @@ public class HttpProtocol extends AbstractHttpProtocol {
                 KeyValue h = KeyValue.build(hs);
                 rb.addHeader(h.getKey(), h.getValue());
             }
+        }
+
+        final String agentName = md.getFirstValue(SET_USER_AGENT_BY_REQUEST, protocolMDprefix);
+
+        if (agentName != null) {
+            rb.removeHeader(HEADER_USER_AGENT);
+            rb.addHeader(HEADER_USER_AGENT, agentName);
         }
     }
 


### PR DESCRIPTION
Hi !

We need to specify a User-Agent by request (set into a KafkaSpout). We tried to use `protocol.set-headers`, but the protocol don't replace the previous User Agent :

```json
"protocol%2E_request%2Eheaders_": 
[
"GET /index.html HTTP/2 User-Agent: defaultUA User-Agent: myUA"
]
```

So we create a new metadata `protocol.set-user-agent` in order to achieve it.

Signed-off-by: Mathieu Bret <mikwiss00@gmail.com>

Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'
* The code is properly formatted with 'mvn git-code-format:format-code -Dgcf.globPattern=**/*'

Thanks!

