### PR TITLE
Change HttpProtocol to defer to configured values for retryOnConnectionFailure and followRedirects

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -138,7 +138,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
         builder =
                 new OkHttpClient.Builder()
                         .retryOnConnectionFailure(true)
-                        .followRedirects(false)
+                        .followRedirects(ConfUtils.getBoolean(conf, "http.allow.redirects", false))
                         .connectTimeout(timeout, TimeUnit.MILLISECONDS)
                         .writeTimeout(timeout, TimeUnit.MILLISECONDS)
                         .readTimeout(timeout, TimeUnit.MILLISECONDS);

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -137,7 +137,9 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
         builder =
                 new OkHttpClient.Builder()
-                        .retryOnConnectionFailure(ConfUtils.getBoolean(conf, "http.retry.on.connection.failure", true))
+                        .retryOnConnectionFailure(
+                                ConfUtils.getBoolean(
+                                        conf, "http.retry.on.connection.failure", true))
                         .followRedirects(ConfUtils.getBoolean(conf, "http.allow.redirects", false))
                         .connectTimeout(timeout, TimeUnit.MILLISECONDS)
                         .writeTimeout(timeout, TimeUnit.MILLISECONDS)

--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -137,7 +137,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
         builder =
                 new OkHttpClient.Builder()
-                        .retryOnConnectionFailure(true)
+                        .retryOnConnectionFailure(ConfUtils.getBoolean(conf, "http.retry.on.connection.failure", true))
                         .followRedirects(ConfUtils.getBoolean(conf, "http.allow.redirects", false))
                         .connectTimeout(timeout, TimeUnit.MILLISECONDS)
                         .writeTimeout(timeout, TimeUnit.MILLISECONDS)

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -90,6 +90,12 @@ config:
   # http.proxy.user:
   # http.proxy.pass:
 
+  # Retry on connection failure:
+  http.retry.on.connection.failure: true
+
+  # Follow redirect HTTP responses:
+  http.allow.redirects: false
+
   http.robots.403.allow: true
   
   # ignore directives from robots.txt files?


### PR DESCRIPTION

In this version we defer to the configuration for the okhttp client settings on:
```
.retryOnConnectionFailure
.followRedirects
```

The rationale behind this is that a lot of sites are increasingly introducing DDos protection strategies and bot checks. For example,  [DDos Guard](https://ddos-guard.net/en/terminology/attack_type/http-challenge) is a popular one. One such check is the "HTTP Challenge" which issues a simple 302 response to the first request. If the requestor is a bot engaged in denial of service activities it is expected to just ignore it and end another request.
Simply by following redirects we can overcome this.

Disclaimer: I haven't squashed my commits because you can do that on merge these days, which is much easier. 