### PR TITLE
Cache redirected robots.txt for target host only if path is /robots.txt and query is empty

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpRobotRulesParser.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/protocol/HttpRobotRulesParser.java
@@ -133,10 +133,10 @@ public class HttpRobotRulesParser extends RobotRulesParser {
                     } else {
                         redir = new URL(redirection);
                     }
-                    if (redir.getPath().equals("/robots.txt")) {
-                        // only if the path of the redirect target is
-                        // `/robots.txt` we can get the rules from the cache
-                        // under the host key of the redirect target
+                    if (redir.getPath().equals("/robots.txt") && redir.getQuery() == null) {
+                        // only if the path (including the query part) of the redirect target is
+                        // `/robots.txt` we can get/put the rules from/to the cache under the host
+                        // key of the redirect target
                         keyredir = getCacheKey(redir);
                         RobotRules cachedRediRobotRules = CACHE.getIfPresent(keyredir);
                         if (cachedRediRobotRules != null) {


### PR DESCRIPTION
Get/put redirected robots.txt from/to cache of target host only if the URL path including the query part is `/robots.txt`. The current code does not take the URL query part into consideration. In some (likely rare) cases, this may cause that the wrong robots.txt, e.g. `/robots.txt?from=source.example.com` is cached.

Note: the host port (and protocol) are part of the cache key. If the redirect leads to a different port on the target host, the robots.txt received from a request on this port is cached separately.