### PR TITLE
BasicURLNormalizer .unmangleQueryString() returns invalid results if "&" symbol in a parents path #1059

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLNormalizer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLNormalizer.java
@@ -303,11 +303,14 @@ public class BasicURLNormalizer extends URLFilter {
      * @return corrected url
      */
     private String unmangleQueryString(String urlToFilter) {
-        int firstAmp = urlToFilter.indexOf('&');
+        String[] pathElements = urlToFilter.split("/");
+        int firstAmp = pathElements[pathElements.length - 1].indexOf('&');
         if (firstAmp > 0) {
-            int firstQuestionMark = urlToFilter.indexOf('?');
-            if (firstQuestionMark == -1) {
-                return urlToFilter.replaceFirst("&", "?");
+            int firstQuestionMark = pathElements[pathElements.length - 1].indexOf('?');
+            if (firstQuestionMark == -1 && pathElements[pathElements.length - 1].indexOf("=") > 0) {
+                pathElements[pathElements.length - 1] =
+                        pathElements[pathElements.length - 1].replaceFirst("&", "?");
+                return String.join("/", pathElements);
             }
         }
         return urlToFilter;

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLNormalizer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/basic/BasicURLNormalizer.java
@@ -304,14 +304,15 @@ public class BasicURLNormalizer extends URLFilter {
      */
     private String unmangleQueryString(String urlToFilter) {
         String[] pathElements = urlToFilter.split("/");
-        int firstAmp = pathElements[pathElements.length - 1].indexOf('&');
-        if (firstAmp > 0) {
-            int firstQuestionMark = pathElements[pathElements.length - 1].indexOf('?');
-            if (firstQuestionMark == -1 && pathElements[pathElements.length - 1].indexOf("=") > 0) {
-                pathElements[pathElements.length - 1] =
-                        pathElements[pathElements.length - 1].replaceFirst("&", "?");
-                return String.join("/", pathElements);
-            }
+        final String lastPathElement = pathElements[pathElements.length - 1];
+        int firstAmp = lastPathElement.indexOf('&');
+        if (firstAmp == -1) {
+            return urlToFilter;
+        }
+        int firstQuestionMark = lastPathElement.indexOf('?');
+        if (firstQuestionMark == -1 && lastPathElement.indexOf("=") > 0) {
+            pathElements[pathElements.length - 1] = lastPathElement.replaceFirst("&", "?");
+            return String.join("/", pathElements);
         }
         return urlToFilter;
     }

--- a/core/src/test/java/com/digitalpebble/stormcrawler/filtering/BasicURLNormalizerTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/filtering/BasicURLNormalizerTest.java
@@ -196,6 +196,22 @@ public class BasicURLNormalizerTest {
     }
 
     @Test
+    public void testFixMangledQueryString() throws MalformedURLException {
+        URLFilter urlFilter = createFilter(false, true, queryParamsToFilter);
+        URL testSourceUrl = new URL("http://google.com");
+        String testUrl = "http://google.com&d=4&good=true";
+        String expectedResult = "http://google.com?d=4&good=true";
+        String normalizedUrl = urlFilter.filter(testSourceUrl, new Metadata(), testUrl);
+        assertEquals("Failed to filter query string", expectedResult, normalizedUrl);
+
+        testSourceUrl = new URL("http://dev.com");
+        testUrl = "http://dev.com/s&utax/NEWSRLSEfy18.pdf";
+        normalizedUrl = urlFilter.filter(testSourceUrl, new Metadata(), testUrl);
+        expectedResult = "http://dev.com/s&utax/NEWSRLSEfy18.pdf";
+        assertEquals("Failed to filter query string", expectedResult, normalizedUrl);
+    }
+
+    @Test
     public void testProperURLEncodingWithoutQueryParameter() throws MalformedURLException {
         URLFilter urlFilter = createFilter(queryParamsToFilter);
         String urlWithEscapedCharacters =


### PR DESCRIPTION
BasicURLNormalizer .unmangleQueryString() returns invalid results if "&" symbol in a parents path #1059

Analyze only last item in a URL path. Test added. 

