### PR TITLE
mechanism to retrieve more generic value of configuration 

### DIFF
--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
@@ -30,6 +30,21 @@ public class ConfUtils {
 
     private ConfUtils() {}
 
+    /**
+     * Returns the value for prefix + optional + suffix, if nothing is found then return prefix +
+     * suffix and if that fails too, the default value
+     */
+    public static int getInt(
+            final Map<String, Object> conf,
+            final String prefix,
+            final String optional,
+            final String suffix,
+            int defaultValue) {
+        Object val = conf.get(prefix + optional + suffix);
+        if (val != null) return ((Number) val).intValue();
+        return getInt(conf, prefix + suffix, defaultValue);
+    }
+
     public static int getInt(Map<String, Object> conf, String key, int defaultValue) {
         Object ret = conf.get(key);
         if (ret == null) {
@@ -54,6 +69,23 @@ public class ConfUtils {
         return ((Number) ret).floatValue();
     }
 
+    /**
+     * Returns the value for prefix + optional + suffix, if nothing is found then return prefix +
+     * suffix and if that fails too, the default value
+     */
+    public static boolean getBoolean(
+            final Map<String, Object> conf,
+            final String prefix,
+            final String optional,
+            final String suffix,
+            boolean defaultValue) {
+        Object ret = conf.get(prefix + optional + suffix);
+        if (ret != null) {
+            return ((Boolean) ret).booleanValue();
+        }
+        return getBoolean(conf, prefix + suffix, defaultValue);
+    }
+
     public static boolean getBoolean(Map<String, Object> conf, String key, boolean defaultValue) {
         Object ret = conf.get(key);
         if (ret == null) {
@@ -62,8 +94,39 @@ public class ConfUtils {
         return ((Boolean) ret).booleanValue();
     }
 
+    /**
+     * Returns the value for prefix + optional + suffix, if nothing is found then return prefix +
+     * suffix or null.
+     */
+    public static String getString(
+            final Map<String, Object> stormConf,
+            final String prefix,
+            final String optional,
+            final String suffix) {
+        String val = getString(stormConf, prefix + optional + suffix);
+        if (val != null) return val;
+        return getString(stormConf, prefix + suffix);
+    }
+
     public static String getString(Map<String, Object> conf, String key) {
         return (String) conf.get(key);
+    }
+
+    /**
+     * Returns the value for prefix + optional + suffix, if nothing is found then return prefix +
+     * suffix and if that fails too, the default value
+     */
+    public static String getString(
+            final Map<String, Object> stormConf,
+            final String prefix,
+            final String optional,
+            final String suffix,
+            String defaultValue) {
+        String val = getString(stormConf, prefix + optional + suffix);
+        if (val != null) return val;
+        val = getString(stormConf, prefix + suffix);
+        if (val != null) return val;
+        return defaultValue;
     }
 
     public static String getString(Map<String, Object> conf, String key, String defaultValue) {
@@ -90,6 +153,24 @@ public class ConfUtils {
             list.add(obj.toString());
         }
         return list;
+    }
+
+    /**
+     * Return one or more Strings regardless of whether they are represented as a single String or a
+     * list in the config for the combination all 2 String parameters. If nothing is found, try
+     * using the prefix and suffix only to see if a more generic param was set e.g. "opensearch." +
+     * "status." + "addresses" then "opensearch."+"addresses"
+     *
+     * @param prefix
+     * @param optional string to be tried first
+     * @param suffix
+     * @return List of String values
+     */
+    public static List<String> loadListFromConf(
+            final String prefix, final String optional, final String suffix, Map stormConf) {
+        List<String> list = loadListFromConf(prefix + optional + suffix, stormConf);
+        if (!list.isEmpty()) return list;
+        return loadListFromConf(prefix + suffix, stormConf);
     }
 
     public static Config loadConf(String resource, Config conf) throws FileNotFoundException {

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/ConfUtils.java
@@ -161,9 +161,9 @@ public class ConfUtils {
      * using the prefix and suffix only to see if a more generic param was set e.g. "opensearch." +
      * "status." + "addresses" then "opensearch."+"addresses"
      *
-     * @param prefix
+     * @param prefix non-optional part of the key
      * @param optional string to be tried first
-     * @param suffix
+     * @param suffix non-optional part of the key
      * @return List of String values
      */
     public static List<String> loadListFromConf(

--- a/core/src/test/java/com/digitalpebble/stormcrawler/util/ConfUtilsTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/util/ConfUtilsTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to DigitalPebble Ltd under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.
+ * DigitalPebble licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.digitalpebble.stormcrawler.util;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Map;
+import org.junit.Test;
+
+public class ConfUtilsTest {
+
+    @Test
+    public void testIntWithOptional() throws MalformedURLException, IOException {
+        Map<String, Object> conf = new java.util.HashMap<>();
+        conf.put("prefix.suffix", 1);
+        conf.put("prefix.optional.suffix", 2);
+        int res = ConfUtils.getInt(conf, "prefix.", "optional.", "suffix", -1);
+        org.junit.Assert.assertEquals(2, res);
+        res = ConfUtils.getInt(conf, "prefix.", "missing.", "suffix", -1);
+        org.junit.Assert.assertEquals(1, res);
+        res = ConfUtils.getInt(conf, "totally.", "missing.", "inAction", -1);
+        org.junit.Assert.assertEquals(-1, res);
+    }
+
+    @Test
+    public void testBooleanWithOptional() throws MalformedURLException, IOException {
+        Map<String, Object> conf = new java.util.HashMap<>();
+        conf.put("prefix.suffix", true);
+        conf.put("prefix.optional.suffix", false);
+        boolean res = ConfUtils.getBoolean(conf, "prefix.", "optional.", "suffix", true);
+        org.junit.Assert.assertEquals(false, res);
+        res = ConfUtils.getBoolean(conf, "prefix.", "missing.", "suffix", false);
+        org.junit.Assert.assertEquals(true, res);
+        res = ConfUtils.getBoolean(conf, "totally.", "missing.", "inAction", false);
+        org.junit.Assert.assertEquals(false, res);
+    }
+
+    @Test
+    public void testStringWithOptional() throws MalformedURLException, IOException {
+        Map<String, Object> conf = new java.util.HashMap<>();
+        conf.put("prefix.suffix", "backup");
+        conf.put("prefix.optional.suffix", "specific");
+        String res = ConfUtils.getString(conf, "prefix.", "optional.", "suffix");
+        org.junit.Assert.assertEquals("specific", res);
+        res = ConfUtils.getString(conf, "prefix.", "missing.", "suffix");
+        org.junit.Assert.assertEquals("backup", res);
+        res = ConfUtils.getString(conf, "totally.", "missing.", "inAction", null);
+        org.junit.Assert.assertEquals(null, res);
+        res = ConfUtils.getString(conf, "totally.", "missing.", "inAction");
+        org.junit.Assert.assertEquals(null, res);
+    }
+}

--- a/external/opensearch/archetype/src/main/resources/archetype-resources/opensearch-conf.yaml
+++ b/external/opensearch/archetype/src/main/resources/archetype-resources/opensearch-conf.yaml
@@ -1,6 +1,14 @@
 # configuration for OpenSearch resources
   
 config:
+
+  # address to use unless a more specific one has been 
+  # defined for a component
+  opensearch.addresses: "http://localhost:9200"
+  #opensearch.user: "USERNAME"
+  #opensearch.password: "PASSWORD"
+  opensearch.concurrentRequests: 2
+
   # Indexer bolt
   # adresses can be specified as a full URL
   # if not we assume that the protocol is http and the port 9200
@@ -13,7 +21,7 @@ config:
   opensearch.indexer.concurrentRequests: 1
   
   # MetricsConsumer
-  opensearch.metrics.addresses: "http://localhost:9200"
+  # opensearch.metrics.addresses: "http://localhost:9200"
   opensearch.metrics.index.name: "metrics"
   
   # Spout and persistence bolt

--- a/external/opensearch/opensearch-conf.yaml
+++ b/external/opensearch/opensearch-conf.yaml
@@ -1,6 +1,14 @@
 # configuration for OpenSearch resources
   
 config:
+
+  # address to use unless a more specific one has been 
+  # defined for a component
+  opensearch.addresses: "http://localhost:9200"
+  #opensearch.user: "USERNAME"
+  #opensearch.password: "PASSWORD"
+  opensearch.concurrentRequests: 2
+
   # Indexer bolt
   # adresses can be specified as a full URL
   # if not we assume that the protocol is http and the port 9200
@@ -13,7 +21,7 @@ config:
   opensearch.indexer.concurrentRequests: 1
   
   # MetricsConsumer
-  opensearch.metrics.addresses: "http://localhost:9200"
+  # opensearch.metrics.addresses: "http://localhost:9200"
   opensearch.metrics.index.name: "metrics"
   
   # Spout and persistence bolt

--- a/external/opensearch/src/main/java/com/digitalpebble/stormcrawler/opensearch/OpenSearchConnection.java
+++ b/external/opensearch/src/main/java/com/digitalpebble/stormcrawler/opensearch/OpenSearchConnection.java
@@ -70,11 +70,13 @@ public final class OpenSearchConnection {
 
     public static RestHighLevelClient getClient(Map<String, Object> stormConf, String boltType) {
 
-        List<String> confighosts =
-                ConfUtils.loadListFromConf(
-                        Constants.PARAMPREFIX + boltType + ".addresses", stormConf);
+        final String dottedType = boltType + ".";
 
-        List<HttpHost> hosts = new ArrayList<>();
+        final List<HttpHost> hosts = new ArrayList<>();
+
+        final List<String> confighosts =
+                ConfUtils.loadListFromConf(
+                        Constants.PARAMPREFIX, dottedType, "addresses", stormConf);
 
         for (String host : confighosts) {
             // no port specified? use default one
@@ -97,25 +99,26 @@ public final class OpenSearchConnection {
             hosts.add(new HttpHost(uri.getHost(), port, scheme));
         }
 
-        RestClientBuilder builder = RestClient.builder(hosts.toArray(new HttpHost[0]));
+        final RestClientBuilder builder = RestClient.builder(hosts.toArray(new HttpHost[0]));
 
         // authentication via user / password
-        String user = ConfUtils.getString(stormConf, Constants.PARAMPREFIX + boltType + ".user");
-        String password =
-                ConfUtils.getString(stormConf, Constants.PARAMPREFIX + boltType + ".password");
+        final String user =
+                ConfUtils.getString(stormConf, Constants.PARAMPREFIX, dottedType, "user");
+        final String password =
+                ConfUtils.getString(stormConf, Constants.PARAMPREFIX, dottedType, "password");
 
-        String proxyhost =
-                ConfUtils.getString(stormConf, Constants.PARAMPREFIX + boltType + ".proxy.host");
+        final String proxyhost =
+                ConfUtils.getString(stormConf, Constants.PARAMPREFIX, dottedType, "proxy.host");
 
-        int proxyport =
-                ConfUtils.getInt(stormConf, Constants.PARAMPREFIX + boltType + ".proxy.port", -1);
+        final int proxyport =
+                ConfUtils.getInt(stormConf, Constants.PARAMPREFIX, dottedType, "proxy.port", -1);
 
-        String proxyscheme =
+        final String proxyscheme =
                 ConfUtils.getString(
-                        stormConf, Constants.PARAMPREFIX + boltType + ".proxy.scheme", "http");
+                        stormConf, Constants.PARAMPREFIX, dottedType, "proxy.scheme", "http");
 
-        boolean needsUser = StringUtils.isNotBlank(user) && StringUtils.isNotBlank(password);
-        boolean needsProxy = StringUtils.isNotBlank(proxyhost) && proxyport != -1;
+        final boolean needsUser = StringUtils.isNotBlank(user) && StringUtils.isNotBlank(password);
+        final boolean needsProxy = StringUtils.isNotBlank(proxyhost) && proxyport != -1;
 
         if (needsUser || needsProxy) {
             builder.setHttpClientConfigCallback(
@@ -135,15 +138,19 @@ public final class OpenSearchConnection {
                     });
         }
 
-        int connectTimeout =
+        final int connectTimeout =
                 ConfUtils.getInt(
                         stormConf,
-                        Constants.PARAMPREFIX + boltType + ".connect.timeout",
+                        Constants.PARAMPREFIX,
+                        dottedType,
+                        "connect.timeout",
                         DEFAULT_CONNECT_TIMEOUT_MILLIS);
-        int socketTimeout =
+        final int socketTimeout =
                 ConfUtils.getInt(
                         stormConf,
-                        Constants.PARAMPREFIX + boltType + ".socket.timeout",
+                        Constants.PARAMPREFIX,
+                        dottedType,
+                        "socket.timeout",
                         DEFAULT_SOCKET_TIMEOUT_MILLIS);
         // timeout until connection is established
         builder.setRequestConfigCallback(
@@ -183,7 +190,7 @@ public final class OpenSearchConnection {
 
         final boolean compression =
                 ConfUtils.getBoolean(
-                        stormConf, Constants.PARAMPREFIX + boltType + ".compression", false);
+                        stormConf, Constants.PARAMPREFIX, dottedType, "compression", false);
 
         builder.setCompressionEnabled(compression);
 
@@ -215,20 +222,22 @@ public final class OpenSearchConnection {
 
         final RestHighLevelClient client = getClient(stormConf, boltType);
 
+        final String dottedType = boltType + ".";
+
         final String flushIntervalString =
                 ConfUtils.getString(
-                        stormConf, Constants.PARAMPREFIX + boltType + ".flushInterval", "5s");
+                        stormConf, Constants.PARAMPREFIX, dottedType, "flushInterval", "5s");
 
         final TimeValue flushInterval =
                 TimeValue.parseTimeValue(
                         flushIntervalString, TimeValue.timeValueSeconds(5), "flushInterval");
 
         final int bulkActions =
-                ConfUtils.getInt(stormConf, Constants.PARAMPREFIX + boltType + ".bulkActions", 50);
+                ConfUtils.getInt(stormConf, Constants.PARAMPREFIX, dottedType, "bulkActions", 50);
 
         final int concurrentRequests =
                 ConfUtils.getInt(
-                        stormConf, Constants.PARAMPREFIX + boltType + ".concurrentRequests", 1);
+                        stormConf, Constants.PARAMPREFIX, dottedType, "concurrentRequests", 1);
 
         final BulkProcessor bulkProcessor =
                 BulkProcessor.builder(
@@ -254,7 +263,7 @@ public final class OpenSearchConnection {
         }
 
         // Maybe some kind of identifier?
-        LOG.debug("Start closing the opensearchConnection");
+        LOG.debug("Start closing the OpenSearch connection");
 
         // First, close the BulkProcessor ensuring pending actions are flushed
         try {


### PR DESCRIPTION
if a specific one is not found, fixes #1070

Used for OpenSearch only, the same could be used for Elasticsearch