### PR TITLE
Test URL Filtering from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Each commit must include a DCO which looks like this
 Signed-off-by: Jane Smith <jane.smith@email.com>
 ```
 
-You may type this line on your own when writing your commit messages. However, if your user.name and user.email are set in your git configs, you can use `-s` or `– – signoff` to add the `Signed-off-by` line to the end of the commit message.
+You may type this line on your own when writing your commit messages. However, if your `user.name` and `user.email` are set in your git config, you can use `-s` or `--signoff` to add the `Signed-off-by` line to the end of the commit message.
 
 
 ## Thanks

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ The [WIKI](https://github.com/DigitalPebble/storm-crawler/wiki) is a good place 
 
 [DigitalPebble Ltd](http://digitalpebble.com) provide commercial support and consulting for StormCrawler.
 
+## Note for developers 
+
+Please format your code before submitting a PR with 
+
+```
+mvn git-code-format:format-code -Dgcf.globPattern=**/*
+```
+
+Each commit must include a DCO which looks like this
+
+```
+Signed-off-by: Jane Smith <jane.smith@email.com>
+```
+
+You may type this line on your own when writing your commit messages. However, if your user.name and user.email are set in your git configs, you can use `-s` or `– – signoff` to add the `Signed-off-by` line to the end of the commit message.
+
+
 ## Thanks
 
 ![alt tag](https://www.yourkit.com/images/yklogo.png)

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/URLFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/URLFilters.java
@@ -56,7 +56,7 @@ public class URLFilters extends URLFilter implements JSONResource {
         filters = new URLFilters[0];
     }
 
-    private String configFile = "urlfilters.config.file";
+    private String configFile = "urlfilters.json";
 
     private Map<String, Object> stormConf;
 
@@ -136,7 +136,9 @@ public class URLFilters extends URLFilter implements JSONResource {
         filters = list.toArray(new URLFilter[0]);
     }
 
+    /** Utility to check the filtering of a URL * */
     public static void main(String[] args) throws ParseException {
+
         Config conf = new Config();
 
         // loads the default configuration file
@@ -144,10 +146,12 @@ public class URLFilters extends URLFilter implements JSONResource {
                 Utils.findAndReadConfigFile("crawler-default.yaml", false);
         conf.putAll(ConfUtils.extractConfigElement(defaultSCConfig));
 
-        String configFile = "urlfilters.config.file";
+        String configFile = "urlfilters.json";
 
-        Options options = new Options();
-        options.addOption("f", true, "filters configuration file. Default " + configFile);
+        Options options =
+                new Options()
+                        .addOption("f", true, "Filters configuration file. Default " + configFile)
+                        .addOption("s", true, "Source URL");
 
         CommandLineParser parser = new DefaultParser();
         CommandLine cmd = parser.parse(options, args);
@@ -164,14 +168,20 @@ public class URLFilters extends URLFilter implements JSONResource {
         // read URL to check
         String inputURL = cmd.getArgList().get(0);
 
+        String sourceURL = inputURL;
+
+        if (cmd.hasOption("s")) {
+            sourceURL = cmd.getOptionValue("s");
+        }
+
         try {
             URLFilters filters = new URLFilters(conf, configFile);
             String normalizedURL = inputURL;
-            URL sourceURL = new URL(normalizedURL);
             try {
                 for (URLFilter filter : filters.filters) {
                     long start = System.currentTimeMillis();
-                    normalizedURL = filter.filter(sourceURL, new Metadata(), normalizedURL);
+                    normalizedURL =
+                            filter.filter(new URL(sourceURL), new Metadata(), normalizedURL);
                     long end = System.currentTimeMillis();
                     System.out.println(
                             "\t["

--- a/core/src/main/java/com/digitalpebble/stormcrawler/filtering/URLFilters.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/filtering/URLFilters.java
@@ -150,8 +150,7 @@ public class URLFilters extends URLFilter implements JSONResource {
 
         Options options =
                 new Options()
-                        .addOption("f", true, "Filters configuration file. Default " + configFile)
-                        .addOption("s", true, "Source URL");
+                        .addOption("f", true, "Filters configuration file. Default " + configFile);
 
         CommandLineParser parser = new DefaultParser();
         CommandLine cmd = parser.parse(options, args);
@@ -168,10 +167,10 @@ public class URLFilters extends URLFilter implements JSONResource {
         // read URL to check
         String inputURL = cmd.getArgList().get(0);
 
+        // if a URL has been specified in 2nd position
         String sourceURL = inputURL;
-
-        if (cmd.hasOption("s")) {
-            sourceURL = cmd.getOptionValue("s");
+        if (cmd.getArgList().size() > 1) {
+            sourceURL = cmd.getArgList().get(1);
         }
 
         try {


### PR DESCRIPTION
Implements #1079

For instance

`storm local target/xxx.jar  com.digitalpebble.stormcrawler.filtering.URLFilters https://pubmed.ncbi.nlm.nih.gov/18926286/?format=pubmed | grep -v main`

to test the filtering pipeline present in the jar.