### PR TITLE
Issue #728: Adding asterisk for metadata transfer

### DIFF
--- a/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -20,14 +20,16 @@ config:
     - com.digitalpebble.stormcrawler.Metadata
     - com.digitalpebble.stormcrawler.persistence.Status
 
-  # metadata to transfer to the outlinks
-  # used by Fetcher for redirections, sitemapparser, etc...
-  # these are also persisted for the parent document (see below)
+  # Lists the metadata to transfer to outlinks
+  # Used by Fetcher and SiteMapParser for redirections,
+  # discovered links, passing cookies to child pages, etc.
+  # These are also persisted for the parent document (see below).
+  # Allows wildcards, eg. "follow.*" transfers all metadata starting with "follow.".
   # metadata.transfer:
   # - customMetadataName
 
-  # lists the metadata to persist to storage
-  # these are not transferred to the outlinks
+  # Lists the metadata to persist to storage
+  # These are not transferred to the outlinks. Also allows wildcards, eg. "follow.*".
   metadata.persist:
    - _redirTo
    - error.cause

--- a/core/src/main/java/com/digitalpebble/stormcrawler/Metadata.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/Metadata.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 
 /** Wrapper around Map &lt;String,String[]&gt; * */
@@ -208,6 +209,13 @@ public class Metadata {
         return md.keySet();
     }
 
+    /** Returns the keySet for all keys starting with a given prefix */
+    public Set<String> keySet(String prefix) {
+        return md.keySet().stream()
+                .filter(key -> key.startsWith(prefix))
+                .collect(Collectors.toSet());
+    }
+
     /** Returns the first non empty value found for the keys or null if none found. */
     public static String getFirstValue(Metadata md, String... keys) {
         for (String key : keys) {
@@ -216,6 +224,16 @@ public class Metadata {
             return val;
         }
         return null;
+    }
+
+    /**
+     * Copies the values arrays for a given key to another metadata object
+     *
+     * @param targetMetadata the metadata to copy to
+     * @param key the key to copy
+     */
+    public void copy(Metadata targetMetadata, String key) {
+        targetMetadata.setValues(key, getValues(key));
     }
 
     /** Returns the underlying Map * */

--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/FetcherBolt.java
@@ -619,8 +619,7 @@ public class FetcherBolt extends StatusEmitterBolt {
 
                     // get any metrics from the protocol metadata
                     // expect Longs
-                    response.getMetadata().keySet().stream()
-                            .filter(s -> s.startsWith("metrics."))
+                    response.getMetadata().keySet("metrics.").stream()
                             .forEach(
                                     s ->
                                             averagedMetrics

--- a/core/src/main/java/com/digitalpebble/stormcrawler/bolt/SimpleFetcherBolt.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/bolt/SimpleFetcherBolt.java
@@ -425,8 +425,7 @@ public class SimpleFetcherBolt extends StatusEmitterBolt {
             final int byteLength = response.getContent().length;
 
             // get any metrics from the protocol metadata
-            response.getMetadata().keySet().stream()
-                    .filter(s -> s.startsWith("metrics."))
+            response.getMetadata().keySet("metrics.").stream()
                     .forEach(
                             s ->
                                     averagedMetrics

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/MetadataTransfer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/MetadataTransfer.java
@@ -65,13 +65,13 @@ public class MetadataTransfer {
     /** Metadata key name for tracking a non-default max depth */
     public static final String maxDepthKeyName = "max.depth";
 
-    private final Set<String> mdToTransfer = new HashSet<>();
+    protected final Set<String> mdToTransfer = new HashSet<>();
 
-    private final Set<String> mdToPersistOnly = new HashSet<>();
+    protected final Set<String> mdToPersistOnly = new HashSet<>();
 
-    private boolean trackPath = true;
+    protected boolean trackPath = true;
 
-    private boolean trackDepth = true;
+    protected boolean trackDepth = true;
 
     public static MetadataTransfer getInstance(Map<String, Object> conf) {
         String className = ConfUtils.getString(conf, metadataTransferClassParamName);
@@ -156,12 +156,34 @@ public class MetadataTransfer {
         return filtered_md;
     }
 
+    /**
+     * Filter the metadata based on a set of keys. If a key ends with a * then all the keys starting
+     * with the prefix will be added.
+     */
     private Metadata _filter(Metadata metadata, Set<String> filter) {
         Metadata filtered_md = new Metadata();
+
+        Set<String> filterKeys = new HashSet<>();
         for (String key : filter) {
-            String[] vals = metadata.getValues(key);
-            if (vals != null) filtered_md.setValues(key, vals);
+            if (key.endsWith("*")) {
+                String prefix = key.substring(0, key.length() - 1);
+                for (String mdKey : metadata.keySet()) {
+                    if (mdKey.startsWith(prefix)) {
+                        filterKeys.add(mdKey);
+                    }
+                }
+            } else {
+                filterKeys.add(key);
+            }
+
+            for (String filterKey : filterKeys) {
+                String[] values = metadata.getValues(filterKey);
+                if (values != null) {
+                    filtered_md.setValues(filterKey, values);
+                }
+            }
         }
+
         return filtered_md;
     }
 }

--- a/core/src/main/java/com/digitalpebble/stormcrawler/util/MetadataTransfer.java
+++ b/core/src/main/java/com/digitalpebble/stormcrawler/util/MetadataTransfer.java
@@ -163,24 +163,14 @@ public class MetadataTransfer {
     private Metadata _filter(Metadata metadata, Set<String> filter) {
         Metadata filtered_md = new Metadata();
 
-        Set<String> filterKeys = new HashSet<>();
         for (String key : filter) {
             if (key.endsWith("*")) {
                 String prefix = key.substring(0, key.length() - 1);
-                for (String mdKey : metadata.keySet()) {
-                    if (mdKey.startsWith(prefix)) {
-                        filterKeys.add(mdKey);
-                    }
+                for (String k : metadata.keySet(prefix)) {
+                    metadata.copy(filtered_md, k);
                 }
             } else {
-                filterKeys.add(key);
-            }
-
-            for (String filterKey : filterKeys) {
-                String[] values = metadata.getValues(filterKey);
-                if (values != null) {
-                    filtered_md.setValues(filterKey, values);
-                }
+                metadata.copy(filtered_md, key);
             }
         }
 

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -46,15 +46,16 @@ config:
   
   urlbuffer.class: "com.digitalpebble.stormcrawler.persistence.urlbuffer.SimpleURLBuffer"
 
-  # metadata to transfer to the outlinks
-  # used by Fetcher for redirections, sitemapparser,
-  # passing cookies to child pages, etc.
-  # These are also persisted for the parent document (see below)
+  # Lists the metadata to transfer to outlinks
+  # Used by Fetcher and SiteMapParser for redirections,
+  # discovered links, passing cookies to child pages, etc.
+  # These are also persisted for the parent document (see below).
+  # Allows wildcards, eg. "follow.*" transfers all metadata starting with "follow.".
   # metadata.transfer:
   # - customMetadataName
 
-  # lists the metadata to persist to storage
-  # these are not transferred to the outlinks
+  # Lists the metadata to persist to storage
+  # These are not transferred to the outlinks. Also allows wildcards, eg. "follow.*".
   metadata.persist:
    - _redirTo
    - error.cause

--- a/core/src/test/java/com/digitalpebble/stormcrawler/MetadataTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/MetadataTest.java
@@ -1,0 +1,25 @@
+package com.digitalpebble.stormcrawler;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetadataTest {
+
+    @Test
+    public void testCopyWithPrefix() {
+        Metadata metadata = new Metadata();
+        metadata.addValue("fetch.statusCode", "500");
+        metadata.addValue("fetch.error.count", "2");
+        metadata.addValue("fetch.exception", "java.lang.Exception");
+        metadata.addValue("fetchInterval", "200");
+        metadata.addValue("isFeed", "true");
+        metadata.addValue("depth", "1");
+
+        Metadata copy = new Metadata();
+        for (String key : metadata.keySet("fetch.")) {
+            metadata.copy(copy, key);
+        }
+
+        Assert.assertEquals(3, copy.size());
+    }
+}

--- a/core/src/test/java/com/digitalpebble/stormcrawler/bolt/SiteMapParserBoltTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/bolt/SiteMapParserBoltTest.java
@@ -239,10 +239,7 @@ public class SiteMapParserBoltTest extends ParsingTester {
     }
 
     private void assertNewsAttributes(Metadata metadata) {
-        long numAttributes =
-                metadata.keySet().stream()
-                        .filter(key -> key.startsWith(Extension.NEWS.name() + "."))
-                        .count();
+        long numAttributes = metadata.keySet(Extension.NEWS.name() + ".").size();
         Assert.assertEquals(7, numAttributes);
         Assert.assertEquals(
                 "The Example Times", metadata.getFirstValue(Extension.NEWS.name() + "." + "name"));
@@ -265,10 +262,7 @@ public class SiteMapParserBoltTest extends ParsingTester {
     }
 
     private void assertImageAttributes(Metadata metadata) {
-        long numAttributes =
-                metadata.keySet().stream()
-                        .filter(key -> key.startsWith(Extension.IMAGE.name() + "."))
-                        .count();
+        long numAttributes = metadata.keySet(Extension.IMAGE.name() + ".").size();
         Assert.assertEquals(5, numAttributes);
         Assert.assertEquals(
                 "This is the caption.",
@@ -288,10 +282,7 @@ public class SiteMapParserBoltTest extends ParsingTester {
     }
 
     private void assertLinksAttributes(Metadata metadata) {
-        long numAttributes =
-                metadata.keySet().stream()
-                        .filter(key -> key.startsWith(Extension.LINKS.name() + "."))
-                        .count();
+        long numAttributes = metadata.keySet(Extension.LINKS.name() + ".").size();
         Assert.assertEquals(3, numAttributes);
         Assert.assertEquals(
                 "alternate", metadata.getFirstValue(Extension.LINKS.name() + "." + "params.rel"));
@@ -303,10 +294,7 @@ public class SiteMapParserBoltTest extends ParsingTester {
     }
 
     private void assertVideoAttributes(Metadata metadata) {
-        long numAttributes =
-                metadata.keySet().stream()
-                        .filter(key -> key.startsWith(Extension.VIDEO.name() + "."))
-                        .count();
+        long numAttributes = metadata.keySet(Extension.VIDEO.name() + ".").size();
         Assert.assertEquals(20, numAttributes);
         Assert.assertEquals(
                 "http://www.example.com/thumbs/123.jpg",
@@ -362,10 +350,7 @@ public class SiteMapParserBoltTest extends ParsingTester {
     }
 
     private void assertMobileAttributes(Metadata metadata) {
-        long numAttributes =
-                metadata.keySet().stream()
-                        .filter(key -> key.startsWith(Extension.MOBILE.name() + "."))
-                        .count();
+        long numAttributes = metadata.keySet(Extension.MOBILE.name() + ".").size();
         Assert.assertEquals(0, numAttributes);
     }
 }

--- a/core/src/test/java/com/digitalpebble/stormcrawler/util/MetadataTransferTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/util/MetadataTransferTest.java
@@ -17,6 +17,7 @@ package com.digitalpebble.stormcrawler.util;
 import com.digitalpebble.stormcrawler.Metadata;
 import java.net.MalformedURLException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
@@ -60,6 +61,45 @@ public class MetadataTransferTest {
             hasThrownException = true;
         }
         Assert.assertEquals(false, hasThrownException);
+    }
+
+    @Test
+    public void testFilter() {
+        Metadata metadata = new Metadata();
+        metadata.addValue("fetch.statusCode", "500");
+        metadata.addValue("fetch.error.count", "2");
+        metadata.addValue("fetch.exception", "java.lang.Exception");
+        metadata.addValue("fetchInterval", "200");
+        metadata.addValue("isFeed", "true");
+        metadata.addValue("depth", "1");
+
+        // test for empty metadata.transfer list
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(MetadataTransfer.metadataTransferParamName, List.of());
+        MetadataTransfer mdt = MetadataTransfer.getInstance(conf);
+        Metadata filteredMetadata = mdt.filter(metadata);
+        Assert.assertEquals(2, filteredMetadata.size());
+
+        // test for metadata.transfer list with asterisk entry
+        conf = new HashMap<>();
+        conf.put(MetadataTransfer.metadataTransferParamName, List.of("fetch*"));
+        mdt = MetadataTransfer.getInstance(conf);
+        filteredMetadata = mdt.filter(metadata);
+        Assert.assertEquals(5, filteredMetadata.size());
+
+        // test for metadata.transfer list with asterisk entry after a dot
+        conf = new HashMap<>();
+        conf.put(MetadataTransfer.metadataTransferParamName, List.of("fetch.*"));
+        mdt = MetadataTransfer.getInstance(conf);
+        filteredMetadata = mdt.filter(metadata);
+        Assert.assertEquals(4, filteredMetadata.size());
+
+        // test for transfer all metadata
+        conf = new HashMap<>();
+        conf.put(MetadataTransfer.metadataTransferParamName, List.of("*"));
+        mdt = MetadataTransfer.getInstance(conf);
+        filteredMetadata = mdt.filter(metadata);
+        Assert.assertEquals(6, filteredMetadata.size());
     }
 }
 

--- a/core/src/test/java/com/digitalpebble/stormcrawler/util/MetadataTransferTest.java
+++ b/core/src/test/java/com/digitalpebble/stormcrawler/util/MetadataTransferTest.java
@@ -19,6 +19,7 @@ import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -27,13 +28,27 @@ public class MetadataTransferTest {
     public void testTransfer() throws MalformedURLException {
         Map<String, Object> conf = new HashMap<>();
         conf.put(MetadataTransfer.trackDepthParamName, true);
+        conf.put(MetadataTransfer.metadataTransferParamName, List.of("cookie.*"));
         MetadataTransfer mdt = MetadataTransfer.getInstance(conf);
+
         Metadata parentMD = new Metadata();
+        parentMD.addValue("cookie.id", "42");
+        parentMD.addValue("cookie.source", "example.com");
+        parentMD.addValue("fetchInterval", "200");
+
         Metadata outlinkMD =
                 mdt.getMetaForOutlink(
                         "http://www.example.com/outlink.html", "http://www.example.com", parentMD);
-        // test the value of track seed and depth
+
+        // test the value of track seed, depth and fetch fields
         Assert.assertEquals("1", outlinkMD.getFirstValue(MetadataTransfer.depthKeyName));
+        Set<String> expectedFields =
+                Set.of(
+                        MetadataTransfer.urlPathKeyName,
+                        MetadataTransfer.depthKeyName,
+                        "cookie.id",
+                        "cookie.source");
+        Assert.assertEquals(expectedFields, outlinkMD.keySet());
         String[] urlpath = outlinkMD.getValues(MetadataTransfer.urlPathKeyName);
         Assert.assertEquals(1, urlpath.length);
     }
@@ -64,7 +79,7 @@ public class MetadataTransferTest {
     }
 
     @Test
-    public void testFilter() {
+    public void testFilterWithAsterisk() {
         Metadata metadata = new Metadata();
         metadata.addValue("fetch.statusCode", "500");
         metadata.addValue("fetch.error.count", "2");
@@ -73,30 +88,30 @@ public class MetadataTransferTest {
         metadata.addValue("isFeed", "true");
         metadata.addValue("depth", "1");
 
-        // test for empty metadata.transfer list
+        // test for empty metadata.persist list
         Map<String, Object> conf = new HashMap<>();
-        conf.put(MetadataTransfer.metadataTransferParamName, List.of());
+        conf.put(MetadataTransfer.metadataPersistParamName, List.of());
         MetadataTransfer mdt = MetadataTransfer.getInstance(conf);
         Metadata filteredMetadata = mdt.filter(metadata);
         Assert.assertEquals(2, filteredMetadata.size());
 
-        // test for metadata.transfer list with asterisk entry
+        // test for metadata.persist list with asterisk entry
         conf = new HashMap<>();
-        conf.put(MetadataTransfer.metadataTransferParamName, List.of("fetch*"));
+        conf.put(MetadataTransfer.metadataPersistParamName, List.of("fetch*"));
         mdt = MetadataTransfer.getInstance(conf);
         filteredMetadata = mdt.filter(metadata);
         Assert.assertEquals(5, filteredMetadata.size());
 
-        // test for metadata.transfer list with asterisk entry after a dot
+        // test for metadata.persist list with asterisk entry after a dot
         conf = new HashMap<>();
-        conf.put(MetadataTransfer.metadataTransferParamName, List.of("fetch.*"));
+        conf.put(MetadataTransfer.metadataPersistParamName, List.of("fetch.*"));
         mdt = MetadataTransfer.getInstance(conf);
         filteredMetadata = mdt.filter(metadata);
         Assert.assertEquals(4, filteredMetadata.size());
 
-        // test for transfer all metadata
+        // test for persist all metadata
         conf = new HashMap<>();
-        conf.put(MetadataTransfer.metadataTransferParamName, List.of("*"));
+        conf.put(MetadataTransfer.metadataPersistParamName, List.of("*"));
         mdt = MetadataTransfer.getInstance(conf);
         filteredMetadata = mdt.filter(metadata);
         Assert.assertEquals(6, filteredMetadata.size());

--- a/external/elasticsearch/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/external/elasticsearch/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -20,14 +20,16 @@ config:
     - com.digitalpebble.stormcrawler.Metadata
     - com.digitalpebble.stormcrawler.persistence.Status
 
-  # metadata to transfer to the outlinks
-  # used by Fetcher for redirections, sitemapparser, etc...
-  # these are also persisted for the parent document (see below)
+  # Lists the metadata to transfer to outlinks
+  # Used by Fetcher and SiteMapParser for redirections,
+  # discovered links, passing cookies to child pages, etc.
+  # These are also persisted for the parent document (see below).
+  # Allows wildcards, eg. "follow.*" transfers all metadata starting with "follow.".
   # metadata.transfer:
   # - customMetadataName
 
-  # lists the metadata to persist to storage
-  # these are not transferred to the outlinks
+  # Lists the metadata to persist to storage
+  # These are not transferred to the outlinks. Also allows wildcards, eg. "follow.*".
   metadata.persist:
    - _redirTo
    - error.cause

--- a/external/opensearch/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
+++ b/external/opensearch/archetype/src/main/resources/archetype-resources/crawler-conf.yaml
@@ -20,14 +20,16 @@ config:
     - com.digitalpebble.stormcrawler.Metadata
     - com.digitalpebble.stormcrawler.persistence.Status
 
-  # metadata to transfer to the outlinks
-  # used by Fetcher for redirections, sitemapparser, etc...
-  # these are also persisted for the parent document (see below)
+  # Lists the metadata to transfer to outlinks
+  # Used by Fetcher and SiteMapParser for redirections,
+  # discovered links, passing cookies to child pages, etc.
+  # These are also persisted for the parent document (see below).
+  # Allows wildcards, eg. "follow.*" transfers all metadata starting with "follow.".
   # metadata.transfer:
   # - customMetadataName
 
-  # lists the metadata to persist to storage
-  # these are not transferred to the outlinks
+  # Lists the metadata to persist to storage
+  # These are not transferred to the outlinks. Also allows wildcards, eg. "follow.*".
   metadata.persist:
    - _redirTo
    - error.cause


### PR DESCRIPTION
Hello all

Goal:
When having a lot of metadata fields that all start with the same prefix, e.g. `parse.[...]`, one can simply write
```
metadata.persist:
- parse.*
```
instead of listing them all.

Besides that, making mdToTransfer, mdToPersistOnly, trackPath and trackDepth protected instead of private. This makes it easier to create a Custom Metadata Transfer class.