### PR TITLE
Implement configurable getDocumentID in DeletionBolt

### DIFF
--- a/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/DeletionBolt.java
+++ b/external/elasticsearch/src/main/java/com/digitalpebble/stormcrawler/elasticsearch/bolt/DeletionBolt.java
@@ -68,8 +68,8 @@ public class DeletionBolt extends BaseRichBolt {
 
         // keep it simple for now and ignore cases where the canonical URL was
         // used
-        String sha256hex = org.apache.commons.codec.digest.DigestUtils.sha256Hex(url);
-        DeleteRequest dr = new DeleteRequest(getIndexName(metadata), sha256hex);
+        String docID = getDocumentID(metadata, url);
+        DeleteRequest dr = new DeleteRequest(getIndexName(metadata), docID);
         try {
             client.delete(dr, RequestOptions.DEFAULT);
         } catch (IOException e) {
@@ -78,6 +78,17 @@ public class DeletionBolt extends BaseRichBolt {
             return;
         }
         _collector.ack(tuple);
+    }
+
+    /**
+     * Get the document id.
+     *
+     * @param metadata The {@link Metadata}.
+     * @param url The normalised url.
+     * @return Return the normalised url SHA-256 digest as String.
+     */
+    protected String getDocumentID(Metadata metadata, String url) {
+        return org.apache.commons.codec.digest.DigestUtils.sha256Hex(url);
     }
 
     @Override

--- a/external/opensearch/src/main/java/com/digitalpebble/stormcrawler/opensearch/bolt/DeletionBolt.java
+++ b/external/opensearch/src/main/java/com/digitalpebble/stormcrawler/opensearch/bolt/DeletionBolt.java
@@ -130,7 +130,7 @@ public class DeletionBolt extends BaseRichBolt
         // keep it simple for now and ignore cases where the canonical URL was
         // used
 
-        final String docID = org.apache.commons.codec.digest.DigestUtils.sha256Hex(url);
+        final String docID = getDocumentID(metadata, url);
         DeleteRequest dr = new DeleteRequest(getIndexName(metadata), docID);
         connection.addToProcessor(dr);
 
@@ -159,6 +159,17 @@ public class DeletionBolt extends BaseRichBolt
      */
     protected String getIndexName(Metadata m) {
         return indexName;
+    }
+
+    /**
+     * Get the document id.
+     *
+     * @param metadata The {@link Metadata}.
+     * @param url The normalised url.
+     * @return Return the normalised url SHA-256 digest as String.
+     */
+    protected String getDocumentID(Metadata metadata, String url) {
+        return org.apache.commons.codec.digest.DigestUtils.sha256Hex(url);
     }
 
     @Override


### PR DESCRIPTION
We already have configurable documentID generator in IndexerBolt and StatusUpdaterBolt, we should also have same feature in DeletionBolt.

Thanks for contributing to StormCrawler, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to StormCrawler, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to StormCrawler. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'
* The code is properly formatted with 'mvn git-code-format:format-code -Dgcf.globPattern=**/*'

Thanks!

