### PR TITLE
Remove coveralls maven plugin, fixes #1148

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,18 +274,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.eluder.coveralls</groupId>
-				<artifactId>coveralls-maven-plugin</artifactId>
-				<version>4.3.0</version>
-				<dependencies>
-					<dependency>
-						<groupId>javax.xml.bind</groupId>
-						<artifactId>jaxb-api</artifactId>
-						<version>2.3.1</version>
-					</dependency>
-				</dependencies>
-			</plugin>
-			<plugin>
 				<groupId>com.cosium.code</groupId>
 				<artifactId>git-code-format-maven-plugin</artifactId>
 				<version>${git-code-format-maven-plugin.version}</version>


### PR DESCRIPTION
The plugin should not be needed by the GH actions so we can remove it from the pom.xml