### PR TITLE
Enable GH discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,6 +39,8 @@ github:
     issues: true
     # Enable projects for project management boards
     projects: true
+    # Enable discussions
+    discussions: true
 
   enabled_merge_buttons:
     squash:  true


### PR DESCRIPTION
as the title says. They were enabled before incubation and we don't have a user list, so might be good to have it for user equestions.