### PR TITLE
#1661 - Skip Solr Testcontainers tests when Docker is not present

### DIFF
--- a/external/solr/src/test/java/org/apache/stormcrawler/solr/SolrCloudContainerTest.java
+++ b/external/solr/src/test/java/org/apache/stormcrawler/solr/SolrCloudContainerTest.java
@@ -27,7 +27,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.MountableFile;
 
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 public abstract class SolrCloudContainerTest {
     private static final Logger LOG = LoggerFactory.getLogger(SolrCloudContainerTest.class);
 

--- a/external/solr/src/test/java/org/apache/stormcrawler/solr/SolrContainerTest.java
+++ b/external/solr/src/test/java/org/apache/stormcrawler/solr/SolrContainerTest.java
@@ -32,7 +32,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @Timeout(value = 120, unit = TimeUnit.SECONDS)
 public abstract class SolrContainerTest {
     protected static ExecutorService executorService;


### PR DESCRIPTION
Fixes #1661.