### PR TITLE
OkHttp protocol: add support for zstd Content-Encoding

### DIFF
--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -195,6 +195,7 @@ List of third-party dependencies grouped by their license type.
         * okhttp (com.squareup.okhttp3:okhttp:5.3.2 - https://square.github.io/okhttp/)
         * okhttp (com.squareup.okhttp3:okhttp-jvm:5.3.2 - https://square.github.io/okhttp/)
         * okhttp-brotli (com.squareup.okhttp3:okhttp-brotli:5.3.2 - https://square.github.io/okhttp/)
+        * okhttp-zstd (com.squareup.okhttp3:okhttp-zstd:5.3.2 - https://square.github.io/okhttp/)
         * okio (com.squareup.okio:okio:3.16.4 - https://github.com/square/okio/)
         * okio (com.squareup.okio:okio-jvm:3.16.4 - https://github.com/square/okio/)
         * opensearch-cli (org.opensearch:opensearch-cli:2.19.4 - https://github.com/opensearch-project/OpenSearch.git)

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -246,6 +246,12 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp-zstd</artifactId>
+			<version>${okhttp.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>

--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -42,11 +42,13 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import kotlin.Pair;
 import okhttp3.Call;
+import okhttp3.CompressionInterceptor;
 import okhttp3.Connection;
 import okhttp3.ConnectionPool;
 import okhttp3.Credentials;
 import okhttp3.EventListener;
 import okhttp3.EventListener.Factory;
+import okhttp3.Gzip;
 import okhttp3.Handshake;
 import okhttp3.Headers;
 import okhttp3.Interceptor;
@@ -59,7 +61,8 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.Route;
-import okhttp3.brotli.BrotliInterceptor;
+import okhttp3.brotli.Brotli;
+import okhttp3.zstd.Zstd;
 import okio.BufferedSource;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -241,8 +244,9 @@ public class HttpProtocol extends AbstractHttpProtocol {
                     }
                 });
 
-        // enable support for Brotli compression (Content-Encoding)
-        builder.addInterceptor(BrotliInterceptor.INSTANCE);
+        // enable support for Zstd, Brotli, Gzip Content-Encoding
+        builder.addInterceptor(
+                new CompressionInterceptor(Zstd.INSTANCE, Brotli.INSTANCE, Gzip.INSTANCE));
 
         final Map<String, Object> connectionPoolConf =
                 (Map<String, Object>) conf.get("okhttp.protocol.connection.pool");


### PR DESCRIPTION
OkHttp supports zstd [Content-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding) since version [5.2.0](https://square.github.io/okhttp/changelogs/changelog/#version-520).

This PR adds the necessary dependency on `okhttp-zstd` and enables support for zstd content-encoding in the OkHttp protocol implementation.

Tested with `http.store.headers: true`:

```
$> java ... org.apache.stormcrawler.protocol.okhttp.HttpProtocol https://www.llama.com/faq/
...
_protocol_versions_: h2,TLS_1_3,TLS_AES_128_GCM_SHA256
...
_request.headers_: GET /faq/ HTTP/2
User-Agent: ...
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en-gb,en;q=0.7,*;q=0.3
Accept-Encoding: zstd, br, gzip
Host: www.llama.com
Connection: Keep-Alive

_response.headers_: HTTP/2 200 
vary: Accept-Encoding
content-encoding: zstd
...
```