### PR TITLE
#1899 OkHttp protocol fails to cancel request after topology.message.timeout.secs

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -18,6 +18,7 @@
 package org.apache.stormcrawler.protocol.okhttp;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
@@ -159,6 +160,10 @@ public class HttpProtocol extends AbstractHttpProtocol {
                         .connectTimeout(timeout, TimeUnit.MILLISECONDS)
                         .writeTimeout(timeout, TimeUnit.MILLISECONDS)
                         .readTimeout(timeout, TimeUnit.MILLISECONDS);
+
+        if (completionTimeout >= 0) {
+            builder.callTimeout(completionTimeout, TimeUnit.SECONDS);
+        }
 
         // protocols in order of preference, see
         // https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/protocols/
@@ -430,17 +435,18 @@ public class HttpProtocol extends AbstractHttpProtocol {
                 responsemetadata.addValue(key.toLowerCase(Locale.ROOT), value);
             }
 
-            final MutableObject trimmed = new MutableObject(TrimmedContentReason.NOT_TRIMMED);
+            final MutableObject<TrimmedContentReason> trimmed =
+                    new MutableObject<>(TrimmedContentReason.NOT_TRIMMED);
             final byte[] bytes = toByteArray(response.body(), pageMaxContent, trimmed);
-            if (trimmed.getValue() != TrimmedContentReason.NOT_TRIMMED) {
+            if (trimmed.get() != TrimmedContentReason.NOT_TRIMMED) {
                 if (!call.isCanceled()) {
                     call.cancel();
                 }
                 responsemetadata.setValue(ProtocolResponse.TRIMMED_RESPONSE_KEY, "true");
                 responsemetadata.setValue(
                         ProtocolResponse.TRIMMED_RESPONSE_REASON_KEY,
-                        trimmed.getValue().toString().toLowerCase(Locale.ROOT));
-                LOG.warn("HTTP content trimmed to {}", bytes.length);
+                        trimmed.get().toString().toLowerCase(Locale.ROOT));
+                LOG.warn("HTTP content trimmed to {} (reason: {})", bytes.length, trimmed.get());
             }
 
             final Long dnsResolution = DNStimes.remove(call.toString());
@@ -453,7 +459,9 @@ public class HttpProtocol extends AbstractHttpProtocol {
     }
 
     private byte[] toByteArray(
-            final ResponseBody responseBody, int maxContent, MutableObject trimmed)
+            final ResponseBody responseBody,
+            int maxContent,
+            MutableObject<TrimmedContentReason> trimmed)
             throws IOException {
 
         if (responseBody == null) {
@@ -493,7 +501,12 @@ public class HttpProtocol extends AbstractHttpProtocol {
                 // requesting more content failed, e.g. by a socket timeout
                 if (partialContentAsTrimmed && source.getBuffer().size() > 0) {
                     // treat already fetched content as trimmed
-                    trimmed.setValue(TrimmedContentReason.DISCONNECT);
+                    if (e instanceof InterruptedIOException) {
+                        // thrown by OkHttp if the call timeout is hit
+                        trimmed.setValue(TrimmedContentReason.TIME);
+                    } else {
+                        trimmed.setValue(TrimmedContentReason.DISCONNECT);
+                    }
                     LOG.debug("Exception while fetching {}", e);
                 } else {
                     throw e;


### PR DESCRIPTION
To force cancellation of the request:
- set [OkHttp call timeout](https://square.github.io/okhttp/5.x/okhttp/okhttp3/-ok-http-client/-builder/call-timeout.html) to topology.message.timeout.secs (if not -1)

Additional changes:
- set the TrimmedReason to `TIME` if OkHttp throws an InterruptedIOException
- log the reason why the response is trimmed
- add type parameter to MutableObject's
- replace deprecated method calls `getValue()`

So far, the solution is only verified using the Protocol main method:
```
$> java -cp .../stormcrawler-core-3.5.2-SNAPSHOT.jar:... \
     org.apache.stormcrawler.protocol.okhttp.HttpProtocol \
     -f /tmp/crawler-conf-test.yaml http://cbhjhlccfkqdpknyu.org/
...
[main] INFO org.apache.stormcrawler.protocol.okhttp.HttpProtocol - Using protocol versions: [h2, http/1.1]
[main] INFO org.apache.stormcrawler.protocol.okhttp.HttpProtocol - Using connection pool with max. 5 idle connections and 300 sec. connection keep-alive time
[Thread-0] WARN org.apache.stormcrawler.protocol.okhttp.HttpProtocol - HTTP content trimmed to 10 (reason: TIME)
[Thread-0] WARN crawlercommons.robots.SimpleRobotRulesParser - Problem processing robots.txt for http://cbhjhlccfkqdpknyu.org/
[Thread-0] WARN crawlercommons.robots.SimpleRobotRulesParser -   Unknown line in robots.txt file (size 10): DQEPigDriE
[Thread-0] WARN org.apache.stormcrawler.protocol.okhttp.HttpProtocol - HTTP content trimmed to 10 (reason: TIME)
http://cbhjhlccfkqdpknyu.org/
robots allowed: true
robots requests: 1
sitemaps identified: 0
date: Thu, 07 May 2026 14:02:24 GMT
server: nginx/1.21.6
transfer-encoding: chunked
_protocol_versions_: http/1.1
metrics.dns.resolution.msec: 4
http.trimmed.reason: time
keep-alive: timeout=20
_request.headers_: GET / HTTP/1.1
User-Agent: MyTestBot/3.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en-gb,en;q=0.7,*;q=0.3
Accept-Encoding: zstd, br, gzip
Host: cbhjhlccfkqdpknyu.org
Connection: Keep-Alive


http.trimmed: true
_request.time_: 1778162544171
content-type: application/octet-stream
connection: keep-alive
_response.ip_: 216.218.185.162
_response.headers_: HTTP/1.1 200 OK
Server: nginx/1.21.6
Date: Thu, 07 May 2026 14:02:24 GMT
Content-Type: application/octet-stream
Transfer-Encoding: chunked
Connection: keep-alive
Keep-Alive: timeout=20



status code: 200
content length: 10
fetched in : 60002 msec
```