### PR TITLE
Increase checkstyle severities

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -279,7 +279,6 @@ under the License.
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
                      value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
-            <property name="severity" value="warning"/>
         </module>
         <module name="CatchParameterName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -254,7 +254,6 @@ under the License.
             <property name="tokens" value="CLASS_DEF"/>
             <message key="name.invalidPattern"
                      value="Type name ''{0}'' must match pattern ''{1}''."/>
-            <property name="severity" value="warning"/>
         </module>
         <module name="TypeName">
             <property name="tokens" value="INTERFACE_DEF, ENUM_DEF,

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -410,9 +410,7 @@ under the License.
         <module name="NonEmptyAtclauseDescription">
             <property name="severity" value="warning"/>
         </module>
-        <module name="InvalidJavadocPosition">
-            <property name="severity" value="warning"/>
-        </module>
+        <module name="InvalidJavadocPosition" />
         <module name="JavadocTagContinuationIndentation">
             <property name="severity" value="warning"/>
         </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -385,7 +385,6 @@ under the License.
                     LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
                     METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
                     RECORD_DEF, RECORD_PATTERN_DEF"/>
-            <property name="severity" value="warning"/>
         </module>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -95,9 +95,7 @@ under the License.
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
         <module name="AvoidStarImport"/>
-        <module name="OneTopLevelClass">
-            <property name="severity" value="warning"/>
-        </module>
+        <module name="OneTopLevelClass" />
         <module name="NoLineWrap">
             <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
         </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -466,7 +466,6 @@ under the License.
                       value="^(?![a-z]$)(?![a-z][A-Z])[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*(?:_[0-9]+)*$"/>
             <message key="name.invalidPattern"
                      value="Method name ''{0}'' must match pattern ''{1}''."/>
-            <property name="severity" value="warning"/>
         </module>
         <module name="SuppressionXpathSingleFilter">
             <property name="checks" value="MethodName"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -272,7 +272,6 @@ under the License.
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
                      value="Parameter name ''{0}'' must match pattern ''{1}''."/>
-            <property name="severity" value="warning"/>
         </module>
         <module name="LambdaParameterName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>

--- a/core/src/main/java/org/apache/stormcrawler/filtering/regex/FastURLFilter.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/regex/FastURLFilter.java
@@ -90,7 +90,7 @@ public class FastURLFilter extends URLFilter implements JSONResource {
         // config via json failed - trying from global config
         if (this.resourceFile == null) {
             this.resourceFile =
-                ConfUtils.getString(stormConf, "fast.urlfilter.file", "fast.urlfilter.json");
+                    ConfUtils.getString(stormConf, "fast.urlfilter.file", "fast.urlfilter.json");
         }
 
         try {
@@ -108,7 +108,7 @@ public class FastURLFilter extends URLFilter implements JSONResource {
 
     @Override
     public void loadJSONResources(InputStream inputStream)
-        throws JsonParseException, JsonMappingException, IOException {
+            throws JsonParseException, JsonMappingException, IOException {
 
         JsonNode rootNode = objectMapper.readTree(inputStream);
 
@@ -171,9 +171,9 @@ public class FastURLFilter extends URLFilter implements JSONResource {
 
     @Override
     public @Nullable String filter(
-        @Nullable URL sourceUrl,
-        @Nullable Metadata sourceMetadata,
-        @NotNull String urlToFilter) {
+            @Nullable URL sourceUrl,
+            @Nullable Metadata sourceMetadata,
+            @NotNull String urlToFilter) {
         try {
             if (rules.filter(urlToFilter, sourceMetadata)) {
                 return null;
@@ -205,8 +205,8 @@ public class FastURLFilter extends URLFilter implements JSONResource {
 
         /**
          * Try the rules from the hostname, domain name, metadata and global scopes in this order.
-         * Returns true if the URL should be removed, false otherwise. The value returns the value of
-         * the first matching rule, be it positive or negative.
+         * Returns true if the URL should be removed, false otherwise. The value returns the value
+         * of the first matching rule, be it positive or negative.
          *
          * @throws MalformedURLException
          */
@@ -238,10 +238,10 @@ public class FastURLFilter extends URLFilter implements JSONResource {
                 for (String v : vals) {
                     if (v.equalsIgnoreCase(scope.getValue())) {
                         FastURLFilter.LOG.debug(
-                            "Filtering {} matching metadata {}:{}",
-                            url,
-                            scope.getKey(),
-                            scope.getValue());
+                                "Filtering {} matching metadata {}:{}",
+                                url,
+                                scope.getKey(),
+                                scope.getValue());
                         if (checkScope(scope, u)) {
                             return true;
                         }

--- a/core/src/main/java/org/apache/stormcrawler/filtering/regex/FastURLFilter.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/regex/FastURLFilter.java
@@ -90,7 +90,7 @@ public class FastURLFilter extends URLFilter implements JSONResource {
         // config via json failed - trying from global config
         if (this.resourceFile == null) {
             this.resourceFile =
-                    ConfUtils.getString(stormConf, "fast.urlfilter.file", "fast.urlfilter.json");
+                ConfUtils.getString(stormConf, "fast.urlfilter.file", "fast.urlfilter.json");
         }
 
         try {
@@ -108,7 +108,7 @@ public class FastURLFilter extends URLFilter implements JSONResource {
 
     @Override
     public void loadJSONResources(InputStream inputStream)
-            throws JsonParseException, JsonMappingException, IOException {
+        throws JsonParseException, JsonMappingException, IOException {
 
         JsonNode rootNode = objectMapper.readTree(inputStream);
 
@@ -171,9 +171,9 @@ public class FastURLFilter extends URLFilter implements JSONResource {
 
     @Override
     public @Nullable String filter(
-            @Nullable URL sourceUrl,
-            @Nullable Metadata sourceMetadata,
-            @NotNull String urlToFilter) {
+        @Nullable URL sourceUrl,
+        @Nullable Metadata sourceMetadata,
+        @NotNull String urlToFilter) {
         try {
             if (rules.filter(urlToFilter, sourceMetadata)) {
                 return null;
@@ -183,184 +183,184 @@ public class FastURLFilter extends URLFilter implements JSONResource {
         }
         return urlToFilter;
     }
-}
 
-class Rules {
+    static class Rules {
 
-    private Scope globalRules;
-    private Map<String, Scope> domainRules = new HashMap<>();
-    private Map<String, Scope> hostNameRules = new HashMap<>();
-    private List<MDScope> metadataRules = new ArrayList<>();
+        private Scope globalRules;
+        private Map<String, Scope> domainRules = new HashMap<>();
+        private Map<String, Scope> hostNameRules = new HashMap<>();
+        private List<MDScope> metadataRules = new ArrayList<>();
 
-    public void addScope(Scope s, Scope.Type t, String value) {
-        if (t.equals(Scope.Type.GLOBAL)) {
-            globalRules = s;
-        } else if (t.equals(Scope.Type.DOMAIN)) {
-            domainRules.put(value, s);
-        } else if (t.equals(Scope.Type.HOSTNAME)) {
-            hostNameRules.put(value, s);
-        } else if (t.equals(Scope.Type.METADATA)) {
-            metadataRules.add(new MDScope(value, s.getRules()));
-        }
-    }
-
-    /**
-     * Try the rules from the hostname, domain name, metadata and global scopes in this order.
-     * Returns true if the URL should be removed, false otherwise. The value returns the value of
-     * the first matching rule, be it positive or negative.
-     *
-     * @throws MalformedURLException
-     */
-    public boolean filter(String url, Metadata metadata) throws MalformedURLException {
-        URL u = URLUtil.toURL(url);
-
-        // first try the full hostname
-        String hostname = u.getHost();
-        if (checkScope(hostNameRules.get(hostname), u)) {
-            return true;
+        public void addScope(Scope s, Scope.Type t, String value) {
+            if (t.equals(Scope.Type.GLOBAL)) {
+                globalRules = s;
+            } else if (t.equals(Scope.Type.DOMAIN)) {
+                domainRules.put(value, s);
+            } else if (t.equals(Scope.Type.HOSTNAME)) {
+                hostNameRules.put(value, s);
+            } else if (t.equals(Scope.Type.METADATA)) {
+                metadataRules.add(new MDScope(value, s.getRules()));
+            }
         }
 
-        // then on the various components of the domain
-        final String[] domainParts = hostname.split("\\.");
-        String domain = null;
-        for (int i = domainParts.length - 1; i >= 0; i--) {
-            domain = domainParts[i] + (domain == null ? "" : "." + domain);
-            if (checkScope(domainRules.get(domain), u)) {
+        /**
+         * Try the rules from the hostname, domain name, metadata and global scopes in this order.
+         * Returns true if the URL should be removed, false otherwise. The value returns the value of
+         * the first matching rule, be it positive or negative.
+         *
+         * @throws MalformedURLException
+         */
+        public boolean filter(String url, Metadata metadata) throws MalformedURLException {
+            URL u = URLUtil.toURL(url);
+
+            // first try the full hostname
+            String hostname = u.getHost();
+            if (checkScope(hostNameRules.get(hostname), u)) {
                 return true;
             }
-        }
 
-        // check on parent's URL metadata
-        for (MDScope scope : metadataRules) {
-            final String[] vals = metadata.getValues(scope.getKey());
-            if (vals == null) {
-                continue;
+            // then on the various components of the domain
+            final String[] domainParts = hostname.split("\\.");
+            String domain = null;
+            for (int i = domainParts.length - 1; i >= 0; i--) {
+                domain = domainParts[i] + (domain == null ? "" : "." + domain);
+                if (checkScope(domainRules.get(domain), u)) {
+                    return true;
+                }
             }
-            for (String v : vals) {
-                if (v.equalsIgnoreCase(scope.getValue())) {
-                    FastURLFilter.LOG.debug(
+
+            // check on parent's URL metadata
+            for (MDScope scope : metadataRules) {
+                final String[] vals = metadata.getValues(scope.getKey());
+                if (vals == null) {
+                    continue;
+                }
+                for (String v : vals) {
+                    if (v.equalsIgnoreCase(scope.getValue())) {
+                        FastURLFilter.LOG.debug(
                             "Filtering {} matching metadata {}:{}",
                             url,
                             scope.getKey(),
                             scope.getValue());
-                    if (checkScope(scope, u)) {
-                        return true;
+                        if (checkScope(scope, u)) {
+                            return true;
+                        }
                     }
                 }
             }
-        }
 
-        if (checkScope(globalRules, u)) {
-            return true;
-        }
+            if (checkScope(globalRules, u)) {
+                return true;
+            }
 
-        return false;
-    }
-
-    private boolean checkScope(Scope s, URL u) {
-        if (s == null) {
             return false;
         }
-        for (Rule r : s.getRules()) {
-            String haystack = u.getPath();
-            // whether to include the query as well?
-            if (r.getType().toString().endsWith("QUERY")) {
-                if (u.getQuery() != null) {
-                    haystack += "?" + u.getQuery();
+
+        private boolean checkScope(Scope s, URL u) {
+            if (s == null) {
+                return false;
+            }
+            for (Rule r : s.getRules()) {
+                String haystack = u.getPath();
+                // whether to include the query as well?
+                if (r.getType().toString().endsWith("QUERY")) {
+                    if (u.getQuery() != null) {
+                        haystack += "?" + u.getQuery();
+                    }
+                }
+                if (r.getPattern().matcher(haystack).find()) {
+                    // matches! returns true for DENY, false for ALLOW
+                    return r.getType().toString().startsWith("DENY");
                 }
             }
-            if (r.getPattern().matcher(haystack).find()) {
-                // matches! returns true for DENY, false for ALLOW
-                return r.getType().toString().startsWith("DENY");
+            return false;
+        }
+    }
+
+    static class Scope {
+
+        public enum Type {
+            DOMAIN,
+            GLOBAL,
+            HOSTNAME,
+            METADATA
+        }
+
+        protected Rule[] rules;
+
+        public void setRules(List<Rule> rlist) {
+            this.rules = rlist.toArray(new Rule[0]);
+        }
+
+        public Rule[] getRules() {
+            return rules;
+        }
+    }
+
+    static class MDScope extends Scope {
+
+        private String key;
+        private String value;
+
+        MDScope(String constraint, Rule[] rules) {
+            this.rules = rules;
+            int eq = constraint.indexOf("=");
+            if (eq != -1) {
+                key = constraint.substring(0, eq);
+                value = constraint.substring(eq + 1);
+            } else {
+                key = constraint;
             }
         }
-        return false;
-    }
-}
 
-class Scope {
+        public String getKey() {
+            return key;
+        }
 
-    public enum Type {
-        DOMAIN,
-        GLOBAL,
-        HOSTNAME,
-        METADATA
-    }
-
-    protected Rule[] rules;
-
-    public void setRules(List<Rule> rlist) {
-        this.rules = rlist.toArray(new Rule[0]);
-    }
-
-    public Rule[] getRules() {
-        return rules;
-    }
-}
-
-class MDScope extends Scope {
-
-    private String key;
-    private String value;
-
-    MDScope(String constraint, Rule[] rules) {
-        this.rules = rules;
-        int eq = constraint.indexOf("=");
-        if (eq != -1) {
-            key = constraint.substring(0, eq);
-            value = constraint.substring(eq + 1);
-        } else {
-            key = constraint;
+        public String getValue() {
+            return value;
         }
     }
 
-    public String getKey() {
-        return key;
-    }
+    static class Rule {
 
-    public String getValue() {
-        return value;
-    }
-}
+        public enum Type {
+            DENYPATH,
+            DENYPATHQUERY,
+            ALLOWPATH,
+            ALLOWPATHQUERY
+        }
 
-class Rule {
+        private Type type;
+        private Pattern pattern;
 
-    public enum Type {
-        DENYPATH,
-        DENYPATHQUERY,
-        ALLOWPATH,
-        ALLOWPATHQUERY
-    }
-
-    private Type type;
-    private Pattern pattern;
-
-    public Rule(String line) {
-        int offset = 0;
-        String lcline = line.toLowerCase(Locale.ROOT);
-        // separate the type from the pattern
-        for (Type t : Type.values()) {
-            String start = t.toString().toLowerCase(Locale.ROOT) + " ";
-            if (lcline.startsWith(start)) {
-                type = t;
-                offset = start.length();
-                break;
+        public Rule(String line) {
+            int offset = 0;
+            String lcline = line.toLowerCase(Locale.ROOT);
+            // separate the type from the pattern
+            for (Type t : Type.values()) {
+                String start = t.toString().toLowerCase(Locale.ROOT) + " ";
+                if (lcline.startsWith(start)) {
+                    type = t;
+                    offset = start.length();
+                    break;
+                }
             }
+            // no match?
+            if (type == null) {
+                return;
+            }
+
+            String patternString = line.substring(offset).trim();
+            pattern = Pattern.compile(patternString);
         }
-        // no match?
-        if (type == null) {
-            return;
+
+        public Type getType() {
+            return type;
         }
 
-        String patternString = line.substring(offset).trim();
-        pattern = Pattern.compile(patternString);
-    }
-
-    public Type getType() {
-        return type;
-    }
-
-    public Pattern getPattern() {
-        return pattern;
+        public Pattern getPattern() {
+            return pattern;
+        }
     }
 }

--- a/core/src/main/java/org/apache/stormcrawler/parse/filter/CollectionTagger.java
+++ b/core/src/main/java/org/apache/stormcrawler/parse/filter/CollectionTagger.java
@@ -70,7 +70,8 @@ public class CollectionTagger extends ParseFilter implements JSONResource {
     private static final Logger LOG = LoggerFactory.getLogger(CollectionTagger.class);
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final TypeReference<Collections> reference = new TypeReference<>() {};
+    private static final TypeReference<Collections> reference = new TypeReference<>() {
+    };
 
     private Collections collections = new Collections();
 
@@ -96,7 +97,7 @@ public class CollectionTagger extends ParseFilter implements JSONResource {
         }
         if (this.resourceFile == null) {
             this.resourceFile =
-                    ConfUtils.getString(stormConf, "collections.file", "collections.json");
+                ConfUtils.getString(stormConf, "collections.file", "collections.json");
         }
 
         try {
@@ -114,7 +115,7 @@ public class CollectionTagger extends ParseFilter implements JSONResource {
 
     @Override
     public void loadJSONResources(InputStream inputStream)
-            throws JsonParseException, JsonMappingException, IOException {
+        throws JsonParseException, JsonMappingException, IOException {
         collections = (Collections) objectMapper.readValue(inputStream, reference);
     }
 
@@ -125,78 +126,78 @@ public class CollectionTagger extends ParseFilter implements JSONResource {
             parse.get(url).getMetadata().setValues(key, tags);
         }
     }
-}
 
-class Collections {
+    static class Collections {
 
-    private Set<Collection> collections;
+        private Set<Collection> collections;
 
-    public void setCollections(Set<Collection> collections) {
-        this.collections = collections;
-    }
+        public void setCollections(Set<Collection> collections) {
+            this.collections = collections;
+        }
 
-    public String[] tag(String url) {
-        Set<String> tags = new HashSet<>();
-        for (Collection collection : collections) {
-            if (collection.matches(url)) {
-                tags.add(collection.getName());
+        public String[] tag(String url) {
+            Set<String> tags = new HashSet<>();
+            for (Collection collection : collections) {
+                if (collection.matches(url)) {
+                    tags.add(collection.getName());
+                }
             }
+            return tags.toArray(new String[0]);
         }
-        return tags.toArray(new String[0]);
-    }
-}
-
-class Collection {
-
-    private String name;
-    private Set<Pattern> includePatterns;
-    private Set<Pattern> excludePatterns;
-
-    public String getName() {
-        return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+    static class Collection {
 
-    /**
-     * @return true if the URL matches a pattern for this collection and no exclusion patterns
-     */
-    public boolean matches(String url) {
-        boolean matches = false;
-        for (Pattern includeP : includePatterns) {
-            Matcher m = includeP.matcher(url);
-            if (m.matches()) {
-                matches = true;
-                break;
+        private String name;
+        private Set<Pattern> includePatterns;
+        private Set<Pattern> excludePatterns;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        /**
+         * @return true if the URL matches a pattern for this collection and no exclusion patterns
+         */
+        public boolean matches(String url) {
+            boolean matches = false;
+            for (Pattern includeP : includePatterns) {
+                Matcher m = includeP.matcher(url);
+                if (m.matches()) {
+                    matches = true;
+                    break;
+                }
             }
-        }
-        // no match
-        if (!matches) {
-            return false;
-        }
+            // no match
+            if (!matches) {
+                return false;
+            }
 
-        if (excludePatterns == null) {
+            if (excludePatterns == null) {
+                return true;
+            }
+
+            // check for antipatterns
+            for (Pattern excludeP : excludePatterns) {
+                Matcher m = excludeP.matcher(url);
+                if (m.matches()) {
+                    return false;
+                }
+            }
+
             return true;
         }
 
-        // check for antipatterns
-        for (Pattern excludeP : excludePatterns) {
-            Matcher m = excludeP.matcher(url);
-            if (m.matches()) {
-                return false;
-            }
+        public void setIncludePatterns(Set<Pattern> includePatterns) {
+            this.includePatterns = includePatterns;
         }
 
-        return true;
-    }
-
-    public void setIncludePatterns(Set<Pattern> includePatterns) {
-        this.includePatterns = includePatterns;
-    }
-
-    public void setExcludePatterns(Set<Pattern> excludePatterns) {
-        this.excludePatterns = excludePatterns;
+        public void setExcludePatterns(Set<Pattern> excludePatterns) {
+            this.excludePatterns = excludePatterns;
+        }
     }
 }

--- a/core/src/main/java/org/apache/stormcrawler/parse/filter/CollectionTagger.java
+++ b/core/src/main/java/org/apache/stormcrawler/parse/filter/CollectionTagger.java
@@ -70,8 +70,7 @@ public class CollectionTagger extends ParseFilter implements JSONResource {
     private static final Logger LOG = LoggerFactory.getLogger(CollectionTagger.class);
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final TypeReference<Collections> reference = new TypeReference<>() {
-    };
+    private static final TypeReference<Collections> reference = new TypeReference<>() {};
 
     private Collections collections = new Collections();
 
@@ -97,7 +96,7 @@ public class CollectionTagger extends ParseFilter implements JSONResource {
         }
         if (this.resourceFile == null) {
             this.resourceFile =
-                ConfUtils.getString(stormConf, "collections.file", "collections.json");
+                    ConfUtils.getString(stormConf, "collections.file", "collections.json");
         }
 
         try {
@@ -115,7 +114,7 @@ public class CollectionTagger extends ParseFilter implements JSONResource {
 
     @Override
     public void loadJSONResources(InputStream inputStream)
-        throws JsonParseException, JsonMappingException, IOException {
+            throws JsonParseException, JsonMappingException, IOException {
         collections = (Collections) objectMapper.readValue(inputStream, reference);
     }
 

--- a/core/src/main/java/org/apache/stormcrawler/spout/MemorySpout.java
+++ b/core/src/main/java/org/apache/stormcrawler/spout/MemorySpout.java
@@ -66,14 +66,16 @@ public class MemorySpout extends BaseRichSpout {
      * statusupdaterbolt.
      *
      * @param withDiscoveredStatus whether the tuples generated should contain a Status field with
-     *     DISCOVERED as value and be emitted on the status stream
+     *                             DISCOVERED as value and be emitted on the status stream
      */
     public MemorySpout(boolean withDiscoveredStatus, String... urls) {
         this.withDiscoveredStatus = withDiscoveredStatus;
         startingUrls = urls;
     }
 
-    /** Add a new URL with the given metadata and nextFetch-date. */
+    /**
+     * Add a new URL with the given metadata and nextFetch-date.
+     */
     public static void add(String url, Metadata md, Date nextFetch) {
         LOG.debug("Adding {} with md {} and nextFetch {}", url, md, nextFetch);
         ScheduledURL tuple = new ScheduledURL(url, md, nextFetch);
@@ -84,7 +86,7 @@ public class MemorySpout extends BaseRichSpout {
 
     @Override
     public void open(
-            Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
+        Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         this.collector = collector;
 
         // check that there is only one instance of it
@@ -97,7 +99,7 @@ public class MemorySpout extends BaseRichSpout {
         for (String u : startingUrls) {
             LOG.debug("About to deserialize {} ", u);
             List<Object> tuple =
-                    scheme.deserialize(ByteBuffer.wrap(u.getBytes(StandardCharsets.UTF_8)));
+                scheme.deserialize(ByteBuffer.wrap(u.getBytes(StandardCharsets.UTF_8)));
             add((String) tuple.get(0), (Metadata) tuple.get(1), now);
         }
         CrawlerMetrics.registerGauge(context, conf, "queue_size", queue::size, 10);
@@ -160,39 +162,41 @@ public class MemorySpout extends BaseRichSpout {
         super.deactivate();
         active = false;
     }
-}
 
-class ScheduledURL implements Comparable<ScheduledURL> {
-    Date nextFetchDate;
-    String url;
-    Metadata metadata;
+    static class ScheduledURL implements Comparable<ScheduledURL> {
+        Date nextFetchDate;
+        String url;
+        Metadata metadata;
 
-    ScheduledURL(String url, Metadata m, Date nextFetchDate) {
-        this.nextFetchDate = nextFetchDate;
-        this.url = url;
-        this.metadata = m;
-    }
-
-    @Override
-    public String toString() {
-        return url + "\t" + nextFetchDate;
-    }
-
-    /** Sort by next fetch date then URl. * */
-    @Override
-    public int compareTo(ScheduledURL o) {
-        // compare the URL
-        int compString = url.compareTo(o.url);
-        if (compString == 0) {
-            return 0;
+        ScheduledURL(String url, Metadata m, Date nextFetchDate) {
+            this.nextFetchDate = nextFetchDate;
+            this.url = url;
+            this.metadata = m;
         }
 
-        // compare the date
-        int comp = nextFetchDate.compareTo(o.nextFetchDate);
-        if (comp != 0) {
-            return comp;
+        @Override
+        public String toString() {
+            return url + "\t" + nextFetchDate;
         }
 
-        return compString;
+        /**
+         * Sort by next fetch date then URl. *
+         */
+        @Override
+        public int compareTo(ScheduledURL o) {
+            // compare the URL
+            int compString = url.compareTo(o.url);
+            if (compString == 0) {
+                return 0;
+            }
+
+            // compare the date
+            int comp = nextFetchDate.compareTo(o.nextFetchDate);
+            if (comp != 0) {
+                return comp;
+            }
+
+            return compString;
+        }
     }
 }

--- a/core/src/main/java/org/apache/stormcrawler/spout/MemorySpout.java
+++ b/core/src/main/java/org/apache/stormcrawler/spout/MemorySpout.java
@@ -66,16 +66,14 @@ public class MemorySpout extends BaseRichSpout {
      * statusupdaterbolt.
      *
      * @param withDiscoveredStatus whether the tuples generated should contain a Status field with
-     *                             DISCOVERED as value and be emitted on the status stream
+     *     DISCOVERED as value and be emitted on the status stream
      */
     public MemorySpout(boolean withDiscoveredStatus, String... urls) {
         this.withDiscoveredStatus = withDiscoveredStatus;
         startingUrls = urls;
     }
 
-    /**
-     * Add a new URL with the given metadata and nextFetch-date.
-     */
+    /** Add a new URL with the given metadata and nextFetch-date. */
     public static void add(String url, Metadata md, Date nextFetch) {
         LOG.debug("Adding {} with md {} and nextFetch {}", url, md, nextFetch);
         ScheduledURL tuple = new ScheduledURL(url, md, nextFetch);
@@ -86,7 +84,7 @@ public class MemorySpout extends BaseRichSpout {
 
     @Override
     public void open(
-        Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
+            Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         this.collector = collector;
 
         // check that there is only one instance of it
@@ -99,7 +97,7 @@ public class MemorySpout extends BaseRichSpout {
         for (String u : startingUrls) {
             LOG.debug("About to deserialize {} ", u);
             List<Object> tuple =
-                scheme.deserialize(ByteBuffer.wrap(u.getBytes(StandardCharsets.UTF_8)));
+                    scheme.deserialize(ByteBuffer.wrap(u.getBytes(StandardCharsets.UTF_8)));
             add((String) tuple.get(0), (Metadata) tuple.get(1), now);
         }
         CrawlerMetrics.registerGauge(context, conf, "queue_size", queue::size, 10);
@@ -179,9 +177,7 @@ public class MemorySpout extends BaseRichSpout {
             return url + "\t" + nextFetchDate;
         }
 
-        /**
-         * Sort by next fetch date then URl. *
-         */
+        /** Sort by next fetch date then URl. * */
         @Override
         public int compareTo(ScheduledURL o) {
             // compare the URL

--- a/core/src/main/java/org/apache/stormcrawler/util/MetadataTransfer.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/MetadataTransfer.java
@@ -123,7 +123,7 @@ public class MetadataTransfer {
      * the URL path.
      */
     public Metadata getMetaForOutlink(String targetUrl, String sourceUrl, Metadata parentMetadata) {
-        Metadata md = _filter(parentMetadata, mdToTransfer);
+        Metadata md = filter(parentMetadata, mdToTransfer);
 
         // keep the path?
         if (trackPath) {
@@ -150,11 +150,11 @@ public class MetadataTransfer {
      * not necessarily transferred to the outlinks.
      */
     public Metadata filter(Metadata metadata) {
-        Metadata filteredMetadata = _filter(metadata, mdToTransfer);
+        Metadata filteredMetadata = filter(metadata, mdToTransfer);
 
         // add the features that are only persisted but
         // not transferred like __redirTo_
-        filteredMetadata.putAll(_filter(metadata, mdToPersistOnly));
+        filteredMetadata.putAll(filter(metadata, mdToPersistOnly));
 
         return filteredMetadata;
     }
@@ -163,7 +163,7 @@ public class MetadataTransfer {
      * Filter the metadata based on a set of keys. If a key ends with a * then all the keys starting
      * with the prefix will be added.
      */
-    private Metadata _filter(Metadata metadata, Set<String> filter) {
+    private Metadata filter(Metadata metadata, Set<String> filter) {
         Metadata filteredMetadata = new Metadata();
 
         for (String key : filter) {

--- a/core/src/main/java/org/apache/stormcrawler/util/PerSecondReducer.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/PerSecondReducer.java
@@ -37,9 +37,9 @@ public class PerSecondReducer implements IReducer<PerSecondReducer.TimeReducerSt
             accumulator.sum += ((Integer) input).doubleValue();
         } else {
             throw new RuntimeException(
-                "MeanReducer::reduce called with unsupported input type `"
-                    + input.getClass()
-                    + "`. Supported types are Double, Long, Integer.");
+                    "MeanReducer::reduce called with unsupported input type `"
+                            + input.getClass()
+                            + "`. Supported types are Double, Long, Integer.");
         }
         return accumulator;
     }

--- a/core/src/main/java/org/apache/stormcrawler/util/PerSecondReducer.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/PerSecondReducer.java
@@ -20,7 +20,7 @@ package org.apache.stormcrawler.util;
 import org.apache.storm.metric.api.IReducer;
 
 /** Used to return an average value per second. */
-public class PerSecondReducer implements IReducer<TimeReducerState> {
+public class PerSecondReducer implements IReducer<PerSecondReducer.TimeReducerState> {
 
     @Override
     public TimeReducerState init() {
@@ -37,9 +37,9 @@ public class PerSecondReducer implements IReducer<TimeReducerState> {
             accumulator.sum += ((Integer) input).doubleValue();
         } else {
             throw new RuntimeException(
-                    "MeanReducer::reduce called with unsupported input type `"
-                            + input.getClass()
-                            + "`. Supported types are Double, Long, Integer.");
+                "MeanReducer::reduce called with unsupported input type `"
+                    + input.getClass()
+                    + "`. Supported types are Double, Long, Integer.");
         }
         return accumulator;
     }
@@ -54,9 +54,9 @@ public class PerSecondReducer implements IReducer<TimeReducerState> {
         double permsec = accumulator.sum / msec;
         return permsec * 1000d;
     }
-}
 
-class TimeReducerState {
-    public long started = System.currentTimeMillis();
-    public double sum = 0.0;
+    static class TimeReducerState {
+        public long started = System.currentTimeMillis();
+        public double sum = 0.0;
+    }
 }

--- a/core/src/test/java/org/apache/stormcrawler/bolt/JSoupParserBoltTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/JSoupParserBoltTest.java
@@ -115,8 +115,8 @@ class JSoupParserBoltTest extends ParsingTester {
         setupParserBolt(bolt);
     }
 
+    /** Checks that content in script is not included in the text representation. */
     @Test
-    /** Checks that content in script is not included in the text representation */
     void testNoScriptInText() throws IOException {
         bolt.prepare(
                 new HashMap<>(), TestUtil.getMockedTopologyContext(), new OutputCollector(output));
@@ -129,8 +129,8 @@ class JSoupParserBoltTest extends ParsingTester {
                 "Text should not contain the content of script tags");
     }
 
+    /** Checks that individual links marked as rel="nofollow" are not followed. */
     @Test
-    /** Checks that individual links marked as rel="nofollow" are not followed */
     void testNoFollowOutlinks() throws IOException {
         bolt.prepare(
                 new HashMap<>(), TestUtil.getMockedTopologyContext(), new OutputCollector(output));

--- a/core/src/test/java/org/apache/stormcrawler/parse/filter/SubDocumentsParseFilter.java
+++ b/core/src/test/java/org/apache/stormcrawler/parse/filter/SubDocumentsParseFilter.java
@@ -39,7 +39,7 @@ public class SubDocumentsParseFilter extends ParseFilter {
             LoggerFactory.getLogger(SubDocumentsParseFilter.class);
 
     @Override
-    public void filter(String URL, byte[] content, DocumentFragment doc, ParseResult parse) {
+    public void filter(String url, byte[] content, DocumentFragment doc, ParseResult parse) {
 
         InputStream stream = new ByteArrayInputStream(content);
 
@@ -69,7 +69,7 @@ public class SubDocumentsParseFilter extends ParseFilter {
                 }
             }
         } catch (Exception e) {
-            LOG.error("Error processing sitemap from {}: {}", URL, e);
+            LOG.error("Error processing sitemap from {}: {}", url, e);
         }
     }
 

--- a/core/src/test/java/org/apache/stormcrawler/util/InitialisationUtilTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/util/InitialisationUtilTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 class InitialisationUtilTest {
 
     @Test
-    void can_initialize_a_simple_class() {
+    void can_initialize_simple_class() {
         final SimpleOpenClass simpleOpenClass =
                 InitialisationUtil.initializeFromQualifiedName(
                         SimpleOpenClass.class.getName(), SimpleOpenClass.class);
@@ -150,7 +150,7 @@ class InitialisationUtilTest {
     }
 
     @Test
-    void fails_if_class_to_initialize_not_extending_classes_to_test_1() {
+    void fails_if_class_to_initialize_not_extending_classes_to_test() {
         Assertions.assertThrows(
                 RuntimeException.class,
                 () ->
@@ -161,7 +161,7 @@ class InitialisationUtilTest {
     }
 
     @Test
-    void fails_if_class_to_initialize_not_extending_classes_to_test_2() {
+    void fails_if_class_to_initialize_not_extending_classes_to_test_other() {
         Assertions.assertThrows(
                 RuntimeException.class,
                 () ->

--- a/core/src/test/java/org/apache/stormcrawler/util/MetadataTransferTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/util/MetadataTransferTest.java
@@ -68,7 +68,7 @@ class MetadataTransferTest {
         conf = new HashMap<>();
         conf.put(
                 MetadataTransfer.metadataTransferClassParamName,
-                myCustomTransferClass.class.getName());
+                MyCustomTransferClass.class.getName());
         hasThrownException = false;
         try {
             MetadataTransfer.getInstance(conf);
@@ -114,4 +114,4 @@ class MetadataTransferTest {
     }
 }
 
-class myCustomTransferClass extends MetadataTransfer {}
+class MyCustomTransferClass extends MetadataTransfer {}

--- a/core/src/test/java/org/apache/stormcrawler/util/MetadataTransferTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/util/MetadataTransferTest.java
@@ -39,16 +39,16 @@ class MetadataTransferTest {
         parentMD.addValue("cookie.source", "example.com");
         parentMD.addValue("fetchInterval", "200");
         Metadata outlinkMD =
-            mdt.getMetaForOutlink(
-                "http://www.example.com/outlink.html", "http://www.example.com", parentMD);
+                mdt.getMetaForOutlink(
+                        "http://www.example.com/outlink.html", "http://www.example.com", parentMD);
         // test the value of track seed, depth and fetch fields
         Assertions.assertEquals("1", outlinkMD.getFirstValue(MetadataTransfer.depthKeyName));
         Set<String> expectedFields =
-            Set.of(
-                MetadataTransfer.urlPathKeyName,
-                MetadataTransfer.depthKeyName,
-                "cookie.id",
-                "cookie.source");
+                Set.of(
+                        MetadataTransfer.urlPathKeyName,
+                        MetadataTransfer.depthKeyName,
+                        "cookie.id",
+                        "cookie.source");
         Assertions.assertEquals(expectedFields, outlinkMD.keySet());
         String[] urlpath = outlinkMD.getValues(MetadataTransfer.urlPathKeyName);
         Assertions.assertEquals(1, urlpath.length);
@@ -67,8 +67,8 @@ class MetadataTransferTest {
         Assertions.assertTrue(hasThrownException);
         conf = new HashMap<>();
         conf.put(
-            MetadataTransfer.metadataTransferClassParamName,
-            MyCustomTransferClass.class.getName());
+                MetadataTransfer.metadataTransferClassParamName,
+                MyCustomTransferClass.class.getName());
         hasThrownException = false;
         try {
             MetadataTransfer.getInstance(conf);
@@ -113,6 +113,5 @@ class MetadataTransferTest {
         Assertions.assertEquals(6, filteredMetadata.size());
     }
 
-    static class MyCustomTransferClass extends MetadataTransfer {
-    }
+    static class MyCustomTransferClass extends MetadataTransfer {}
 }

--- a/core/src/test/java/org/apache/stormcrawler/util/MetadataTransferTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/util/MetadataTransferTest.java
@@ -39,16 +39,16 @@ class MetadataTransferTest {
         parentMD.addValue("cookie.source", "example.com");
         parentMD.addValue("fetchInterval", "200");
         Metadata outlinkMD =
-                mdt.getMetaForOutlink(
-                        "http://www.example.com/outlink.html", "http://www.example.com", parentMD);
+            mdt.getMetaForOutlink(
+                "http://www.example.com/outlink.html", "http://www.example.com", parentMD);
         // test the value of track seed, depth and fetch fields
         Assertions.assertEquals("1", outlinkMD.getFirstValue(MetadataTransfer.depthKeyName));
         Set<String> expectedFields =
-                Set.of(
-                        MetadataTransfer.urlPathKeyName,
-                        MetadataTransfer.depthKeyName,
-                        "cookie.id",
-                        "cookie.source");
+            Set.of(
+                MetadataTransfer.urlPathKeyName,
+                MetadataTransfer.depthKeyName,
+                "cookie.id",
+                "cookie.source");
         Assertions.assertEquals(expectedFields, outlinkMD.keySet());
         String[] urlpath = outlinkMD.getValues(MetadataTransfer.urlPathKeyName);
         Assertions.assertEquals(1, urlpath.length);
@@ -67,8 +67,8 @@ class MetadataTransferTest {
         Assertions.assertTrue(hasThrownException);
         conf = new HashMap<>();
         conf.put(
-                MetadataTransfer.metadataTransferClassParamName,
-                MyCustomTransferClass.class.getName());
+            MetadataTransfer.metadataTransferClassParamName,
+            MyCustomTransferClass.class.getName());
         hasThrownException = false;
         try {
             MetadataTransfer.getInstance(conf);
@@ -112,6 +112,7 @@ class MetadataTransferTest {
         filteredMetadata = mdt.filter(metadata);
         Assertions.assertEquals(6, filteredMetadata.size());
     }
-}
 
-class MyCustomTransferClass extends MetadataTransfer {}
+    static class MyCustomTransferClass extends MetadataTransfer {
+    }
+}

--- a/external/opensearch-java/src/main/java/org/apache/stormcrawler/opensearch/parse/filter/JSONResourceWrapper.java
+++ b/external/opensearch-java/src/main/java/org/apache/stormcrawler/opensearch/parse/filter/JSONResourceWrapper.java
@@ -66,8 +66,8 @@ public class JSONResourceWrapper extends ParseFilter {
     }
 
     @Override
-    public void filter(String URL, byte[] content, DocumentFragment doc, ParseResult parse) {
-        refresher.getDelegate().filter(URL, content, doc, parse);
+    public void filter(String url, byte[] content, DocumentFragment doc, ParseResult parse) {
+        refresher.getDelegate().filter(url, content, doc, parse);
     }
 
     @Override

--- a/external/opensearch-java/src/test/java/org/apache/stormcrawler/opensearch/DelegateRefresherTest.java
+++ b/external/opensearch-java/src/test/java/org/apache/stormcrawler/opensearch/DelegateRefresherTest.java
@@ -84,7 +84,7 @@ class DelegateRefresherTest {
         }
 
         @Override
-        public void filter(String URL, byte[] content, DocumentFragment doc, ParseResult parse) {}
+        public void filter(String url, byte[] content, DocumentFragment doc, ParseResult parse) {}
 
         @Override
         public String getResourceFile() {

--- a/external/opensearch/src/main/java/org/apache/stormcrawler/opensearch/parse/filter/JSONResourceWrapper.java
+++ b/external/opensearch/src/main/java/org/apache/stormcrawler/opensearch/parse/filter/JSONResourceWrapper.java
@@ -69,8 +69,8 @@ public class JSONResourceWrapper extends ParseFilter {
     }
 
     @Override
-    public void filter(String URL, byte[] content, DocumentFragment doc, ParseResult parse) {
-        refresher.getDelegate().filter(URL, content, doc, parse);
+    public void filter(String url, byte[] content, DocumentFragment doc, ParseResult parse) {
+        refresher.getDelegate().filter(url, content, doc, parse);
     }
 
     @Override

--- a/external/opensearch/src/test/java/org/apache/stormcrawler/opensearch/DelegateRefresherTest.java
+++ b/external/opensearch/src/test/java/org/apache/stormcrawler/opensearch/DelegateRefresherTest.java
@@ -84,7 +84,7 @@ class DelegateRefresherTest {
         }
 
         @Override
-        public void filter(String URL, byte[] content, DocumentFragment doc, ParseResult parse) {}
+        public void filter(String url, byte[] content, DocumentFragment doc, ParseResult parse) {}
 
         @Override
         public String getResourceFile() {

--- a/external/playwright/src/main/java/org/apache/stormcrawler/protocol/playwright/HttpProtocol.java
+++ b/external/playwright/src/main/java/org/apache/stormcrawler/protocol/playwright/HttpProtocol.java
@@ -229,7 +229,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
                 // NOTE: The handler will only be called for the first url if the
                 // response is a redirect.
                 page.route(
-                        _url -> true,
+                        lambdaUrl -> true,
                         route -> {
                             // abort if we know the main page is a redirection
                             if (status.get() != -1) {

--- a/external/tika/src/test/java/org/apache/stormcrawler/tika/ParserBoltTest.java
+++ b/external/tika/src/test/java/org/apache/stormcrawler/tika/ParserBoltTest.java
@@ -45,12 +45,12 @@ class ParserBoltTest extends ParsingTester {
         setupParserBolt(bolt);
     }
 
-    @Test
     /**
-     * Checks that recursive docs are handled correctly
+     * Checks that recursive docs are handled correctly.
      *
-     * @see https://issues.apache.org/jira/browse/TIKA-2096
+     * @see <a href="https://issues.apache.org/jira/browse/TIKA-2096">TIKA-2096</a>
      */
+    @Test
     void testRecursiveDoc() throws IOException {
         Map<String, Object> conf = new HashMap<>();
         conf.put("parser.extract.embedded", true);
@@ -71,12 +71,12 @@ class ParserBoltTest extends ParsingTester {
                         .contains("Life, Liberty and the pursuit of Happiness"));
     }
 
-    @Test
     /**
-     * Checks that the mimetype whitelists are handled correctly
+     * Checks that the mimetype whitelists are handled correctly.
      *
-     * @see https://github.com/apache/stormcrawler/issues/712
+     * @see <a href="https://github.com/apache/stormcrawler/issues/712">#712</a>
      */
+    @Test
     void testMimeTypeWhileList() throws IOException {
         Map<String, Object> conf = new HashMap<>();
         conf.put("parser.mimetype.whitelist", "application/.+word.*");

--- a/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCHdfsBolt.java
+++ b/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCHdfsBolt.java
@@ -59,8 +59,8 @@ public class WARCHdfsBolt extends GzipHdfsBolt {
         withFsUrl("file:///");
     }
 
-    public WARCHdfsBolt withHeader(Map<String, String> header_fields) {
-        this.header_fields = header_fields;
+    public WARCHdfsBolt withHeader(Map<String, String> headerFields) {
+        this.header_fields = headerFields;
         return this;
     }
 

--- a/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCHdfsBoltTest.java
+++ b/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCHdfsBoltTest.java
@@ -190,34 +190,24 @@ class WARCHdfsBoltTest {
         String txt = "abcdef";
         byte[] content = txt.getBytes(StandardCharsets.UTF_8);
         Metadata metadata = new Metadata();
-        metadata.addValue( //
+        metadata.addValue(
                 protocolMDprefix + ProtocolResponse.REQUEST_HEADERS_KEY,
                 "GET / "
                         + httpVersionString
-                        + //
-                        "\r\n"
-                        + //
-                        "User-Agent: myBot/1.0 (https://example.org/bot/; bot@example.org)\r\n"
-                        + //
-                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
-                        + //
-                        "Accept-Language: en-us,en-gb,en;q=0.7,*;q=0.3\r\n"
-                        + //
-                        "Accept-Encoding: br,gzip\r\n"
-                        + //
-                        "Host: example.org\r\n"
+                        + "\r\n"
+                        + "User-Agent: myBot/1.0 (https://example.org/bot/; bot@example.org)\r\n"
+                        + "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+                        + "Accept-Language: en-us,en-gb,en;q=0.7,*;q=0.3\r\n"
+                        + "Accept-Encoding: br,gzip\r\n"
+                        + "Host: example.org\r\n"
                         + "Connection: Keep-Alive\r\n\r\n");
-        metadata.addValue( //
+        metadata.addValue(
                 protocolMDprefix + ProtocolResponse.RESPONSE_HEADERS_KEY,
                 httpVersionString
-                        + //
-                        " 200 OK\r\n"
-                        + //
-                        "Content-Type: text/html\r\n"
-                        + //
-                        "Content-Encoding: gzip\r\n"
-                        + //
-                        "Content-Length: 26\r\n"
+                        + " 200 OK\r\n"
+                        + "Content-Type: text/html\r\n"
+                        + "Content-Encoding: gzip\r\n"
+                        + "Content-Length: 26\r\n"
                         + "Connection: close\r\n\r\n");
         metadata.addValue(
                 protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY,

--- a/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCRecordFormatTest.java
+++ b/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCRecordFormatTest.java
@@ -122,15 +122,12 @@ class WARCRecordFormatTest {
         byte[] content = txt.getBytes(StandardCharsets.UTF_8);
         String sha1str = "sha1:D6FMCDZDYW23YELHXWUEXAZ6LQCXU56S";
         Metadata metadata = new Metadata();
-        metadata.addValue( //
-                protocolMDprefix + ProtocolResponse.RESPONSE_HEADERS_KEY, //
+        metadata.addValue(
+                protocolMDprefix + ProtocolResponse.RESPONSE_HEADERS_KEY,
                 "HTTP/1.1 200 OK\r\n"
-                        + //
-                        "Content-Type: text/html\r\n"
-                        + //
-                        "Content-Encoding: gzip\r\n"
-                        + //
-                        "Content-Length: 26\r\n"
+                        + "Content-Type: text/html\r\n"
+                        + "Content-Encoding: gzip\r\n"
+                        + "Content-Length: 26\r\n"
                         + "Connection: close");
         metadata.addValue(protocolMDprefix + ProtocolResponse.RESPONSE_IP_KEY, "123.123.123.123");
         Tuple tuple = mock(Tuple.class);
@@ -165,15 +162,12 @@ class WARCRecordFormatTest {
         String txt = "abcdef";
         byte[] content = txt.getBytes(StandardCharsets.UTF_8);
         Metadata metadata = new Metadata();
-        metadata.addValue( //
-                protocolMDprefix + ProtocolResponse.RESPONSE_HEADERS_KEY, //
+        metadata.addValue(
+                protocolMDprefix + ProtocolResponse.RESPONSE_HEADERS_KEY,
                 "HTTP/2 200 OK\r\n"
-                        + //
-                        "Content-Type: text/html\r\n"
-                        + //
-                        "Content-Encoding: gzip\r\n"
-                        + //
-                        "Content-Length: 26\r\n"
+                        + "Content-Type: text/html\r\n"
+                        + "Content-Encoding: gzip\r\n"
+                        + "Content-Length: 26\r\n"
                         + "Connection: close");
         metadata.addValue(
                 protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY,
@@ -208,17 +202,13 @@ class WARCRecordFormatTest {
         String txt = "abcdef";
         byte[] content = txt.getBytes(StandardCharsets.UTF_8);
         Metadata metadata = new Metadata();
-        metadata.addValue( //
-                protocolMDprefix + ProtocolResponse.REQUEST_HEADERS_KEY, //
+        metadata.addValue(
+                protocolMDprefix + ProtocolResponse.REQUEST_HEADERS_KEY,
                 "GET / HTTP/2\r\n"
-                        + //
-                        "User-Agent: mybot\r\n"
-                        + //
-                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
-                        + //
-                        "Accept-Language: en-us,en-gb,en;q=0.7,*;q=0.3\r\n"
-                        + //
-                        "Accept-Encoding: br,gzip\r\n"
+                        + "User-Agent: mybot\r\n"
+                        + "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+                        + "Accept-Language: en-us,en-gb,en;q=0.7,*;q=0.3\r\n"
+                        + "Accept-Encoding: br,gzip\r\n"
                         + "Connection: Keep-Alive\r\n\r\n");
         metadata.addValue(protocolMDprefix + ProtocolResponse.RESPONSE_IP_KEY, "123.123.123.123");
         Tuple tuple = mock(Tuple.class);


### PR DESCRIPTION
Fixed the following checkstyle issues and increase they severity to error:
 - InvalidJavadocPosition (4)
 - LambdaParameterName (1)
 - TypeName (1)
 - MethodName (4)
 - ParenPad (5)
 - ParameterName (6)
 - OneTopLevelClass (9)

The following checkstyle rules are still kept on warning severity, because there are multiple violations:
- EmptyCatchBlock (11)
- VariableDeclarationUsageDistance (28)
- JavadocParagraph (17)
- MissingJavadocMethod (252)
- MissingJavadocType (90)
- NonEmptyAtclauseDescription (18)
- SummaryJavadoc (87)
- TodoComment (15)
- AbbreviationAsWordInName (250)
- LocalVariableName (23)
- MemberName (23)
- LineLength (73)