### PR TITLE
Fix missing space between block and inline sibling elements in JSoupTextExtractor

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/parse/JSoupTextExtractor.java
+++ b/core/src/main/java/org/apache/stormcrawler/parse/JSoupTextExtractor.java
@@ -139,7 +139,7 @@ public class JSoupTextExtractor implements TextExtractor {
 
                     public void tail(Node node, int depth) {
                         // make sure there is a space between block tags and immediately
-                        // following text nodes <div>One</div>Two should be "One Two".
+                        // following siblings <div>One</div><a>Two</a> should be "One Two".
                         if (node instanceof Element) {
                             Element element = (Element) node;
                             if (element == excluded) {

--- a/core/src/main/java/org/apache/stormcrawler/parse/JSoupTextExtractor.java
+++ b/core/src/main/java/org/apache/stormcrawler/parse/JSoupTextExtractor.java
@@ -146,7 +146,7 @@ public class JSoupTextExtractor implements TextExtractor {
                                 excluded = null;
                             }
                             if (element.isBlock()
-                                    && (node.nextSibling() instanceof TextNode)
+                                    && node.nextSibling() != null
                                     && !lastCharIsWhitespace(accum)) {
                                 accum.append(' ');
                             }

--- a/core/src/test/java/org/apache/stormcrawler/parse/JSoupTextExtractorTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/parse/JSoupTextExtractorTest.java
@@ -68,16 +68,15 @@ class JSoupTextExtractorTest {
     void testBlockFollowedByInlineElement() {
         Config conf = new Config();
         JSoupTextExtractor extractor = new JSoupTextExtractor(conf);
-        // Real-world case from https://www.acai-island.com/contact where
-        // "Email" and the address were concatenated as "Emailacaiisland1300@gmail.com"
+        // block element followed by an inline anchor — see #1925
         String content =
                 "<html><body><div>"
-                        + "<h3>Email</h3>"
-                        + "<a href=\"mailto:acaiisland1300@gmail.com\">acaiisland1300@gmail.com</a>"
+                        + "<h3>Contact</h3>"
+                        + "<a href=\"mailto:info@example.com\">info@example.com</a>"
                         + "</div></body></html>";
         Document jsoupDoc = Parser.htmlParser().parseInput(content, "http://example.com");
         String text = extractor.text(jsoupDoc.body());
-        assertEquals("Email acaiisland1300@gmail.com", text);
+        assertEquals("Contact info@example.com", text);
     }
 
     @Test
@@ -87,11 +86,11 @@ class JSoupTextExtractorTest {
         String content =
                 "<html><body><div>"
                         + "<div>Phone</div>"
-                        + "<span>(631) 656-0088</span>"
+                        + "<span>555-0100</span>"
                         + "</div></body></html>";
         Document jsoupDoc = Parser.htmlParser().parseInput(content, "http://example.com");
         String text = extractor.text(jsoupDoc.body());
-        assertEquals("Phone (631) 656-0088", text);
+        assertEquals("Phone 555-0100", text);
     }
 
     @Test

--- a/core/src/test/java/org/apache/stormcrawler/parse/JSoupTextExtractorTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/parse/JSoupTextExtractorTest.java
@@ -65,6 +65,36 @@ class JSoupTextExtractorTest {
     }
 
     @Test
+    void testBlockFollowedByInlineElement() {
+        Config conf = new Config();
+        JSoupTextExtractor extractor = new JSoupTextExtractor(conf);
+        // Real-world case from https://www.acai-island.com/contact where
+        // "Email" and the address were concatenated as "Emailacaiisland1300@gmail.com"
+        String content =
+                "<html><body><div>"
+                        + "<h3>Email</h3>"
+                        + "<a href=\"mailto:acaiisland1300@gmail.com\">acaiisland1300@gmail.com</a>"
+                        + "</div></body></html>";
+        Document jsoupDoc = Parser.htmlParser().parseInput(content, "http://example.com");
+        String text = extractor.text(jsoupDoc.body());
+        assertEquals("Email acaiisland1300@gmail.com", text);
+    }
+
+    @Test
+    void testBlockFollowedByInlineSpan() {
+        Config conf = new Config();
+        JSoupTextExtractor extractor = new JSoupTextExtractor(conf);
+        String content =
+                "<html><body><div>"
+                        + "<div>Phone</div>"
+                        + "<span>(631) 656-0088</span>"
+                        + "</div></body></html>";
+        Document jsoupDoc = Parser.htmlParser().parseInput(content, "http://example.com");
+        String text = extractor.text(jsoupDoc.body());
+        assertEquals("Phone (631) 656-0088", text);
+    }
+
+    @Test
     void testTrimContent() throws IOException {
         Config conf = new Config();
         List<String> listinc = new LinkedList<>();


### PR DESCRIPTION
Fixes #1925

**Problem**

When a block-level element (e.g. `<h3>`) is immediately followed by an inline element (e.g. `<a>`, `<span>`), the extracted text concatenates both without any space. For instance, this HTML from a real page (https://www.acai-island.com/contact):

```html
<h3>Email</h3>
<a href="mailto:acaiisland1300@gmail.com">acaiisland1300@gmail.com</a>
```

Produces `Emailacaiisland1300@gmail.com` instead of `Email acaiisland1300@gmail.com`.

**Root cause**

In `tail()`, the space after a block element is only appended when `nextSibling() instanceof TextNode`. This misses cases where the next sibling is an inline Element.

**Fix**

Changed the condition to `nextSibling() != null`, so a space is appended after any block element regardless of the sibling type. The existing `lastCharIsWhitespace` guard prevents duplicate spaces.

**Tests**

Added two test cases covering block+inline combinations (`<h3>`+`<a>` and `<div>`+`<span>`).