### PR TITLE
Improve fault tolerance: handle parse errors, fix logging, and minor cleanup  

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/ConfigurableTopology.java
+++ b/core/src/main/java/org/apache/stormcrawler/ConfigurableTopology.java
@@ -30,8 +30,12 @@ import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.utils.Utils;
 import org.apache.stormcrawler.persistence.Status;
 import org.apache.stormcrawler.util.ConfUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class ConfigurableTopology {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigurableTopology.class);
 
     protected Config conf = new Config();
 
@@ -70,7 +74,7 @@ public abstract class ConfigurableTopology {
         try {
             StormSubmitter.submitTopology(name, conf, builder.createTopology());
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.error("Failed to submit topology: {}", name, e);
             return -1;
         }
         return 0;

--- a/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
@@ -364,12 +364,26 @@ public class FetcherBolt extends StatusEmitterBolt {
                 // custom crawl delay from metadata?
                 String v = metadata.getFirstValue(CRAWL_DELAY_KEY_NAME);
                 if (v != null) {
-                    delay = Long.parseLong(v);
+                    try {
+                        delay = Long.parseLong(v);
+                    } catch (NumberFormatException e) {
+                        LOG.warn(
+                                "Invalid crawl delay value '{}' in metadata for queue '{}', using default.",
+                                v,
+                                id);
+                    }
                 }
                 // custom min crawl delay from metadata?
                 v = metadata.getFirstValue(CRAWL_MIN_DELAY_KEY_NAME);
                 if (v != null) {
-                    minDelay = Long.parseLong(v);
+                    try {
+                        minDelay = Long.parseLong(v);
+                    } catch (NumberFormatException e) {
+                        LOG.warn(
+                                "Invalid min crawl delay value '{}' in metadata for queue '{}', using default.",
+                                v,
+                                id);
+                    }
                 }
             }
 
@@ -388,7 +402,14 @@ public class FetcherBolt extends StatusEmitterBolt {
                 if (metadata != null) {
                     final String val = metadata.getFirstValue(CRAWL_MAX_THREAD_KEY_NAME);
                     if (val != null) {
-                        threadVal = Integer.parseInt(val);
+                        try {
+                            threadVal = Integer.parseInt(val);
+                        } catch (NumberFormatException e) {
+                            LOG.warn(
+                                    "Invalid max threads value '{}' in metadata for queue '{}', using default.",
+                                    val,
+                                    id);
+                        }
                     }
                 }
 

--- a/core/src/main/java/org/apache/stormcrawler/filtering/URLFilters.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/URLFilters.java
@@ -210,7 +210,7 @@ public class URLFilters extends URLFilter implements JSONResource {
                 LOG.error("URL filtering threw exception", e);
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("Failed to initialize URLFilters", e);
             System.exit(-1);
         }
         System.exit(0);

--- a/external/aws/src/main/java/org/apache/stormcrawler/aws/bolt/CloudSearchUtils.java
+++ b/external/aws/src/main/java/org/apache/stormcrawler/aws/bolt/CloudSearchUtils.java
@@ -18,26 +18,14 @@
 package org.apache.stormcrawler.aws.bolt;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 import java.util.regex.Pattern;
-import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
 
 public class CloudSearchUtils {
 
-    private static MessageDigest digester;
-
     private static final Pattern INVALID_XML_CHARS =
             Pattern.compile("[^\\t\\n\\r -\\uD7FF\\uE000-\\uFFFD]");
-
-    static {
-        try {
-            digester = MessageDigest.getInstance("SHA-512");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     private CloudSearchUtils() {}
 
@@ -51,8 +39,7 @@ public class CloudSearchUtils {
         // letter or number and the following characters: _ - = # ; : / ? @
         // &. Document IDs must be at least 1 and no more than 128
         // characters long.
-        byte[] dig = digester.digest(url.getBytes(StandardCharsets.UTF_8));
-        String ID = Hex.encodeHexString(dig);
+        String ID = DigestUtils.sha512Hex(url.getBytes(StandardCharsets.UTF_8));
         // is that even possible?
         if (ID.length() > 128) {
             throw new RuntimeException("ID larger than max 128 chars");
@@ -81,7 +68,7 @@ public class CloudSearchUtils {
             throw new RuntimeException("Field name must be between 3 and 64 chars : " + lowercase);
         }
         if (lowercase.equals("score")) {
-            throw new RuntimeException("Field name must be score");
+            throw new RuntimeException("Field name must NOT be score");
         }
         return lowercase;
     }

--- a/external/aws/src/main/java/org/apache/stormcrawler/aws/s3/S3CacheChecker.java
+++ b/external/aws/src/main/java/org/apache/stormcrawler/aws/s3/S3CacheChecker.java
@@ -19,7 +19,6 @@ package org.apache.stormcrawler.aws.s3;
 
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.S3Object;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
@@ -65,12 +64,7 @@ public class S3CacheChecker extends AbstractS3CacheBolt {
         Metadata metadata = (Metadata) tuple.getValueByField("metadata");
 
         // normalises URL
-        String key = "";
-        try {
-            key = URLEncoder.encode(url, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            // ignore it - we know UTF-8 is valid
-        }
+        String key = URLEncoder.encode(url, java.nio.charset.StandardCharsets.UTF_8);
         // check size of the key
         if (key.length() >= 1024) {
             LOG.info("Key too large : {}", key);

--- a/external/aws/src/main/java/org/apache/stormcrawler/aws/s3/S3Cacher.java
+++ b/external/aws/src/main/java/org/apache/stormcrawler/aws/s3/S3Cacher.java
@@ -22,7 +22,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Map;
 import org.apache.storm.task.OutputCollector;
@@ -94,12 +93,7 @@ public abstract class S3Cacher extends AbstractS3CacheBolt {
         }
 
         // normalises URL
-        String key = "";
-        try {
-            key = URLEncoder.encode(url, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            // ignore it - we know UTF-8 is valid
-        }
+        String key = URLEncoder.encode(url, java.nio.charset.StandardCharsets.UTF_8);
         // check size of the key
         if (key.length() >= 1024) {
             LOG.info("Key too large : {}", key);

--- a/external/playwright/src/main/java/org/apache/stormcrawler/protocol/playwright/parsefilter/JsRenderingDetector.java
+++ b/external/playwright/src/main/java/org/apache/stormcrawler/protocol/playwright/parsefilter/JsRenderingDetector.java
@@ -28,6 +28,7 @@ import org.apache.stormcrawler.parse.ParseData;
 import org.apache.stormcrawler.parse.ParseFilter;
 import org.apache.stormcrawler.parse.ParseResult;
 import org.apache.stormcrawler.protocol.playwright.HttpProtocol;
+import org.apache.stormcrawler.util.CharsetIdentification;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.DocumentFragment;
@@ -221,7 +222,15 @@ public class JsRenderingDetector extends ParseFilter {
     }
 
     private String detectReason(final String url, final byte[] content, final ParseResult parse) {
-        final String html = new String(content, StandardCharsets.UTF_8);
+        final Metadata md = parse.get(url).getMetadata();
+        final String charsetName = CharsetIdentification.getCharsetFast(md, content, -1);
+        java.nio.charset.Charset cs;
+        try {
+            cs = java.nio.charset.Charset.forName(charsetName);
+        } catch (Exception e) {
+            cs = StandardCharsets.UTF_8;
+        }
+        final String html = new String(content, cs);
 
         // 1. SPA framework fingerprints
         for (final String fp : fingerprints) {


### PR DESCRIPTION
A collection of small but concrete correctness and robustness improvements.  
  
- `FetcherBolt`: catch `NumberFormatException` when parsing crawl delay and  
  max thread values from metadata; log a warning and fall back to defaults  
  instead of crashing the bolt  
- `ConfigurableTopology`, `URLFilters`: replace `e.printStackTrace()` with  
  proper SLF4J `LOG.error()` calls  
- `CloudSearchUtils`: fix misleading error message ("must be score" →  
  "must NOT be score"); replace manual `MessageDigest` boilerplate with  
  `DigestUtils.sha512Hex()`  
- `S3CacheChecker`, `S3Cacher`: use the `StandardCharsets.UTF_8` overload of  
  `URLEncoder.encode()` to remove an unnecessary checked exception  
- `JsRenderingDetector`: use `CharsetIdentification.getCharsetFast()` to  
  detect the actual document charset instead of hardcoding UTF-8