### PR TITLE
Add AGENTS.md + SECURITY.md pointing to the security model (scanner discoverability)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+## Security
+
+See the [Apache StormCrawler Security Model](https://stormcrawler.apache.org/security/) for the project's
+threat model, trust boundaries, in-scope / out-of-scope declarations, and known non-findings before
+reporting security issues. See also [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+For the assumptions, trust boundaries, scope, and what Apache StormCrawler considers a security
+vulnerability, see the **[Apache StormCrawler Security Model](https://stormcrawler.apache.org/security/)**.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately following the
+[ASF security process](https://www.apache.org/security/) — email
+[security@apache.org](mailto:security@apache.org). Do not open public GitHub issues for security reports.

--- a/pom.xml
+++ b/pom.xml
@@ -558,6 +558,8 @@ under the License.
                                 <exclude>NOTICE</exclude>
                                 <exclude>CONTRIBUTING.md</exclude>
                                 <exclude>RELEASING.md</exclude>
+                                <exclude>AGENTS.md</exclude>
+                                <exclude>SECURITY.md</exclude>
                                 <exclude>external/opensearch/dashboards/**</exclude>
                                 <exclude>external/solr/archetype/src/main/resources/archetype-resources/configsets/**</exclude>
                                 <exclude>THIRD-PARTY.properties</exclude>


### PR DESCRIPTION
Adds an `AGENTS.md` and `SECURITY.md` at the repo root, both pointing to the existing [Apache StormCrawler Security Model](https://stormcrawler.apache.org/security/), so automated security scanners (and researchers) can mechanically discover the project's threat model via the standard `AGENTS.md` -> `SECURITY.md` -> model chain.

Also adds `AGENTS.md` and `SECURITY.md` to the `apache-rat-plugin` excludes in `pom.xml`, matching the existing treatment of `CONTRIBUTING.md` / `RELEASING.md`.

No code or behaviour changes — documentation/metadata only. This is a proposal for the PMC to review; please adjust or reject as needed.