### PR TITLE
#1938 - Migrate AWS Java SDK from 1.x to 2.x (#1938)

### DIFF
--- a/docs/src/main/asciidoc/configuration.adoc
+++ b/docs/src/main/asciidoc/configuration.adoc
@@ -458,6 +458,7 @@ See the link:https://github.com/apache/stormcrawler/tree/main/external/aws[aws m
 | s3.region | - | AWS region for S3 operations.
 | s3.bucket | - | S3 bucket name for content caching.
 | s3.endpoint | - | Custom S3 endpoint (optional, for S3-compatible services).
+| s3.path.style.access | false | Use path-style access (`http://host/bucket`) instead of virtual-hosted style. Required for S3-compatible endpoints such as LocalStack or MinIO.
 |===
 
 ==== AI (LLM Text Extraction)

--- a/external/aws/README.md
+++ b/external/aws/README.md
@@ -3,6 +3,8 @@
 
 AWS resources for StormCrawler, currently contains an indexer bolt for [CloudSearch](https://aws.amazon.com/cloudsearch/) and another bolt for storing and retrieving web pages to/from [S3](https://aws.amazon.com/s3/).
 
+This module is built on the [AWS SDK for Java 2.x](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/home.html). Credentials are resolved through the SDK's [default credentials provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html) (environment variables, Java system properties, `~/.aws/credentials`, container/instance profiles, etc.).
+
 ## Prerequisites
 
 Add stormcrawler-aws to the dependencies of your project\:
@@ -55,5 +57,18 @@ Any fields not defined in the CloudSearch domain will be ignored by the CloudSea
 ## S3
 
 Add `S3ContentCacher` or `S3CacheChecker` to your crawl topology.
+
+* Configuration
+
+| key | default | description |
+| --- | --- | --- |
+| `s3.bucket` | - | S3 bucket name used for content caching. The bucket must already exist. |
+| `s3.region` | - | AWS region for S3 operations. |
+| `s3.endpoint` | - | Custom S3 endpoint (optional, for S3-compatible services). |
+| `s3.path.style.access` | `false` | Use path-style access (`http://host/bucket`) instead of virtual-hosted style. Required for S3-compatible endpoints such as LocalStack or MinIO. |
+
+## Testing
+
+The S3 bolts are covered by integration tests that run against [LocalStack](https://localstack.cloud/) via [Testcontainers](https://www.testcontainers.org/), so a running Docker daemon is required. Tests are skipped automatically when Docker is not available.
 
 

--- a/external/aws/aws-conf.yaml
+++ b/external/aws/aws-conf.yaml
@@ -42,4 +42,9 @@ s3.bucket: "crawl"
 
 # s3.endpoint: ""
 
+# enable path-style access (http://host/bucket) instead of the default
+# virtual-hosted style (http://bucket.host). Required for S3-compatible
+# endpoints such as LocalStack or MinIO.
+# s3.path.style.access: false
+
 

--- a/external/aws/pom.xml
+++ b/external/aws/pom.xml
@@ -37,20 +37,67 @@ under the License.
     <description>AWS resources for StormCrawler</description>
 
     <properties>
-        <aws.version>1.12.797</aws.version>
+        <aws.version>2.46.7</aws.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-cloudsearch</artifactId>
-            <version>${aws.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudsearch</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>${aws.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudsearchdomain</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.stormcrawler</groupId>
+            <artifactId>stormcrawler-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/external/aws/pom.xml
+++ b/external/aws/pom.xml
@@ -81,12 +81,6 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>

--- a/external/aws/src/main/java/org/apache/stormcrawler/aws/bolt/CloudSearchIndexerBolt.java
+++ b/external/aws/src/main/java/org/apache/stormcrawler/aws/bolt/CloudSearchIndexerBolt.java
@@ -19,26 +19,12 @@ package org.apache.stormcrawler.aws.bolt;
 
 import static org.apache.stormcrawler.Constants.StatusStreamName;
 
-import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.services.cloudsearchdomain.AmazonCloudSearchDomainClient;
-import com.amazonaws.services.cloudsearchdomain.model.ContentType;
-import com.amazonaws.services.cloudsearchdomain.model.DocumentServiceWarning;
-import com.amazonaws.services.cloudsearchdomain.model.UploadDocumentsRequest;
-import com.amazonaws.services.cloudsearchdomain.model.UploadDocumentsResult;
-import com.amazonaws.services.cloudsearchv2.AmazonCloudSearchClient;
-import com.amazonaws.services.cloudsearchv2.model.DescribeDomainsRequest;
-import com.amazonaws.services.cloudsearchv2.model.DescribeDomainsResult;
-import com.amazonaws.services.cloudsearchv2.model.DescribeIndexFieldsRequest;
-import com.amazonaws.services.cloudsearchv2.model.DescribeIndexFieldsResult;
-import com.amazonaws.services.cloudsearchv2.model.DomainStatus;
-import com.amazonaws.services.cloudsearchv2.model.IndexFieldStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.ParseException;
@@ -65,6 +51,20 @@ import org.apache.stormcrawler.persistence.Status;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudsearch.CloudSearchClient;
+import software.amazon.awssdk.services.cloudsearch.model.DescribeDomainsRequest;
+import software.amazon.awssdk.services.cloudsearch.model.DescribeDomainsResponse;
+import software.amazon.awssdk.services.cloudsearch.model.DescribeIndexFieldsRequest;
+import software.amazon.awssdk.services.cloudsearch.model.DescribeIndexFieldsResponse;
+import software.amazon.awssdk.services.cloudsearch.model.DomainStatus;
+import software.amazon.awssdk.services.cloudsearch.model.IndexFieldStatus;
+import software.amazon.awssdk.services.cloudsearchdomain.CloudSearchDomainClient;
+import software.amazon.awssdk.services.cloudsearchdomain.model.ContentType;
+import software.amazon.awssdk.services.cloudsearchdomain.model.DocumentServiceWarning;
+import software.amazon.awssdk.services.cloudsearchdomain.model.UploadDocumentsRequest;
+import software.amazon.awssdk.services.cloudsearchdomain.model.UploadDocumentsResponse;
 
 /** Writes documents to CloudSearch. */
 public class CloudSearchIndexerBolt extends AbstractIndexerBolt {
@@ -77,7 +77,7 @@ public class CloudSearchIndexerBolt extends AbstractIndexerBolt {
     private static final SimpleDateFormat DATE_FORMAT =
             new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT);
 
-    private AmazonCloudSearchDomainClient client;
+    private CloudSearchDomainClient client;
 
     private int maxDocsInBatch = -1;
 
@@ -132,38 +132,44 @@ public class CloudSearchIndexerBolt extends AbstractIndexerBolt {
 
         String regionName = ConfUtils.getString(conf, CloudSearchConstants.REGION);
 
-        AmazonCloudSearchClient cl = new AmazonCloudSearchClient();
-        if (StringUtils.isNotBlank(regionName)) {
-            cl.setRegion(RegionUtils.getRegion(regionName));
-        }
-
         String domainName = null;
 
-        // retrieve the domain name
-        DescribeDomainsResult domains = cl.describeDomains(new DescribeDomainsRequest());
+        var clBuilder = CloudSearchClient.builder();
+        if (StringUtils.isNotBlank(regionName)) {
+            clBuilder.region(Region.of(regionName));
+        }
+        try (CloudSearchClient cl = clBuilder.build()) {
+            // retrieve the domain name
+            DescribeDomainsResponse domains =
+                    cl.describeDomains(DescribeDomainsRequest.builder().build());
 
-        for (DomainStatus ds : domains.getDomainStatusList()) {
-            if (ds.getDocService().getEndpoint().equals(endpoint)) {
-                domainName = ds.getDomainName();
-                break;
+            for (DomainStatus ds : domains.domainStatusList()) {
+                if (ds.docService().endpoint().equals(endpoint)) {
+                    domainName = ds.domainName();
+                    break;
+                }
+            }
+            // check domain name
+            if (StringUtils.isBlank(domainName)) {
+                throw new RuntimeException("No domain name found for CloudSearch endpoint");
+            }
+
+            DescribeIndexFieldsResponse indexDescription =
+                    cl.describeIndexFields(
+                            DescribeIndexFieldsRequest.builder().domainName(domainName).build());
+            for (IndexFieldStatus ifs : indexDescription.indexFields()) {
+                String indexname = ifs.options().indexFieldName();
+                String indextype = ifs.options().indexFieldTypeAsString();
+                LOG.info("CloudSearch index name {} of type {}", indexname, indextype);
+                csfields.put(indexname, indextype);
             }
         }
-        // check domain name
-        if (StringUtils.isBlank(domainName)) {
-            throw new RuntimeException("No domain name found for CloudSearch endpoint");
-        }
 
-        DescribeIndexFieldsResult indexDescription =
-                cl.describeIndexFields(new DescribeIndexFieldsRequest().withDomainName(domainName));
-        for (IndexFieldStatus ifs : indexDescription.getIndexFields()) {
-            String indexname = ifs.getOptions().getIndexFieldName();
-            String indextype = ifs.getOptions().getIndexFieldType();
-            LOG.info("CloudSearch index name {} of type {}", indexname, indextype);
-            csfields.put(indexname, indextype);
+        var builder = CloudSearchDomainClient.builder().endpointOverride(URI.create(endpoint));
+        if (StringUtils.isNotBlank(regionName)) {
+            builder.region(Region.of(regionName));
         }
-
-        client = new AmazonCloudSearchDomainClient();
-        client.setEndpoint(endpoint);
+        client = builder.build();
     }
 
     @Override
@@ -382,20 +388,22 @@ public class CloudSearchIndexerBolt extends AbstractIndexerBolt {
             return;
         }
         // not in debug mode
-        try (InputStream inputStream = new ByteArrayInputStream(bb)) {
-            UploadDocumentsRequest batch = new UploadDocumentsRequest();
-            batch.setContentLength((long) bb.length);
-            batch.setContentType(ContentType.Applicationjson);
-            batch.setDocuments(inputStream);
-            UploadDocumentsResult result = client.uploadDocuments(batch);
-            LOG.info(result.getStatus());
-            for (DocumentServiceWarning warning : result.getWarnings()) {
-                LOG.info(warning.getMessage());
+        try {
+            UploadDocumentsRequest batch =
+                    UploadDocumentsRequest.builder()
+                            .contentLength((long) bb.length)
+                            .contentType(ContentType.APPLICATION_JSON)
+                            .build();
+            UploadDocumentsResponse result =
+                    client.uploadDocuments(batch, RequestBody.fromBytes(bb));
+            LOG.info(result.status());
+            for (DocumentServiceWarning warning : result.warnings()) {
+                LOG.info(warning.message());
             }
-            if (!result.getWarnings().isEmpty()) {
-                eventCounter.scope("Warnings").incrBy(result.getWarnings().size());
+            if (!result.warnings().isEmpty()) {
+                eventCounter.scope("Warnings").incrBy(result.warnings().size());
             }
-            eventCounter.scope("Added").incrBy(result.getAdds());
+            eventCounter.scope("Added").incrBy(result.adds());
             // ack the tuples
             for (Tuple t : unacked) {
                 String url = t.getStringByField("url");
@@ -423,7 +431,9 @@ public class CloudSearchIndexerBolt extends AbstractIndexerBolt {
     public void cleanup() {
         // This will flush any unsent documents.
         sendBatch();
-        client.shutdown();
+        if (client != null) {
+            client.close();
+        }
     }
 
     @Override

--- a/external/aws/src/main/java/org/apache/stormcrawler/aws/s3/AbstractS3CacheBolt.java
+++ b/external/aws/src/main/java/org/apache/stormcrawler/aws/s3/AbstractS3CacheBolt.java
@@ -17,12 +17,7 @@
 
 package org.apache.stormcrawler.aws.s3;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.services.s3.AmazonS3Client;
+import java.net.URI;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.storm.task.OutputCollector;
@@ -32,6 +27,12 @@ import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Fields;
 import org.apache.stormcrawler.metrics.ScopedCounter;
 import org.apache.stormcrawler.util.ConfUtils;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 
 public abstract class AbstractS3CacheBolt extends BaseRichBolt {
 
@@ -42,33 +43,52 @@ public abstract class AbstractS3CacheBolt extends BaseRichBolt {
     // is the region needed?
     public static final String REGION = S3_PREFIX + "region";
 
+    /**
+     * Enables path-style access ({@code http://host/bucket}) instead of the default virtual-hosted
+     * style ({@code http://bucket.host}). Useful when targeting a non-AWS S3 endpoint such as
+     * LocalStack or MinIO.
+     */
+    public static final String PATH_STYLE_ACCESS = S3_PREFIX + "path.style.access";
+
     public static final String INCACHE = S3_PREFIX + "inCache";
 
     protected OutputCollector _collector;
     protected ScopedCounter eventCounter;
 
-    protected AmazonS3Client client;
+    protected S3Client client;
 
     protected String bucketName;
 
     /** Returns an S3 client given the configuration * */
-    public static AmazonS3Client getS3Client(Map<String, Object> conf) {
-        AWSCredentialsProvider provider = new DefaultAWSCredentialsProviderChain();
-        AWSCredentials credentials = provider.getCredentials();
-        ClientConfiguration config = new ClientConfiguration();
-
-        AmazonS3Client client = new AmazonS3Client(credentials, config);
+    public static S3Client getS3Client(Map<String, Object> conf) {
+        S3ClientBuilder builder =
+                S3Client.builder().credentialsProvider(DefaultCredentialsProvider.create());
 
         String regionName = ConfUtils.getString(conf, REGION);
         if (StringUtils.isNotBlank(regionName)) {
-            client.setRegion(RegionUtils.getRegion(regionName));
+            builder.region(Region.of(regionName));
         }
 
         String endpoint = ConfUtils.getString(conf, ENDPOINT);
         if (StringUtils.isNotBlank(endpoint)) {
-            client.setEndpoint(endpoint);
+            builder.endpointOverride(URI.create(endpoint));
         }
-        return client;
+
+        if (ConfUtils.getBoolean(conf, PATH_STYLE_ACCESS, false)) {
+            builder.forcePathStyle(true);
+        }
+
+        return builder.build();
+    }
+
+    /** Checks whether the given bucket exists and is accessible. */
+    protected boolean doesBucketExist(String bucket) {
+        try {
+            client.headBucket(HeadBucketRequest.builder().bucket(bucket).build());
+            return true;
+        } catch (NoSuchBucketException e) {
+            return false;
+        }
     }
 
     @Override

--- a/external/aws/src/main/java/org/apache/stormcrawler/aws/s3/S3CacheChecker.java
+++ b/external/aws/src/main/java/org/apache/stormcrawler/aws/s3/S3CacheChecker.java
@@ -17,8 +17,7 @@
 
 package org.apache.stormcrawler.aws.s3;
 
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.S3Object;
+import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
@@ -33,6 +32,11 @@ import org.apache.stormcrawler.metrics.CrawlerMetrics;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 /**
  * Checks whether a URL can be found in the cache, if not delegate to the following bolt e.g.
@@ -50,7 +54,7 @@ public class S3CacheChecker extends AbstractS3CacheBolt {
         super.prepare(conf, context, collector);
         bucketName = ConfUtils.getString(conf, BUCKET);
 
-        boolean bucketExists = client.doesBucketExist(bucketName);
+        boolean bucketExists = doesBucketExist(bucketName);
         if (!bucketExists) {
             String message = "Bucket " + bucketName + " does not exist";
             throw new RuntimeException(message);
@@ -76,32 +80,30 @@ public class S3CacheChecker extends AbstractS3CacheBolt {
         }
 
         long preCacheQueryTime = System.currentTimeMillis();
-        S3Object obj = null;
-        try {
-            obj = client.getObject(bucketName, key);
-        } catch (AmazonS3Exception e) {
+        byte[] content = null;
+        try (ResponseInputStream<GetObjectResponse> obj =
+                client.getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build())) {
+            content = IOUtils.toByteArray(obj);
+        } catch (NoSuchKeyException e) {
             eventCounter.scope("result_misses").incrBy(1);
             // key does not exist?
             // no need for logging
+        } catch (S3Exception | IOException e) {
+            eventCounter.scope("result.exception").incrBy(1);
+            LOG.error("Exception when fetching from S3 cache", e);
         }
         long postCacheQueryTime = System.currentTimeMillis();
         LOG.debug("Queried S3 cache in {} msec", (postCacheQueryTime - preCacheQueryTime));
 
-        if (obj != null) {
-            try {
-                byte[] content = IOUtils.toByteArray(obj.getObjectContent());
-                eventCounter.scope("result_hits").incrBy(1);
-                eventCounter.scope("bytes_fetched").incrBy(content.length);
+        if (content != null) {
+            eventCounter.scope("result_hits").incrBy(1);
+            eventCounter.scope("bytes_fetched").incrBy(content.length);
 
-                metadata.setValue(INCACHE, "true");
+            metadata.setValue(INCACHE, "true");
 
-                _collector.emit(CACHE_STREAM, tuple, new Values(url, content, metadata));
-                _collector.ack(tuple);
-                return;
-            } catch (Exception e) {
-                eventCounter.scope("result.exception").incrBy(1);
-                LOG.error("IOException when extracting byte array", e);
-            }
+            _collector.emit(CACHE_STREAM, tuple, new Values(url, content, metadata));
+            _collector.ack(tuple);
+            return;
         }
 
         _collector.emit(tuple, new Values(url, metadata));

--- a/external/aws/src/main/java/org/apache/stormcrawler/aws/s3/S3Cacher.java
+++ b/external/aws/src/main/java/org/apache/stormcrawler/aws/s3/S3Cacher.java
@@ -17,11 +17,6 @@
 
 package org.apache.stormcrawler.aws.s3;
 
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectResult;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.Map;
 import org.apache.storm.task.OutputCollector;
@@ -33,6 +28,10 @@ import org.apache.stormcrawler.metrics.CrawlerMetrics;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.StorageClass;
 
 /** Stores binary content into Amazon S3. The credentials must be stored in ~/.aws/credentials */
 public abstract class S3Cacher extends AbstractS3CacheBolt {
@@ -54,7 +53,7 @@ public abstract class S3Cacher extends AbstractS3CacheBolt {
 
         bucketName = ConfUtils.getString(conf, BUCKET);
 
-        boolean bucketExists = client.doesBucketExist(bucketName);
+        boolean bucketExists = doesBucketExist(bucketName);
         if (!bucketExists) {
             String message = "Bucket " + bucketName + " does not exist";
             throw new RuntimeException(message);
@@ -104,25 +103,20 @@ public abstract class S3Cacher extends AbstractS3CacheBolt {
             return;
         }
 
-        ByteArrayInputStream input = new ByteArrayInputStream(contentToCache);
-
-        ObjectMetadata md = new ObjectMetadata();
-        md.setContentLength(contentToCache.length);
-        md.setHeader("x-amz-storage-class", "STANDARD_IA");
+        PutObjectRequest request =
+                PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(getKeyPrefix() + key)
+                        .storageClass(StorageClass.STANDARD_IA)
+                        .build();
 
         try {
-            PutObjectResult result = client.putObject(bucketName, getKeyPrefix() + key, input, md);
+            client.putObject(request, RequestBody.fromBytes(contentToCache));
             eventCounter.scope("cached").incr();
             // TODO check something with the result?
-        } catch (AmazonS3Exception exception) {
-            LOG.error("AmazonS3Exception while storing {}", url, exception);
+        } catch (S3Exception exception) {
+            LOG.error("S3Exception while storing {}", url, exception);
             eventCounter.scope("s3_exception").incr();
-        } finally {
-            try {
-                input.close();
-            } catch (IOException e) {
-                LOG.error("Error while closing ByteArrayInputStream", e);
-            }
         }
 
         _collector.emit(tuple, new Values(url, content, metadata));

--- a/external/aws/src/test/java/org/apache/stormcrawler/aws/s3/S3CacheBoltTest.java
+++ b/external/aws/src/test/java/org/apache/stormcrawler/aws/s3/S3CacheBoltTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.aws.s3;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.tuple.Tuple;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.TestOutputCollector;
+import org.apache.stormcrawler.TestUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+@Testcontainers(disabledWithoutDocker = true)
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class S3CacheBoltTest {
+
+    private static final DockerImageName IMAGE =
+            DockerImageName.parse("localstack/localstack:3.8.1");
+
+    @Container
+    static LocalStackContainer localstack =
+            new LocalStackContainer(IMAGE).withServices(LocalStackContainer.Service.S3);
+
+    private static final String BUCKET = "sc-cache";
+
+    private TestOutputCollector output;
+
+    @BeforeAll
+    static void beforeAll() {
+        // The bolts resolve credentials through the default provider chain; expose the LocalStack
+        // ones as Java system properties so that chain picks them up.
+        System.setProperty("aws.accessKeyId", localstack.getAccessKey());
+        System.setProperty("aws.secretAccessKey", localstack.getSecretKey());
+
+        try (S3Client admin = AbstractS3CacheBolt.getS3Client(conf())) {
+            admin.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
+        }
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.clearProperty("aws.accessKeyId");
+        System.clearProperty("aws.secretAccessKey");
+    }
+
+    @BeforeEach
+    void setup() {
+        output = new TestOutputCollector();
+    }
+
+    private static Map<String, Object> conf() {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(AbstractS3CacheBolt.ENDPOINT, localstack.getEndpoint().toString());
+        conf.put(AbstractS3CacheBolt.REGION, localstack.getRegion());
+        conf.put(AbstractS3CacheBolt.BUCKET, BUCKET);
+        // LocalStack is reached through a host/port endpoint, so path-style access is required.
+        conf.put(AbstractS3CacheBolt.PATH_STYLE_ACCESS, true);
+        return conf;
+    }
+
+    private Tuple cacherTuple(String url, byte[] content, Metadata metadata) {
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getBinaryByField("content")).thenReturn(content);
+        when(tuple.getStringByField("url")).thenReturn(url);
+        when(tuple.getValueByField("metadata")).thenReturn(metadata);
+        return tuple;
+    }
+
+    private Tuple checkerTuple(String url, Metadata metadata) {
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getStringByField("url")).thenReturn(url);
+        when(tuple.getValueByField("metadata")).thenReturn(metadata);
+        return tuple;
+    }
+
+    @Test
+    void storesAndRetrievesContent() {
+        String url = "https://www.example.com/some/page";
+        byte[] content = "the cached body".getBytes(StandardCharsets.UTF_8);
+
+        // store the content in S3
+        S3ContentCacher cacher = new S3ContentCacher();
+        cacher.prepare(conf(), TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+        cacher.execute(cacherTuple(url, content, new Metadata()));
+
+        assertEquals(1, output.getAckedTuples().size());
+
+        // retrieve it again through the checker
+        TestOutputCollector checkerOutput = new TestOutputCollector();
+        S3CacheChecker checker = new S3CacheChecker();
+        checker.prepare(
+                conf(), TestUtil.getMockedTopologyContext(), new OutputCollector(checkerOutput));
+
+        Metadata metadata = new Metadata();
+        checker.execute(checkerTuple(url, metadata));
+
+        assertEquals(1, checkerOutput.getAckedTuples().size());
+
+        List<List<Object>> cached = checkerOutput.getEmitted(S3CacheChecker.CACHE_STREAM);
+        assertEquals(1, cached.size());
+        assertArrayEquals(content, (byte[]) cached.get(0).get(1));
+        assertEquals("true", metadata.getFirstValue(AbstractS3CacheBolt.INCACHE));
+    }
+
+    @Test
+    void missingKeyIsForwardedDownstream() {
+        S3CacheChecker checker = new S3CacheChecker();
+        checker.prepare(conf(), TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+
+        Metadata metadata = new Metadata();
+        checker.execute(checkerTuple("https://www.example.com/never-cached", metadata));
+
+        assertEquals(1, output.getAckedTuples().size());
+        // forwarded on the default stream, not the cache stream
+        assertEquals(1, output.getEmitted().size());
+        assertEquals(0, output.getEmitted(S3CacheChecker.CACHE_STREAM).size());
+    }
+
+    @Test
+    void prepareFailsWhenBucketIsMissing() {
+        Map<String, Object> conf = conf();
+        conf.put(AbstractS3CacheBolt.BUCKET, "does-not-exist");
+
+        S3CacheChecker checker = new S3CacheChecker();
+        assertThrows(
+                RuntimeException.class,
+                () ->
+                        checker.prepare(
+                                conf,
+                                TestUtil.getMockedTopologyContext(),
+                                new OutputCollector(output)));
+    }
+}


### PR DESCRIPTION
Migrates the `external/aws` module from the AWS Java SDK 1.x (EOL 2025-12-31) to the AWS SDK for Java 2.x, covering the S3 cache bolts and the CloudSearch indexer bolt. Adds a new optional `s3.path.style.access` config (for S3-compatible endpoints like LocalStack/MinIO) and LocalStack/Testcontainers integration tests for the S3 bolts. Updates the module README, `aws-conf.yaml` and the configuration docs accordingly.

Note: `THIRD-PARTY.txt` still references the old v1 artifacts — left to the usual post-merge license regeneration. CloudSearch is not covered by container tests since LocalStack does not support it.

Closes #1938
