### PR TITLE
#466 - Handle text/plain content in JSoupParserBolt

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/bolt/JSoupParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/JSoupParserBolt.java
@@ -116,6 +116,19 @@ public class JSoupParserBolt extends StatusEmitterBolt {
 
     private TextExtractor textExtractor;
 
+    /**
+     * Honor {@link TextExtractor#NO_TEXT_PARAM_NAME} on the text/plain path. No extractor is
+     * invoked there, so the value is read directly.
+     */
+    private boolean plainTextNoText;
+
+    /**
+     * Character cap for stored plain text, read from {@link TextExtractor#TEXT_MAX_TEXT_PARAM_NAME}
+     * ({@code -1} = unbounded). Bounds the emitted text only; the raw fetched size is bounded by
+     * {@code http.content.limit}.
+     */
+    private int plainTextMaxSize;
+
     private String protocolMetadataPrefix;
 
     private boolean robotsHeaderSkip;
@@ -188,6 +201,12 @@ public class JSoupParserBolt extends StatusEmitterBolt {
             LOG.warn("Cannot instantiazr textextractor.class '{}'.", clazz, e);
             throw new RuntimeException(e);
         }
+
+        // The text/plain path does not run the TextExtractor (there is no markup to
+        // extract from), so the two size-related knobs are read here and applied
+        // directly. The include/exclude knobs require markup and have no effect.
+        plainTextNoText = ConfUtils.getBoolean(conf, TextExtractor.NO_TEXT_PARAM_NAME, false);
+        plainTextMaxSize = ConfUtils.getInt(conf, TextExtractor.TEXT_MAX_TEXT_PARAM_NAME, -1);
     }
 
     @Override
@@ -202,6 +221,10 @@ public class JSoupParserBolt extends StatusEmitterBolt {
         // check that its content type is HTML
         // look at value found in HTTP headers
         boolean contentTypeIsOk = false;
+
+        // text/plain content needs no markup parsing: the decoded bytes are
+        // the text, there are no outlinks (see issue #466)
+        boolean isPlainText = false;
 
         String mimeType =
                 metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, this.protocolMetadataPrefix);
@@ -219,8 +242,12 @@ public class JSoupParserBolt extends StatusEmitterBolt {
         }
 
         if (StringUtils.isNotBlank(mimeType)) {
-            if (mimeType.toLowerCase(Locale.ROOT).contains("html")) {
+            final String lcMimeType = mimeType.toLowerCase(Locale.ROOT);
+            if (lcMimeType.contains("html")) {
                 contentTypeIsOk = true;
+            } else if (lcMimeType.contains("text/plain")) {
+                contentTypeIsOk = true;
+                isPlainText = true;
             }
         } else {
             // go ahead even if no mimetype is available
@@ -272,79 +299,100 @@ public class JSoupParserBolt extends StatusEmitterBolt {
         try {
             String html = Charset.forName(charset).decode(ByteBuffer.wrap(content)).toString();
 
-            jsoupDoc = Parser.htmlParser().parseInput(html, url);
-
-            if (!robotsMetaSkip) {
-                // extracts the robots directives from the meta tags
-                Element robotelement = jsoupDoc.selectFirst("meta[name~=(?i)robots][content]");
-                if (robotelement != null) {
-                    robotsTags.extractMetaTags(robotelement.attr("content"));
-                }
-            }
-
-            // store a normalised representation in metadata
-            // so that the indexer is aware of it
-            robotsTags.normaliseToMetadata(metadata);
-
-            // do not extract the links if no follow has been set
-            // and we are in strict mode
-            if (robotsTags.isNoFollow() && robotsNoFollowStrict) {
+            if (isPlainText) {
+                // no markup to parse: the decoded content is the text itself and
+                // there are no outlinks. An empty shell document is kept so that
+                // the downstream redirection check and parse filters still work.
+                jsoupDoc = org.jsoup.nodes.Document.createShell(url);
                 slinks = new HashMap<>(0);
+                robotsTags.normaliseToMetadata(metadata);
+                // the decoded content is the text; bound it the same way the
+                // TextExtractor would (no.text / skip.after) while preserving the
+                // original layout, which is the whole point of a .txt
+                if (plainTextNoText) {
+                    text = "";
+                } else if (plainTextMaxSize > 0 && html.length() > plainTextMaxSize) {
+                    text = html.substring(0, plainTextMaxSize);
+                } else {
+                    text = html;
+                }
             } else {
-                final Elements links = jsoupDoc.select("a[href]");
-                slinks = new HashMap<>(links.size());
-                final URL baseUrl = URLUtil.toURL(url);
-                for (Element link : links) {
-                    // nofollow
-                    String[] relkeywords = link.attr("rel").split(" ");
-                    boolean noFollow =
-                            Stream.of(relkeywords).anyMatch(x -> x.equalsIgnoreCase("nofollow"));
+                jsoupDoc = Parser.htmlParser().parseInput(html, url);
 
-                    // remove altogether
-                    if (noFollow && robotsNoFollowStrict) {
-                        continue;
-                    }
-
-                    // link not specifically marked as no follow
-                    // but whole page is
-                    if (!noFollow && robotsTags.isNoFollow()) {
-                        noFollow = true;
-                    }
-
-                    String targetUrl = null;
-
-                    try {
-                        // abs:href tells jsoup to return fully qualified domains
-                        // for relative urls
-                        // but it is very slow as it builds intermediate URL objects
-                        // and normalises the URL of the document every time
-                        targetUrl = URLUtil.resolveUrl(baseUrl, link.attr("href")).toExternalForm();
-                    } catch (MalformedURLException e) {
-                        LOG.debug(
-                                "Cannot resolve URL with baseURL : {} and href : {}",
-                                baseUrl,
-                                link.attr("href"),
-                                e);
-                    }
-
-                    if (StringUtils.isBlank(targetUrl)) {
-                        continue;
-                    }
-
-                    final List<String> anchors =
-                            slinks.computeIfAbsent(targetUrl, a -> new LinkedList<>());
-
-                    // any existing anchors for the same target?
-                    final String anchor = link.text();
-                    // track the anchors only if no follow is false
-                    if (!noFollow && StringUtils.isNotBlank(anchor)) {
-                        anchors.add(anchor);
+                if (!robotsMetaSkip) {
+                    // extracts the robots directives from the meta tags
+                    Element robotelement = jsoupDoc.selectFirst("meta[name~=(?i)robots][content]");
+                    if (robotelement != null) {
+                        robotsTags.extractMetaTags(robotelement.attr("content"));
                     }
                 }
-            }
 
-            Element body = jsoupDoc.body();
-            text = textExtractor.text(body);
+                // store a normalised representation in metadata
+                // so that the indexer is aware of it
+                robotsTags.normaliseToMetadata(metadata);
+
+                // do not extract the links if no follow has been set
+                // and we are in strict mode
+                if (robotsTags.isNoFollow() && robotsNoFollowStrict) {
+                    slinks = new HashMap<>(0);
+                } else {
+                    final Elements links = jsoupDoc.select("a[href]");
+                    slinks = new HashMap<>(links.size());
+                    final URL baseUrl = URLUtil.toURL(url);
+                    for (Element link : links) {
+                        // nofollow
+                        String[] relkeywords = link.attr("rel").split(" ");
+                        boolean noFollow =
+                                Stream.of(relkeywords)
+                                        .anyMatch(x -> x.equalsIgnoreCase("nofollow"));
+
+                        // remove altogether
+                        if (noFollow && robotsNoFollowStrict) {
+                            continue;
+                        }
+
+                        // link not specifically marked as no follow
+                        // but whole page is
+                        if (!noFollow && robotsTags.isNoFollow()) {
+                            noFollow = true;
+                        }
+
+                        String targetUrl = null;
+
+                        try {
+                            // abs:href tells jsoup to return fully qualified domains
+                            // for relative urls
+                            // but it is very slow as it builds intermediate URL objects
+                            // and normalises the URL of the document every time
+                            targetUrl =
+                                    URLUtil.resolveUrl(baseUrl, link.attr("href")).toExternalForm();
+                        } catch (MalformedURLException e) {
+                            LOG.debug(
+                                    "Cannot resolve URL with baseURL : {} and href : {}",
+                                    baseUrl,
+                                    link.attr("href"),
+                                    e);
+                        }
+
+                        if (StringUtils.isBlank(targetUrl)) {
+                            continue;
+                        }
+
+                        final List<String> anchors =
+                                slinks.computeIfAbsent(targetUrl, a -> new LinkedList<>());
+
+                        // any existing anchors for the same target?
+                        final String anchor = link.text();
+                        // track the anchors only if no follow is false
+                        if (!noFollow && StringUtils.isNotBlank(anchor)) {
+                            anchors.add(anchor);
+                        }
+                    }
+                }
+
+                Element body = jsoupDoc.body();
+                text = textExtractor.text(body);
+            }
 
         } catch (Throwable e) {
             String errorMessage = "Exception while parsing " + url + ": " + e;

--- a/core/src/test/java/org/apache/stormcrawler/bolt/JSoupParserBoltTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/JSoupParserBoltTest.java
@@ -222,6 +222,78 @@ class JSoupParserBoltTest extends ParsingTester {
         Assertions.assertEquals(25, statusTuples.size());
     }
 
+    /**
+     * text/plain content needs no markup parsing and should be passed on rather than treated as an
+     * error, see issue #466.
+     */
+    @Test
+    void testPlainText() throws IOException {
+        bolt.prepare(
+                new HashMap<>(), TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+        String plain = "This is a plain text document.\nIt has no markup and no links.\n";
+        Metadata metadata = new Metadata();
+        metadata.setValue("Content-Type", "text/plain; charset=UTF-8");
+        parse("http://www.example.com/page.txt", plain.getBytes(StandardCharsets.UTF_8), metadata);
+
+        // not emitted on the status stream as an error
+        List<List<Object>> statusTuples = output.getEmitted(Constants.StatusStreamName);
+        Assertions.assertEquals(0, statusTuples.size(), "plain text should not produce outlinks");
+
+        // emitted on the default stream with the content as text
+        Assertions.assertEquals(1, output.getEmitted().size());
+        List<Object> parsedTuple = output.getEmitted().remove(0);
+        String text = (String) parsedTuple.get(3);
+        Assertions.assertEquals(plain, text, "text should be the verbatim plain text content");
+
+        Metadata md = (Metadata) parsedTuple.get(2);
+        Assertions.assertTrue(
+                md.getFirstValue("parse.Content-Type").contains("text/plain"),
+                "detected content-type should be text/plain");
+        Assertions.assertEquals(JSoupParserBolt.class.getName(), md.getFirstValue("parsed.by"));
+    }
+
+    /**
+     * The plain-text path does not run the TextExtractor, but it still honors {@code
+     * textextractor.skip.after} by truncating the stored text, see issue #466.
+     */
+    @Test
+    void testPlainTextTruncatedAtSkipAfter() throws IOException {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("textextractor.skip.after", 10);
+        bolt.prepare(conf, TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+
+        String plain = "0123456789ABCDEFGHIJ"; // 20 chars, cap is 10
+        Metadata metadata = new Metadata();
+        metadata.setValue("Content-Type", "text/plain; charset=UTF-8");
+        parse("http://www.example.com/big.txt", plain.getBytes(StandardCharsets.UTF_8), metadata);
+
+        Assertions.assertEquals(1, output.getEmitted().size());
+        List<Object> parsedTuple = output.getEmitted().remove(0);
+        String text = (String) parsedTuple.get(3);
+        Assertions.assertEquals(
+                "0123456789", text, "plain text should be truncated at textextractor.skip.after");
+    }
+
+    /**
+     * The plain-text path honors {@code textextractor.no.text} and stores no text, see issue #466.
+     */
+    @Test
+    void testPlainTextNoText() throws IOException {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("textextractor.no.text", true);
+        bolt.prepare(conf, TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+
+        String plain = "This is a plain text document.\n";
+        Metadata metadata = new Metadata();
+        metadata.setValue("Content-Type", "text/plain; charset=UTF-8");
+        parse("http://www.example.com/page.txt", plain.getBytes(StandardCharsets.UTF_8), metadata);
+
+        Assertions.assertEquals(1, output.getEmitted().size());
+        List<Object> parsedTuple = output.getEmitted().remove(0);
+        String text = (String) parsedTuple.get(3);
+        Assertions.assertEquals("", text, "no text should be stored when textextractor.no.text");
+    }
+
     @Test
     void testExecuteWithJavascriptLink() throws IOException {
         bolt.prepare(stormConf, TestUtil.getMockedTopologyContext(), new OutputCollector(output));

--- a/docs/src/main/asciidoc/configuration.adoc
+++ b/docs/src/main/asciidoc/configuration.adoc
@@ -318,7 +318,7 @@ Configures parsing of fetched text and the handling of discovered URIs
 | detect.mimetype | true | Enable MIME type detection during parsing.
 | feed.filter.hours.since.published | -1 | Discard feeds older than value hours.
 | feed.sniffContent | false | Try to detect feeds automatically.
-| jsoup.treat.non.html.as.error | true | If true, non-HTML content is treated as an error by JSoupParserBolt.
+| jsoup.treat.non.html.as.error | true | If true, non-HTML content is treated as an error by JSoupParserBolt. Note that `text/plain` is always handled directly (the content is used as the text) and never treated as an error. Its stored text honors `textextractor.no.text` and is capped at `textextractor.skip.after`; the raw fetched size is bounded by `http.content.limit`.
 | parsefilters.config.file | parsefilters.json | Path to JSON config defining ParseFilters. See link:https://github.com/apache/stormcrawler/blob/main/archetype/src/main/resources/archetype-resources/src/main/resources/parsefilters.json[default parsefilters.json].
 | parser.emitOutlinks | true | Emit discovered links as DISCOVERED tuples.
 | parser.emitOutlinks.max.per.page | -1 | Limit number of emitted links per page.

--- a/docs/src/main/asciidoc/internals.adoc
+++ b/docs/src/main/asciidoc/internals.adoc
@@ -121,7 +121,7 @@ You can easily build your own custom indexer to integrate with other storage sys
 === Parser Bolts
 ==== JSoupParserBolt
 
-The link:https://github.com/apache/stormcrawler/blob/main/core/src/main/java/org/apache/stormcrawler/bolt/JSoupParserBolt.java[JSoupParserBolt] can be used to parse HTML documents and extract the outlinks, text, and metadata it contains. If you want to parse non-HTML documents, use the link:https://github.com/apache/stormcrawler/tree/main/external/tika/src/main/java/org/apache/stormcrawler/tika[Tika-based ParserBolt] from the external modules.
+The link:https://github.com/apache/stormcrawler/blob/main/core/src/main/java/org/apache/stormcrawler/bolt/JSoupParserBolt.java[JSoupParserBolt] can be used to parse HTML documents and extract the outlinks, text, and metadata it contains. `text/plain` content is also handled: since there is no markup to parse, the content is used directly as the text and no outlinks are extracted. If you want to parse other non-HTML documents, use the link:https://github.com/apache/stormcrawler/tree/main/external/tika/src/main/java/org/apache/stormcrawler/tika[Tika-based ParserBolt] from the external modules.
 
 This parser calls the xref:urlfilters[URLFilters] and xref:parsefilters[ParseFilters] defined in the configuration. Please note that it calls xref:metadatatransfer[MetadataTransfer] prior to calling the xref:parsefilters[ParseFilters]. If you create new Outlinks in your [[ParseFilters]], you'll need to make sure that you use MetadataTransfer there to inherit the Metadata from the parent document.
 


### PR DESCRIPTION
text/plain content requires no markup parsing, so instead of raising an error (the default with jsoup.treat.non.html.as.error) the bolt now uses the decoded content directly as the extracted text and emits no outlinks.

Adds a unit test and documentation updates.

Closes #466


### For all changes

- [x] Is there a issue associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with `#XXXX` where `XXXX` is the issue number you are trying to resolve?

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Is the code properly formatted with `mvn git-code-format:format-code -Dgcf.globPattern="**/*" -Dskip.format.code=false`?

### For code changes

- [x] Have you ensured that the full suite of tests is executed via `mvn clean verify`?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file?

### Note

Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
