### PR TITLE
#1951 refactor: replace linear proxy scan with lookup map in MultiProxyManager

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/proxy/MultiProxyManager.java
+++ b/core/src/main/java/org/apache/stormcrawler/proxy/MultiProxyManager.java
@@ -21,6 +21,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Scanner;
@@ -44,6 +47,7 @@ public class MultiProxyManager implements ProxyManager {
     private SCProxy[] proxies;
     private ProxyRotation rotation;
     private final AtomicInteger lastAccessedIndex = new AtomicInteger(0);
+    private Map<String, SCProxy> proxyLookupMap;
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(HttpProtocol.class);
 
@@ -146,6 +150,11 @@ public class MultiProxyManager implements ProxyManager {
 
         // assign proxies to class variable
         this.proxies = fileProxies;
+
+        this.proxyLookupMap = new HashMap<>();
+        for (SCProxy proxy : this.proxies) {
+            this.proxyLookupMap.put(proxyKey(proxy), proxy);
+        }
     }
 
     public void configure(ProxyRotation rotation, String[] proxyList) throws RuntimeException {
@@ -170,6 +179,11 @@ public class MultiProxyManager implements ProxyManager {
 
         // assign proxies to class variable
         this.proxies = fileProxies;
+
+        this.proxyLookupMap = new HashMap<>();
+        for (SCProxy proxy : this.proxies) {
+            this.proxyLookupMap.put(proxyKey(proxy), proxy);
+        }
     }
 
     private SCProxy getRandom() {
@@ -215,12 +229,17 @@ public class MultiProxyManager implements ProxyManager {
     }
 
     private Optional<SCProxy> getConfiguredProxy(SCProxy proxy) {
-        for (SCProxy configuredProxy : this.proxies) {
-            if (ProxyUtils.isSameProxy(configuredProxy, proxy)) {
-                return Optional.of(configuredProxy);
-            }
-        }
-        return Optional.empty();
+        return Optional.ofNullable(proxyLookupMap.get(proxyKey(proxy)));
+    }
+
+    private static String proxyKey(SCProxy proxy) {
+        String protocol = proxy.getProtocol() == null ? "" : proxy.getProtocol().toLowerCase(Locale.ROOT);
+        String address = proxy.getAddress() == null ? "" : proxy.getAddress().toLowerCase(Locale.ROOT);
+        return protocol + "|"
+            + address + "|"
+            + proxy.getPort() + "|"
+            + (proxy.getUsername() != null ? proxy.getUsername() : "") + "|"
+            + (proxy.getPassword() != null ? proxy.getPassword() : "");
     }
 
     @Override


### PR DESCRIPTION
Closes #1951

## Summary
Replace the O(n) linear scan in `getConfiguredProxy()` with an O(1) map lookup.

## Changes
- Added `proxyLookupMap` field (HashMap keyed on normalized proxy identity)
- Built the map in both `configure()` overloads after proxies are loaded
- Added `proxyKey()` helper that normalizes `protocol` and `address` to lowercase, consistent with `ProxyUtils.isSameProxy()`
- Replaced the for-loop in `getConfiguredProxy()` with a map lookup

## Notes
- No behavior change
- Key includes credentials to match `ProxyUtils.isSameProxy()` semantics
- `MultiProxyManagerTest`: 13/13 passed
- `ProtocolTest.testBlocking` failure is pre-existing and unrelated to this change