### PR TITLE
#1951 refactor: replace linear proxy scan with lookup map in MultiProxyManager

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/proxy/MultiProxyManager.java
+++ b/core/src/main/java/org/apache/stormcrawler/proxy/MultiProxyManager.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Scanner;
@@ -44,6 +46,7 @@ public class MultiProxyManager implements ProxyManager {
     private SCProxy[] proxies;
     private ProxyRotation rotation;
     private final AtomicInteger lastAccessedIndex = new AtomicInteger(0);
+    private Map<SCProxy, SCProxy> proxyLookupMap;
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(HttpProtocol.class);
 
@@ -146,6 +149,11 @@ public class MultiProxyManager implements ProxyManager {
 
         // assign proxies to class variable
         this.proxies = fileProxies;
+
+        this.proxyLookupMap = new HashMap<>();
+        for (SCProxy proxy : this.proxies) {
+            this.proxyLookupMap.put(proxy, proxy);
+        }
     }
 
     public void configure(ProxyRotation rotation, String[] proxyList) throws RuntimeException {
@@ -170,6 +178,11 @@ public class MultiProxyManager implements ProxyManager {
 
         // assign proxies to class variable
         this.proxies = fileProxies;
+
+        this.proxyLookupMap = new HashMap<>();
+        for (SCProxy proxy : this.proxies) {
+            this.proxyLookupMap.put(proxy, proxy);
+        }
     }
 
     private SCProxy getRandom() {
@@ -215,12 +228,7 @@ public class MultiProxyManager implements ProxyManager {
     }
 
     private Optional<SCProxy> getConfiguredProxy(SCProxy proxy) {
-        for (SCProxy configuredProxy : this.proxies) {
-            if (ProxyUtils.isSameProxy(configuredProxy, proxy)) {
-                return Optional.of(configuredProxy);
-            }
-        }
-        return Optional.empty();
+        return Optional.ofNullable(proxyLookupMap.get(proxy));
     }
 
     @Override

--- a/core/src/main/java/org/apache/stormcrawler/proxy/ProxyUtils.java
+++ b/core/src/main/java/org/apache/stormcrawler/proxy/ProxyUtils.java
@@ -17,9 +17,6 @@
 
 package org.apache.stormcrawler.proxy;
 
-import java.util.Locale;
-import java.util.Objects;
-
 final class ProxyUtils {
 
     static final int MIN_PORT = 1;
@@ -39,17 +36,5 @@ final class ProxyUtils {
                             + value
                             + "`");
         }
-    }
-
-    static boolean isSameProxy(SCProxy proxy, SCProxy otherProxy) {
-        return Objects.equals(normalize(proxy.getProtocol()), normalize(otherProxy.getProtocol()))
-                && Objects.equals(normalize(proxy.getAddress()), normalize(otherProxy.getAddress()))
-                && Objects.equals(proxy.getPort(), otherProxy.getPort())
-                && Objects.equals(proxy.getUsername(), otherProxy.getUsername())
-                && Objects.equals(proxy.getPassword(), otherProxy.getPassword());
-    }
-
-    private static String normalize(String value) {
-        return value == null ? null : value.toLowerCase(Locale.ROOT);
     }
 }

--- a/core/src/main/java/org/apache/stormcrawler/proxy/SCProxy.java
+++ b/core/src/main/java/org/apache/stormcrawler/proxy/SCProxy.java
@@ -17,6 +17,8 @@
 
 package org.apache.stormcrawler.proxy;
 
+import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -40,8 +42,8 @@ public class SCProxy {
     private final String protocol;
     private final String address;
     private final String port;
-    private String username;
-    private String password;
+    private final String username;
+    private final String password;
     private String country;
     private String area;
     private String location;
@@ -78,11 +80,15 @@ public class SCProxy {
         this.port = matcher.group("port");
 
         // load optional authentication data
+        String u = null;
+        String p = null;
         try {
-            this.username = matcher.group("username");
-            this.password = matcher.group("password");
+            u = matcher.group("username");
+            p = matcher.group("password");
         } catch (IllegalArgumentException ignored) {
         }
+        this.username = u;
+        this.password = p;
     }
 
     /** Construct a proxy class from it's variables. */
@@ -106,12 +112,9 @@ public class SCProxy {
         this.port = port;
 
         // load optional parameters
-        if (!username.isBlank()) {
-            this.username = username;
-        }
-        if (!password.isBlank()) {
-            this.password = password;
-        }
+        this.username = username.isBlank() ? null : username;
+        this.password = password.isBlank() ? null : password;
+
         if (!country.isBlank()) {
             this.country = country;
         }
@@ -185,5 +188,37 @@ public class SCProxy {
 
     public String getStatus() {
         return status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof SCProxy)) {
+            return false;
+        }
+
+        SCProxy other = (SCProxy) o;
+        return Objects.equals(normalize(this.protocol), normalize(other.protocol))
+                && Objects.equals(normalize(this.address), normalize(other.address))
+                && Objects.equals(this.port, other.port)
+                && Objects.equals(this.username, other.username)
+                && Objects.equals(this.password, other.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                normalize(this.protocol),
+                normalize(this.address),
+                this.port,
+                this.username,
+                this.password);
+    }
+
+    private static String normalize(String value) {
+        return value == null ? null : value.toLowerCase(Locale.ROOT);
     }
 }

--- a/core/src/test/java/org/apache/stormcrawler/proxy/SCProxyTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/proxy/SCProxyTest.java
@@ -89,4 +89,75 @@ class SCProxyTest {
         proxy.incrementUsage();
         Assertions.assertEquals(1, proxy.getUsage());
     }
+
+    @Test
+    void testEqualsAndHashCode() {
+        SCProxy a = new SCProxy("http://user1:pass1@example.com:8080");
+        SCProxy b = new SCProxy("http://user1:pass1@example.com:8080");
+
+        // equal on identical identity fields
+        Assertions.assertEquals(a, b);
+        // hashCode equal for equal objects
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void testEqualsCaseInsensitive() {
+        SCProxy a = new SCProxy("http://user1:pass1@example.com:8080");
+        SCProxy b = new SCProxy("HTTP://user1:pass1@EXAMPLE.COM:8080");
+
+        // protocol and address are case-insensitive
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void testNotEqualOnDifferentFields() {
+        SCProxy base = new SCProxy("http://user1:pass1@example.com:8080");
+
+        Assertions.assertNotEquals(
+                base, new SCProxy("http://user1:pass1@example.com:9090")); // different port
+        Assertions.assertNotEquals(
+                base, new SCProxy("http://user2:pass1@example.com:8080")); // different username
+        Assertions.assertNotEquals(
+                base, new SCProxy("http://user1:pass2@example.com:8080")); // different password
+    }
+
+    @Test
+    void testEqualsExcludesNonIdentityFields() {
+        // country, area, location, status are excluded from identity
+        SCProxy a =
+                new SCProxy(
+                        "http",
+                        "example.com",
+                        "8080",
+                        "user1",
+                        "pass1",
+                        "KR",
+                        "Seoul",
+                        "loc1",
+                        "active");
+        SCProxy b =
+                new SCProxy(
+                        "http",
+                        "example.com",
+                        "8080",
+                        "user1",
+                        "pass1",
+                        "US",
+                        "NY",
+                        "loc2",
+                        "inactive");
+
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void testEqualsNullAndDifferentType() {
+        SCProxy proxy = new SCProxy("http://user1:pass1@example.com:8080");
+
+        Assertions.assertNotEquals(proxy, null);
+        Assertions.assertNotEquals(proxy, "not-a-proxy");
+    }
 }


### PR DESCRIPTION
Closes #1951

## Summary
Replace the O(n) linear scan in `getConfiguredProxy()` with an O(1) map lookup by putting proxy identity on the type itself.

## Changes
- Added `equals`/`hashCode` to `SCProxy` based on identity fields only: `protocol` and `address` (lowercased), `port`, `username`, `password`. Excludes `country`, `area`, `location`, `status`, and `usage`.
- Built a `Map<SCProxy, SCProxy>` in both `configure()` overloads and replaced `getConfiguredProxy` with `Optional.ofNullable(map.get(proxy))`
- Removed `ProxyUtils.isSameProxy` and its private `normalize` helper, folding the logic into `SCProxy.equals`

## Notes
- No behavior change
- Single definition of proxy identity, less dead code
- `MultiProxyManagerTest`: 13/13 passed
- `ProtocolTest.testBlocking` failure is pre-existing and unrelated to this change

### For all changes
- [x] Is there a issue associated with this PR? Is it referenced in the commit message?
- [x] Does your PR title start with `#XXXX` where `XXXX` is the issue number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Is the code properly formatted with `mvn git-code-format:format-code -Dgcf.globPattern="**/*" -Dskip.format.code=false`?
### For code changes
- [x] Have you ensured that the full suite of tests is executed via `mvn clean verify`?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under ASF 2.0?
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file?