### PR TITLE
  #1955 - Make FileSpout work in distributed mode

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/spout/FileSpout.java
+++ b/core/src/main/java/org/apache/stormcrawler/spout/FileSpout.java
@@ -61,6 +61,9 @@ public class FileSpout extends BaseRichSpout {
     public static final int BATCH_SIZE = 10000;
     public static final Logger LOG = LoggerFactory.getLogger(FileSpout.class);
     private final Queue<String> inputFiles;
+    private final String seedDir;
+    private final String fileFilter;
+    private final String[] seedFiles;
     protected SpoutOutputCollector collector;
     protected Scheme scheme = new StringTabScheme();
     protected LinkedList<byte[]> buffer = new LinkedList<>();
@@ -68,7 +71,7 @@ public class FileSpout extends BaseRichSpout {
     protected int totalTasks;
     protected int taskIndex;
     private BufferedReader currentBuffer;
-    private boolean withDiscoveredStatus = false;
+    private final boolean withDiscoveredStatus;
 
     /**
      * @param dir containing the seed files
@@ -94,18 +97,10 @@ public class FileSpout extends BaseRichSpout {
      */
     public FileSpout(String dir, String filter, boolean withDiscoveredStatus) {
         this.withDiscoveredStatus = withDiscoveredStatus;
-        Path pdir = Paths.get(dir);
-        inputFiles = new LinkedList<>();
-        LOG.info("Reading directory: {} (filter: {})", pdir, filter);
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(pdir, filter)) {
-            for (Path entry : stream) {
-                String inputFile = entry.toAbsolutePath().toString();
-                inputFiles.add(inputFile);
-                LOG.info("Input : {}", inputFile);
-            }
-        } catch (IOException ioe) {
-            LOG.error("IOException: %s%n", ioe);
-        }
+        this.seedDir = dir;
+        this.fileFilter = filter;
+        this.seedFiles = null;
+        this.inputFiles = new LinkedList<>();
     }
 
     /**
@@ -115,12 +110,14 @@ public class FileSpout extends BaseRichSpout {
      * @since 1.13
      */
     public FileSpout(boolean withDiscoveredStatus, String... files) {
-        this.withDiscoveredStatus = withDiscoveredStatus;
         if (files.length == 0) {
             throw new IllegalArgumentException("Must configure at least one inputFile");
         }
-        inputFiles = new LinkedList<>();
-        Collections.addAll(inputFiles, files);
+        this.withDiscoveredStatus = withDiscoveredStatus;
+        this.seedDir = null;
+        this.fileFilter = null;
+        this.seedFiles = files;
+        this.inputFiles = new LinkedList<>();
     }
 
     /**
@@ -195,6 +192,34 @@ public class FileSpout extends BaseRichSpout {
         // same as the number of shards
         totalTasks = context.getComponentTasks(context.getThisComponentId()).size();
         taskIndex = context.getThisTaskIndex();
+
+        // Resolve the seeds here, not in the constructor: in distributed mode the
+        // spout is serialised on the submit client and only open() runs on the
+        // workers, where the seed directory/files actually live (issue #1955).
+        populateInputFiles();
+    }
+
+    /**
+     * Resolves the configured seed directory or file list into {@link #inputFiles}. Called from
+     * {@link #open} so the filesystem is read on the worker, not on the client at construction
+     * time.
+     */
+    private void populateInputFiles() {
+        if (seedDir != null) {
+            Path pdir = Paths.get(seedDir);
+            LOG.info("Reading directory: {} (filter: {})", pdir, fileFilter);
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(pdir, fileFilter)) {
+                for (Path entry : stream) {
+                    String inputFile = entry.toAbsolutePath().toString();
+                    inputFiles.add(inputFile);
+                    LOG.info("Input : {}", inputFile);
+                }
+            } catch (IOException ioe) {
+                LOG.error("IOException while reading seed directory {}", pdir, ioe);
+            }
+        } else {
+            Collections.addAll(inputFiles, seedFiles);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/apache/stormcrawler/spout/FileSpout.java
+++ b/core/src/main/java/org/apache/stormcrawler/spout/FileSpout.java
@@ -60,16 +60,16 @@ public class FileSpout extends BaseRichSpout {
 
     public static final int BATCH_SIZE = 10000;
     public static final Logger LOG = LoggerFactory.getLogger(FileSpout.class);
-    private final Queue<String> inputFiles;
+    private transient Queue<String> inputFiles;
     private final String seedDir;
     private final String fileFilter;
     private final String[] seedFiles;
-    protected SpoutOutputCollector collector;
+    protected transient SpoutOutputCollector collector;
     protected Scheme scheme = new StringTabScheme();
     protected LinkedList<byte[]> buffer = new LinkedList<>();
     protected boolean active;
-    protected int totalTasks;
-    protected int taskIndex;
+    protected transient int totalTasks;
+    protected transient int taskIndex;
     private BufferedReader currentBuffer;
     private final boolean withDiscoveredStatus;
 
@@ -100,7 +100,6 @@ public class FileSpout extends BaseRichSpout {
         this.seedDir = dir;
         this.fileFilter = filter;
         this.seedFiles = null;
-        this.inputFiles = new LinkedList<>();
     }
 
     /**
@@ -117,7 +116,6 @@ public class FileSpout extends BaseRichSpout {
         this.seedDir = null;
         this.fileFilter = null;
         this.seedFiles = files;
-        this.inputFiles = new LinkedList<>();
     }
 
     /**
@@ -196,6 +194,7 @@ public class FileSpout extends BaseRichSpout {
         // Resolve the seeds here, not in the constructor: in distributed mode the
         // spout is serialised on the submit client and only open() runs on the
         // workers, where the seed directory/files actually live (issue #1955).
+        inputFiles = new LinkedList<>();
         populateInputFiles();
     }
 

--- a/core/src/test/java/org/apache/stormcrawler/spout/FileSpoutTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/spout/FileSpoutTest.java
@@ -159,6 +159,29 @@ class FileSpoutTest {
         assertEquals("https://github.com", tuple.get(0));
     }
 
+    @Test
+    void testDirectoryResolvedAtOpenNotConstruction(
+            @org.junit.jupiter.api.io.TempDir Path tempDir) throws Exception {
+        // Build the spout while the directory is still empty.
+        final FileSpout spout = new FileSpout(tempDir.toAbsolutePath().toString(), "*.txt");
+
+        // Create the seed file AFTER construction but BEFORE open().
+        // On today's code the constructor already listed the (empty) directory,
+        // so nothing is emitted. Once resolution moves to open(), the file is seen.
+        Files.write(
+                tempDir.resolve("seeds.txt"),
+                "https://stormcrawler.apache.org\n".getBytes(StandardCharsets.UTF_8));
+
+        final FileSpoutOutputCollectorMock collectorMock = new FileSpoutOutputCollectorMock();
+        spout.open(Map.of(), new FileSpoutTopologyContextMock(), collectorMock);
+        spout.activate();
+        spout.nextTuple();
+
+        final List<Object> tuple = collectorMock.getTuple();
+        assertNotNull(tuple);
+        assertEquals("https://stormcrawler.apache.org", tuple.get(0));
+    }
+
     private Path getPath(String resource) throws URISyntaxException {
         return Path.of(
                 Objects.requireNonNull(

--- a/core/src/test/java/org/apache/stormcrawler/spout/FileSpoutTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/spout/FileSpoutTest.java
@@ -160,8 +160,8 @@ class FileSpoutTest {
     }
 
     @Test
-    void testDirectoryResolvedAtOpenNotConstruction(
-            @org.junit.jupiter.api.io.TempDir Path tempDir) throws Exception {
+    void testDirectoryResolvedAtOpenNotConstruction(@org.junit.jupiter.api.io.TempDir Path tempDir)
+            throws Exception {
         // Build the spout while the directory is still empty.
         final FileSpout spout = new FileSpout(tempDir.toAbsolutePath().toString(), "*.txt");
 
@@ -176,6 +176,54 @@ class FileSpoutTest {
         spout.open(Map.of(), new FileSpoutTopologyContextMock(), collectorMock);
         spout.activate();
         spout.nextTuple();
+
+        final List<Object> tuple = collectorMock.getTuple();
+        assertNotNull(tuple);
+        assertEquals("https://stormcrawler.apache.org", tuple.get(0));
+    }
+
+    @Test
+    void testDirectoryConstructorHappyPath(@org.junit.jupiter.api.io.TempDir Path tempDir)
+            throws Exception {
+        Files.write(
+                tempDir.resolve("seeds.txt"),
+                "https://stormcrawler.apache.org\n".getBytes(StandardCharsets.UTF_8));
+
+        final FileSpout spout = new FileSpout(tempDir.toAbsolutePath().toString(), "*.txt");
+        final FileSpoutOutputCollectorMock collectorMock = new FileSpoutOutputCollectorMock();
+        spout.open(Map.of(), new FileSpoutTopologyContextMock(), collectorMock);
+        spout.activate();
+        spout.nextTuple();
+
+        final List<Object> tuple = collectorMock.getTuple();
+        assertNotNull(tuple);
+        assertEquals("https://stormcrawler.apache.org", tuple.get(0));
+    }
+
+    @Test
+    void testSurvivesSerialization(@org.junit.jupiter.api.io.TempDir Path tempDir)
+            throws Exception {
+        Files.write(
+                tempDir.resolve("seeds.txt"),
+                "https://stormcrawler.apache.org\n".getBytes(StandardCharsets.UTF_8));
+
+        final FileSpout spout = new FileSpout(tempDir.toAbsolutePath().toString(), "*.txt");
+
+        final java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+        try (java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(bos)) {
+            oos.writeObject(spout);
+        }
+        final FileSpout restored;
+        try (java.io.ObjectInputStream ois =
+                new java.io.ObjectInputStream(
+                        new java.io.ByteArrayInputStream(bos.toByteArray()))) {
+            restored = (FileSpout) ois.readObject();
+        }
+
+        final FileSpoutOutputCollectorMock collectorMock = new FileSpoutOutputCollectorMock();
+        restored.open(Map.of(), new FileSpoutTopologyContextMock(), collectorMock);
+        restored.activate();
+        restored.nextTuple();
 
         final List<Object> tuple = collectorMock.getTuple();
         assertNotNull(tuple);


### PR DESCRIPTION
  FileSpout read the seed directory and filled its input queue inside the constructor. In distributed mode the constructor runs only on the client that submits the topology, so the resolved queue (usually empty, since the seed files live on the workers) was serialised and shipped out. The spout then sat idle with no activity in the logs.

  The constructors now only keep the values they are given: the directory and filter, or the explicit file list. The seeds are resolved in `open()`, which runs on each worker. `WARCSpout` already calls `super.open()`, so it gets the same behaviour without any change.

  While moving the code I also fixed a log call that used printf-style `%s` formatting instead of SLF4J `{}` placeholders.

  Tests: a regression test builds the spout against an empty directory and creates the seed file only after construction, before `open()`. It fails on the old code and passes now. There is also a directory happy-path test and a serialisation round-trip.

  Closes #1955


### For all changes

- [x] Is there a issue associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with `#XXXX` where `XXXX` is the issue number you are trying to resolve?

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Is the code properly formatted with `mvn git-code-format:format-code -Dgcf.globPattern="**/*" -Dskip.format.code=false`?

### For code changes

- [x] Have you ensured that the full suite of tests is executed via `mvn clean verify`?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file?

### Note

Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
