### PR TITLE
use placeholder instead of older version of archetypes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ StormCrawler requires Java 17 or above. To execute tests, it requires you to hav
 Once Storm is installed, the easiest way to get started is to generate a new StormCrawler project following the instructions below:
 
 ```shell
-mvn archetype:generate -DarchetypeGroupId=org.apache.stormcrawler -DarchetypeArtifactId=stormcrawler-archetype -DarchetypeVersion=3.4.0
-
+mvn archetype:generate -DarchetypeGroupId=org.apache.stormcrawler -DarchetypeArtifactId=stormcrawler-archetype -DarchetypeVersion=<CURRENT_VERSION>
 ```
+
+Be sure to replace <CURRENT_VERSION> with the latest released version, which you can find on [search.maven.org](https://central.sonatype.com/artifact/org.apache.stormcrawler/stormcrawler-archetype).
 
 You'll be asked to enter a groupId (e.g. com.mycompany.crawler), an artefactId (e.g. stormcrawler), a version, a package name and details about the user agent to use.
 

--- a/docs/src/main/asciidoc/quick-start.adoc
+++ b/docs/src/main/asciidoc/quick-start.adoc
@@ -53,7 +53,7 @@ mvn archetype:generate `
 ----
 ====
 
-Be sure to replace `<CURRENT_VERSION>` with the latest released version of StormCrawler, which you can find on link:https://search.maven.org/artifact/org.apache.stormcrawler/stormcrawler-archetype[search.maven.org].
+Be sure to replace `<CURRENT_VERSION>` with the latest released version, which you can find on link:https://central.sonatype.com/artifact/org.apache.stormcrawler/stormcrawler-archetype[central.sonatype.com].
 
 During the process, you’ll be prompted to provide the following:
 

--- a/external/opensearch/README.md
+++ b/external/opensearch/README.md
@@ -16,7 +16,9 @@ Getting started
 
 The easiest way is currently to use the archetype for OpenSearch with:
 
-`mvn archetype:generate -DarchetypeGroupId=org.apache.stormcrawler -DarchetypeArtifactId=stormcrawler-opensearch-archetype -DarchetypeVersion=3.4.0`
+`mvn archetype:generate -DarchetypeGroupId=org.apache.stormcrawler -DarchetypeArtifactId=stormcrawler-opensearch-archetype -DarchetypeVersion=<CURRENT_VERSION>`
+
+Be sure to replace <CURRENT_VERSION> with the latest released version, which you can find on [search.maven.org](https://central.sonatype.com/artifact/org.apache.stormcrawler/stormcrawler-opensearch-archetype).
 
 You'll be asked to enter a groupId (e.g. com.mycompany.crawler), an artefactId (e.g. stormcrawler), a version, a package name and details about the user agent to use.
 

--- a/external/solr/README.md
+++ b/external/solr/README.md
@@ -6,7 +6,9 @@ Set of [Apache Solr](https://solr.apache.org/) resources for StormCrawler that a
 
 The easiest way is currently to use the archetype for Solr with:
 
-`mvn archetype:generate -DarchetypeGroupId=org.apache.stormcrawler -DarchetypeArtifactId=stormcrawler-solr-archetype -DarchetypeVersion=3.4.0`
+`mvn archetype:generate -DarchetypeGroupId=org.apache.stormcrawler -DarchetypeArtifactId=stormcrawler-solr-archetype -DarchetypeVersion=<CURRENT_VERSION>`
+
+Be sure to replace <CURRENT_VERSION> with the latest released version, which you can find on [search.maven.org](https://central.sonatype.com/artifact/org.apache.stormcrawler/stormcrawler-solr-archetype).
 
 You'll be asked to enter a groupId (e.g. com.mycompany.crawler), an artefactId (e.g. stormcrawler), a version, a package name and details about the user agent to use.
 


### PR DESCRIPTION
+ update link

The versions for the archetypes in the README always end up out of sync. Instead, we just put a placeholder like done in the [documentation](https://stormcrawler.apache.org/docs/latest/index.html#_bootstrapping_a_stormcrawler_project). 