### PR TITLE
Don't trigger mvn workflow for changes to the docs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,9 +20,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   rat:


### PR DESCRIPTION
Trivial - changes to the docs do not need to trigger the mvn workflow. Waste of time and resources