### PR TITLE
Workaround to activate LogViewer in docker compose

### DIFF
--- a/archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   supervisor:
     image: storm:latest
     container_name: supervisor
-    command: storm supervisor -c worker.childopts=-Xmx%HEAP-MEM%m
+    command: storm supervisor -c worker.childopts=-Xmx%HEAP-MEM%m -c storm.local.hostname=localhost
     depends_on:
       - nimbus
       - zookeeper
@@ -45,6 +45,16 @@ services:
     restart: always
     ports:
       - "127.0.0.1:8080:8080"
+
+  logviewer:
+    image: storm:latest
+    container_name: logviewer
+    command: storm logviewer
+    depends_on:
+      - supervisor
+    restart: always
+    ports:
+      - "127.0.0.1:8000:8000"
 
   urlfrontier:
     image: crawlercommons/url-frontier:latest

--- a/docs/src/main/asciidoc/quick-start.adoc
+++ b/docs/src/main/asciidoc/quick-start.adoc
@@ -101,7 +101,7 @@ services:
   supervisor:
     image: storm:latest
     container_name: supervisor
-    command: storm supervisor -c worker.childopts=-Xmx2g
+    command: storm supervisor -c worker.childopts=-Xmx2g -c storm.local.hostname=localhost
     depends_on:
       - nimbus
       - zookeeper
@@ -116,6 +116,16 @@ services:
     restart: always
     ports:
       - "127.0.0.1:8080:8080"
+
+  logviewer:
+    image: storm:latest
+    container_name: logviewer
+    command: storm logviewer
+    depends_on:
+      - supervisor
+    restart: always
+    ports:
+      - "127.0.0.1:8000:8000"
 
   urlfrontier:
     image: crawlercommons/url-frontier:latest

--- a/external/opensearch/archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/external/opensearch/archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   supervisor:
     image: storm:latest
     container_name: supervisor
-    command: storm supervisor -c worker.childopts=-Xmx%HEAP-MEM%m
+    command: storm supervisor -c worker.childopts=-Xmx%HEAP-MEM%m -c storm.local.hostname=localhost
     depends_on:
       - nimbus
       - zookeeper
@@ -45,6 +45,16 @@ services:
     restart: always
     ports:
       - "127.0.0.1:8080:8080"
+
+  logviewer:
+    image: storm:latest
+    container_name: logviewer
+    command: storm logviewer
+    depends_on:
+      - supervisor
+    restart: always
+    ports:
+      - "127.0.0.1:8000:8000"
 
   opensearch-sc:
     image: opensearchproject/opensearch:2.19.4


### PR DESCRIPTION
Adds the logviewer container to docker compose; the supervisor declare its hostname as localhost so that the resolution can work.