### PR TITLE
#2001 Document adaptive scheduler metadata

### DIFF
--- a/docs/src/main/asciidoc/internals.adoc
+++ b/docs/src/main/asciidoc/internals.adoc
@@ -56,9 +56,17 @@ scheduler.adaptive.fetchInterval.min: 60
 scheduler.adaptive.fetchInterval.max: 20160
 scheduler.adaptive.fetchInterval.rate.incr: .5
 scheduler.adaptive.fetchInterval.rate.decr: .5
+
+metadata.persist:
+  - signature
+  - fetch.statusCode
+  - fetchInterval
+  - signatureChangeDate
+  - last-modified
+  - protocol.etag
 ----
 
-The `AdaptiveScheduler` requires the `MD5SignatureParseFilter` to be configured so that the `signature` metadata field is populated.
+The `AdaptiveScheduler` requires the `MD5SignatureParseFilter` to be configured so that the `signature` metadata field is populated. The scheduler also persists its current `fetchInterval` and the metadata used to detect content changes. The `last-modified` and `protocol.etag` fields allow conditional requests when `scheduler.adaptive.setLastModified` is enabled.
 
 
 === Bolts

--- a/docs/src/main/asciidoc/internals.adoc
+++ b/docs/src/main/asciidoc/internals.adoc
@@ -66,7 +66,7 @@ metadata.persist:
   - protocol.etag
 ----
 
-The `AdaptiveScheduler` requires the `MD5SignatureParseFilter` to be configured so that the `signature` metadata field is populated. The scheduler also persists its current `fetchInterval` and the metadata used to detect content changes. The `last-modified` and `protocol.etag` fields allow conditional requests when `scheduler.adaptive.setLastModified` is enabled.
+The `AdaptiveScheduler` requires the `MD5SignatureParseFilter` to be configured so that the `signature` metadata field is populated. The scheduler also persists its current `fetchInterval` and the metadata used to detect content changes. The `last-modified` field (written when `scheduler.adaptive.setLastModified` is enabled) and `protocol.etag` allow conditional requests (`If-Modified-Since` / `If-None-Match`).
 
 
 === Bolts


### PR DESCRIPTION
## Summary

- document the complete metadata set persisted by `AdaptiveScheduler`
- use the exact lowercase `last-modified` key from the implementation
- include `fetch.statusCode`, which the persisted-status path also requires

Fixes #2001

## Validation

- parsed the documented key list as YAML
- `git diff --check`
- attempted `mvn -pl docs -am -DskipTests package`; Maven Central returned HTTP 403 while resolving `org.apache:apache:pom:39`

## Checklist

- [x] The issue is referenced in the commit and PR
- [x] The title starts with the issue number
- [x] The branch is based on the current target branch
- [x] The contribution is one commit
- [x] No code or dependencies changed
