### PR TITLE
bugfix - max content not applied for robots.txt when redirecting

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/protocol/HttpRobotRulesParser.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/HttpRobotRulesParser.java
@@ -180,7 +180,7 @@ public class HttpRobotRulesParser extends RobotRulesParser {
                                 redir);
                     }
 
-                    response = http.getProtocolOutput(redir.toString(), Metadata.empty);
+                    response = http.getProtocolOutput(redir.toString(), fetchRobotsMd);
                     code = response.getStatusCode();
                     bytesFetched.add(
                             response.getContent() != null ? response.getContent().length : 0);


### PR DESCRIPTION
Trivial fix

`http.robots.content.limit` is used on the original fetch attempt but not on redirects