### PR TITLE
Resolve relative outlinks against <base href> in JSoupParserBolt

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/bolt/JSoupParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/JSoupParserBolt.java
@@ -338,7 +338,16 @@ public class JSoupParserBolt extends StatusEmitterBolt {
                 } else {
                     final Elements links = jsoupDoc.select("a[href]");
                     slinks = new HashMap<>(links.size());
-                    final URL baseUrl = URLUtil.toURL(url);
+                    // Resolve relative links against the document's base URI
+                    // rather than its URL: when the page contains a <base href>
+                    // element jsoup updates baseUri() accordingly, which is what
+                    // browsers use to resolve relative hrefs. Falls back to the
+                    // document URL when no (valid) <base> is present.
+                    String baseUri = jsoupDoc.baseUri();
+                    if (StringUtils.isBlank(baseUri)) {
+                        baseUri = url;
+                    }
+                    final URL baseUrl = URLUtil.toURL(baseUri);
                     for (Element link : links) {
                         // nofollow
                         String[] relkeywords = link.attr("rel").split(" ");

--- a/core/src/test/java/org/apache/stormcrawler/bolt/JSoupParserBoltTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/JSoupParserBoltTest.java
@@ -304,4 +304,37 @@ class JSoupParserBoltTest extends ParsingTester {
         Assertions.assertEquals(
                 "http://www.javascriptlinks.com/mylink", statusTuples.get(0).get(0));
     }
+
+    /**
+     * Relative outlinks must be resolved against the document's {@code <base href>} element when
+     * one is present, matching browser behaviour, rather than against the document URL. Otherwise a
+     * page served from a sub-path with a base pointing at the domain root doubles the path segment.
+     */
+    @Test
+    void testBaseHrefOutlinkResolution() throws IOException {
+        bolt.prepare(stormConf, TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+
+        String html =
+                "<html><head>"
+                        + "<base href=\"https://www.example.be/\">"
+                        + "</head><body>"
+                        + "<a href=\"fr/rayons/stockage-archivage-de-donnees/218725\">Stockage</a>"
+                        + "</body></html>";
+
+        Metadata metadata = new Metadata();
+        metadata.setValue("Content-Type", "text/html; charset=UTF-8");
+        parse(
+                "https://www.example.be/fr/rayons/actualites-reportages/216943",
+                html.getBytes(StandardCharsets.UTF_8),
+                metadata);
+
+        List<List<Object>> statusTuples = output.getEmitted(Constants.StatusStreamName);
+        Assertions.assertEquals(1, statusTuples.size());
+        Assertions.assertEquals(Status.DISCOVERED, statusTuples.get(0).get(2));
+        // resolved against the <base href> (domain root), NOT against the document path,
+        // which would have produced .../actualites-reportages/fr/rayons/stockage-...
+        Assertions.assertEquals(
+                "https://www.example.be/fr/rayons/stockage-archivage-de-donnees/218725",
+                statusTuples.get(0).get(0));
+    }
 }


### PR DESCRIPTION
## Problem

`JSoupParserBolt` resolved relative outlinks against the document URL, ignoring any `<base href>` element in the page. For a page served from a sub-path whose `<base>` points at the domain root, this doubled the path segment.

Example — page `https://host/fr/rayons/actualites-reportages/216943` with `<base href="https://host/">` and a link `href="fr/rayons/stockage-archivage-de-donnees/218725"`:

- Expected: `https://host/fr/rayons/stockage-archivage-de-donnees/218725`
- Produced: `https://host/fr/rayons/actualites-reportages/fr/rayons/stockage-archivage-de-donnees/218725`

## Fix

Resolve relative links against `jsoupDoc.baseUri()` instead of the raw document URL. jsoup updates `baseUri()` to the `<base href>` value when the element is present, matching browser behaviour, and falls back to the document URL otherwise. This keeps the existing fast resolution path (no per-link `abs:href` object building).

## Test

Added `testBaseHrefOutlinkResolution` reproducing the doubled-path case. It fails without the fix (producing the doubled URL) and passes with it. Full `JSoupParserBoltTest` class: 12/12 passing.