### PR TITLE
Fix broken anchor in Asciidoc

### DIFF
--- a/docs/src/main/asciidoc/configuration.adoc
+++ b/docs/src/main/asciidoc/configuration.adoc
@@ -275,7 +275,6 @@ header.
 | topology.message.timeout.secs | -1 | OKHTTP message timeout.
 |===
 
-[[IP Address Filtering]]
 ===== IP Address Filtering
 
 The OkHttp protocol implementation (`org.apache.stormcrawler.protocol.okhttp.HttpProtocol`) can


### PR DESCRIPTION
Trivial fix of a broken anchor in Asciidoc:
- Simply use [automatic anchors](https://docs.asciidoctor.org/asciidoc/latest/macros/xref/#anchors)
- Custom anchors are not allowed to include white space, see [valid ID characters](https://docs.asciidoctor.org/asciidoc/latest/attributes/id/#valid-id-characters)

@dpol1: this causes a minor glitch in the 3.7.0 documentation. But not a blocker or a reason to spin a new release candidate.